### PR TITLE
Allow non-body mount host node

### DIFF
--- a/Sources/TokamakDOM/App/App.swift
+++ b/Sources/TokamakDOM/App/App.swift
@@ -21,6 +21,9 @@ import TokamakCore
 import TokamakStaticHTML
 
 extension App {
+  public static func _launch(_ app: Self, _ rootEnvironment: EnvironmentValues) {
+    _launch(app, rootEnvironment, TokamakDOM.body)
+  }
   /// The default implementation of `launch` for a `TokamakDOM` app.
   ///
   /// Creates a host `div` node and appends it to the body.
@@ -28,8 +31,7 @@ extension App {
   /// The body is styled with `margin: 0;` to match the `SwiftUI` layout
   /// system as closely as possible
   ///
-  public static func _launch(_ app: Self, _ rootEnvironment: EnvironmentValues) {
-    let body = TokamakDOM.body
+  public static func _launch(_ app: Self, _ rootEnvironment: EnvironmentValues, _ body: JSObjectRef) {
     if body.style.object!.all == "" {
       body.style = "margin: 0;"
     }


### PR DESCRIPTION
I'm creating Tokamak playground app for demonstration and it requires non-body hosting.

<img width="1458" alt="Screen Shot 2020-08-30 at 10 48 43" src="https://user-images.githubusercontent.com/11702759/91649381-681a8900-eaae-11ea-897b-547a82c266d0.png">
