### PR TITLE
Use setAttribute, not properties to fix SVG update

### DIFF
--- a/Sources/TokamakDOM/App/App.swift
+++ b/Sources/TokamakDOM/App/App.swift
@@ -24,6 +24,7 @@ extension App {
   public static func _launch(_ app: Self, _ rootEnvironment: EnvironmentValues) {
     _launch(app, rootEnvironment, TokamakDOM.body)
   }
+
   /// The default implementation of `launch` for a `TokamakDOM` app.
   ///
   /// Creates a host `div` node and appends it to the body.
@@ -31,7 +32,11 @@ extension App {
   /// The body is styled with `margin: 0;` to match the `SwiftUI` layout
   /// system as closely as possible
   ///
-  public static func _launch(_ app: Self, _ rootEnvironment: EnvironmentValues, _ body: JSObjectRef) {
+  public static func _launch(
+    _ app: Self,
+    _ rootEnvironment: EnvironmentValues,
+    _ body: JSObjectRef
+  ) {
     if body.style.object!.all == "" {
       body.style = "margin: 0;"
     }

--- a/Sources/TokamakDOM/DOMNode.swift
+++ b/Sources/TokamakDOM/DOMNode.swift
@@ -25,7 +25,7 @@ extension AnyHTML {
     // then use the standard lib to get the difference?
 
     for (attribute, value) in attributes {
-      _ = dom.ref[dynamicMember: attribute] = .string(value)
+      _ = dom.ref.setAttribute!(attribute, value)
     }
 
     if let dynamicSelf = self as? AnyDynamicHTML {

--- a/Sources/TokamakDOM/DOMNode.swift
+++ b/Sources/TokamakDOM/DOMNode.swift
@@ -25,7 +25,11 @@ extension AnyHTML {
     // then use the standard lib to get the difference?
 
     for (attribute, value) in attributes {
-      _ = dom.ref.setAttribute!(attribute, value)
+      if attribute.isUpdatedAsProperty {
+        dom.ref[dynamicMember: attribute.value] = .string(value)
+      } else {
+        _ = dom.ref.setAttribute!(attribute.value, value)
+      }
     }
 
     if let dynamicSelf = self as? AnyDynamicHTML {

--- a/Sources/TokamakDOM/Styles/ToggleStyle.swift
+++ b/Sources/TokamakDOM/Styles/ToggleStyle.swift
@@ -28,7 +28,7 @@ public struct DefaultToggleStyle: ToggleStyle {
 
 public struct CheckboxToggleStyle: ToggleStyle {
   public func makeBody(configuration: ToggleStyleConfiguration) -> some View {
-    var attrs = ["type": "checkbox"]
+    var attrs: [HTMLAttribute: String] = ["type": "checkbox"]
     if configuration.isOn {
       attrs["checked"] = "checked"
     }

--- a/Sources/TokamakDOM/Views/DynamicHTML.swift
+++ b/Sources/TokamakDOM/Views/DynamicHTML.swift
@@ -19,6 +19,8 @@ import JavaScriptKit
 import TokamakCore
 import TokamakStaticHTML
 
+public typealias HTML = TokamakStaticHTML.HTML
+
 public typealias Listener = (JSObjectRef) -> ()
 
 protocol AnyDynamicHTML: AnyHTML {
@@ -27,7 +29,7 @@ protocol AnyDynamicHTML: AnyHTML {
 
 public struct DynamicHTML<Content>: View, AnyDynamicHTML {
   public let tag: String
-  public let attributes: [String: String]
+  public let attributes: [HTMLAttribute: String]
   public let listeners: [String: Listener]
   let content: Content
 
@@ -41,7 +43,7 @@ public struct DynamicHTML<Content>: View, AnyDynamicHTML {
 extension DynamicHTML where Content: StringProtocol {
   public init(
     _ tag: String,
-    _ attributes: [String: String] = [:],
+    _ attributes: [HTMLAttribute: String] = [:],
     listeners: [String: Listener] = [:],
     content: Content
   ) {
@@ -56,7 +58,7 @@ extension DynamicHTML where Content: StringProtocol {
 extension DynamicHTML: ParentView where Content: View {
   public init(
     _ tag: String,
-    _ attributes: [String: String] = [:],
+    _ attributes: [HTMLAttribute: String] = [:],
     listeners: [String: Listener] = [:],
     @ViewBuilder content: () -> Content
   ) {
@@ -75,7 +77,7 @@ extension DynamicHTML: ParentView where Content: View {
 extension DynamicHTML where Content == EmptyView {
   public init(
     _ tag: String,
-    _ attributes: [String: String] = [:],
+    _ attributes: [HTMLAttribute: String] = [:],
     listeners: [String: Listener] = [:]
   ) {
     self = DynamicHTML(tag, attributes, listeners: listeners) { EmptyView() }

--- a/Sources/TokamakDOM/Views/Selectors/Picker.swift
+++ b/Sources/TokamakDOM/Views/Selectors/Picker.swift
@@ -36,7 +36,7 @@ extension _PickerContainer: ViewDeferredToRenderer {
 
 extension _PickerElement: ViewDeferredToRenderer {
   public var deferredBody: AnyView {
-    let attributes: [String: String]
+    let attributes: [HTMLAttribute: String]
     if let value = valueIndex {
       attributes = ["value": "\(value)"]
     } else {

--- a/Sources/TokamakDOM/Views/Selectors/Picker.swift
+++ b/Sources/TokamakDOM/Views/Selectors/Picker.swift
@@ -38,7 +38,7 @@ extension _PickerElement: ViewDeferredToRenderer {
   public var deferredBody: AnyView {
     let attributes: [HTMLAttribute: String]
     if let value = valueIndex {
-      attributes = ["value": "\(value)"]
+      attributes = [.value: "\(value)"]
     } else {
       attributes = [:]
     }

--- a/Sources/TokamakDOM/Views/Selectors/Slider.swift
+++ b/Sources/TokamakDOM/Views/Selectors/Slider.swift
@@ -31,7 +31,7 @@ extension Slider: ViewDeferredToRenderer {
       "min": String(proxy.bounds.lowerBound),
       "max": String(proxy.bounds.upperBound),
       "step": step,
-      "value": String(proxy.valueBinding.wrappedValue),
+      .value: String(proxy.valueBinding.wrappedValue),
       "style": """
         display: block;
         width: 100%;

--- a/Sources/TokamakDOM/Views/Selectors/Slider.swift
+++ b/Sources/TokamakDOM/Views/Selectors/Slider.swift
@@ -14,6 +14,7 @@
 
 import JavaScriptKit
 import TokamakCore
+import TokamakStaticHTML
 
 extension Slider: ViewDeferredToRenderer {
   public var deferredBody: AnyView {
@@ -25,7 +26,7 @@ extension Slider: ViewDeferredToRenderer {
     case let .discrete(value):
       step = String(value)
     }
-    let attributes = [
+    let attributes: [HTMLAttribute: String] = [
       "type": "range",
       "min": String(proxy.bounds.lowerBound),
       "max": String(proxy.bounds.upperBound),

--- a/Sources/TokamakDOM/Views/Text/SecureField.swift
+++ b/Sources/TokamakDOM/Views/Text/SecureField.swift
@@ -22,7 +22,7 @@ extension SecureField: ViewDeferredToRenderer where Label == Text {
     let proxy = _SecureFieldProxy(self)
     return AnyView(DynamicHTML("input", [
       "type": "password",
-      "value": proxy.textBinding.wrappedValue,
+      .value: proxy.textBinding.wrappedValue,
       "placeholder": proxy.label.rawText,
       "class": "_tokamak-securefield",
     ], listeners: [

--- a/Sources/TokamakDOM/Views/Text/TextField.swift
+++ b/Sources/TokamakDOM/Views/Text/TextField.swift
@@ -46,7 +46,7 @@ extension TextField: ViewDeferredToRenderer where Label == Text {
 
     return AnyView(DynamicHTML("input", [
       "type": proxy.textFieldStyle is RoundedBorderTextFieldStyle ? "search" : "text",
-      HTMLAttribute("value", isUpdatedAsProperty: true): proxy.textBinding.wrappedValue,
+      .property("value"): proxy.textBinding.wrappedValue,
       "placeholder": proxy.label.rawText,
       "style": css(for: proxy.textFieldStyle),
       "class": className(for: proxy.textFieldStyle),

--- a/Sources/TokamakDOM/Views/Text/TextField.swift
+++ b/Sources/TokamakDOM/Views/Text/TextField.swift
@@ -46,7 +46,7 @@ extension TextField: ViewDeferredToRenderer where Label == Text {
 
     return AnyView(DynamicHTML("input", [
       "type": proxy.textFieldStyle is RoundedBorderTextFieldStyle ? "search" : "text",
-      .property("value"): proxy.textBinding.wrappedValue,
+      .value: proxy.textBinding.wrappedValue,
       "placeholder": proxy.label.rawText,
       "style": css(for: proxy.textFieldStyle),
       "class": className(for: proxy.textFieldStyle),

--- a/Sources/TokamakDOM/Views/Text/TextField.swift
+++ b/Sources/TokamakDOM/Views/Text/TextField.swift
@@ -16,6 +16,7 @@
 //
 
 import TokamakCore
+import TokamakStaticHTML
 
 extension TextField: ViewDeferredToRenderer where Label == Text {
   func css(for style: TextFieldStyle) -> String {
@@ -45,7 +46,7 @@ extension TextField: ViewDeferredToRenderer where Label == Text {
 
     return AnyView(DynamicHTML("input", [
       "type": proxy.textFieldStyle is RoundedBorderTextFieldStyle ? "search" : "text",
-      "value": proxy.textBinding.wrappedValue,
+      HTMLAttribute("value", isUpdatedAsProperty: true): proxy.textBinding.wrappedValue,
       "placeholder": proxy.label.rawText,
       "style": css(for: proxy.textFieldStyle),
       "class": className(for: proxy.textFieldStyle),

--- a/Sources/TokamakStaticHTML/Modifiers/Effects/RotationEffect.swift
+++ b/Sources/TokamakStaticHTML/Modifiers/Effects/RotationEffect.swift
@@ -18,7 +18,7 @@
 import TokamakCore
 
 extension _RotationEffect: DOMViewModifier {
-  public var attributes: [String: String] {
+  public var attributes: [HTMLAttribute: String] {
     ["style": "transform: rotate(\(angle.degrees)deg)"]
   }
 }

--- a/Sources/TokamakStaticHTML/Modifiers/LayoutModifiers.swift
+++ b/Sources/TokamakStaticHTML/Modifiers/LayoutModifiers.swift
@@ -33,7 +33,7 @@ private extension DOMViewModifier {
 }
 
 extension _FrameLayout: DOMViewModifier {
-  public var attributes: [String: String] {
+  public var attributes: [HTMLAttribute: String] {
     ["style": """
     \(unwrapToStyle(\.width, property: "width"))
     \(unwrapToStyle(\.height, property: "height"))
@@ -47,7 +47,7 @@ extension _FrameLayout: DOMViewModifier {
 }
 
 extension _FlexFrameLayout: DOMViewModifier {
-  public var attributes: [String: String] {
+  public var attributes: [HTMLAttribute: String] {
     ["style": """
     \(unwrapToStyle(\.minWidth, property: "min-width"))
     width: \(unwrapToStyle(\.idealWidth, defaultValue: fillWidth ? "100%" : "auto"));
@@ -88,7 +88,7 @@ private extension EdgeInsets {
 
 extension _PaddingLayout: DOMViewModifier {
   public var isOrderDependent: Bool { true }
-  public var attributes: [String: String] {
+  public var attributes: [HTMLAttribute: String] {
     var padding = [(String, CGFloat)]()
     let insets = self.insets ?? .init(_all: 10)
     for edge in Edge.allCases {

--- a/Sources/TokamakStaticHTML/Modifiers/ViewModifier.swift
+++ b/Sources/TokamakStaticHTML/Modifiers/ViewModifier.swift
@@ -15,7 +15,7 @@
 import TokamakCore
 
 public protocol DOMViewModifier {
-  var attributes: [String: String] { get }
+  var attributes: [HTMLAttribute: String] { get }
   /// Can the modifier be flattened?
   var isOrderDependent: Bool { get }
 }
@@ -28,7 +28,7 @@ extension ModifiedContent: DOMViewModifier
   where Content: DOMViewModifier, Modifier: DOMViewModifier
 {
   // Merge attributes
-  public var attributes: [String: String] {
+  public var attributes: [HTMLAttribute: String] {
     var attr = content.attributes
     for (key, val) in modifier.attributes {
       if let prev = attr[key] {
@@ -40,14 +40,14 @@ extension ModifiedContent: DOMViewModifier
 }
 
 extension _ZIndexModifier: DOMViewModifier {
-  public var attributes: [String: String] {
+  public var attributes: [HTMLAttribute: String] {
     ["style": "z-index: \(index);"]
   }
 }
 
 extension _BackgroundModifier: DOMViewModifier where Background == Color {
   public var isOrderDependent: Bool { true }
-  public var attributes: [String: String] {
+  public var attributes: [HTMLAttribute: String] {
     ["style": "background-color: \(background.cssValue(environment))"]
   }
 }

--- a/Sources/TokamakStaticHTML/Shapes/Path.swift
+++ b/Sources/TokamakStaticHTML/Shapes/Path.swift
@@ -28,7 +28,7 @@ extension Path: ViewDeferredToRenderer {
     storage: Storage,
     strokeStyle: StrokeStyle = .zero
   ) -> AnyView {
-    let stroke = [
+    let stroke: [HTMLAttribute: String] = [
       "stroke-width": "\(strokeStyle.lineWidth)",
     ]
     let uniqueKeys = { (first: String, _: String) in first }
@@ -58,7 +58,7 @@ extension Path: ViewDeferredToRenderer {
     case let .roundedRect(roundedRect):
       // When cornerRadius is nil we use 50% rx.
       let size = roundedRect.rect.size
-      let cornerRadius = { () -> [String: String] in
+      let cornerRadius = { () -> [HTMLAttribute: String] in
         if let cornerSize = roundedRect.cornerSize {
           return [
             "rx": "\(cornerSize.width)",

--- a/Sources/TokamakStaticHTML/Shapes/Shape.swift
+++ b/Sources/TokamakStaticHTML/Shapes/Shape.swift
@@ -21,7 +21,7 @@ import TokamakCore
 extension _OverlayModifier: DOMViewModifier
   where Overlay == _ShapeView<_StrokedShape<TokamakCore.Rectangle._Inset>, Color>
 {
-  public var attributes: [String: String] {
+  public var attributes: [HTMLAttribute: String] {
     let style = overlay.shape.style.dashPhase == 0 ? "solid" : "dashed"
     return ["style": """
     border-style: \(style);
@@ -35,7 +35,7 @@ extension _OverlayModifier: DOMViewModifier
 // TODO: Implement arbitrary clip paths with CSS `clip-path`
 extension _ClipEffect: DOMViewModifier {
   public var isOrderDependent: Bool { true }
-  public var attributes: [String: String] {
+  public var attributes: [HTMLAttribute: String] {
     if let roundedRect = shape as? RoundedRectangle {
       return ["style": "border-radius: \(roundedRect.cornerSize.width)px; overflow: hidden;"]
     } else if shape is Circle {

--- a/Sources/TokamakStaticHTML/Shapes/_ShapeView.swift
+++ b/Sources/TokamakStaticHTML/Shapes/_ShapeView.swift
@@ -18,11 +18,11 @@
 import TokamakCore
 
 protocol ShapeAttributes {
-  func attributes(_ style: ShapeStyle) -> [String: String]
+  func attributes(_ style: ShapeStyle) -> [HTMLAttribute: String]
 }
 
 extension _StrokedShape: ShapeAttributes {
-  func attributes(_ style: ShapeStyle) -> [String: String] {
+  func attributes(_ style: ShapeStyle) -> [HTMLAttribute: String] {
     if let color = style as? Color {
       return ["style": "stroke: \(color.cssValue(environment)); fill: none;"]
     } else {

--- a/Sources/TokamakStaticHTML/StaticRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticRenderer.swift
@@ -59,7 +59,7 @@ extension HTMLTarget {
 struct HTMLBody: AnyHTML {
   let tag: String = "body"
   let innerHTML: String? = nil
-  let attributes: [String: String] = [
+  let attributes: [HTMLAttribute: String] = [
     "style": "margin: 0;" + rootNodeStyles,
   ]
 }

--- a/Sources/TokamakStaticHTML/Views/HTML.swift
+++ b/Sources/TokamakStaticHTML/Views/HTML.swift
@@ -17,6 +17,11 @@
 
 import TokamakCore
 
+/** Represents an attribute of an HTML tag. To consume updates from updated attributes, the DOM
+ renderer needs to know whether the attribute should be assigned via a DOM element property or the
+ [`setAttribute`](https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute) function.
+ The `isUpdatedAsProperty` flag is used to disambiguate between these two cases.
+ */
 public struct HTMLAttribute: Hashable {
   public let value: String
   public let isUpdatedAsProperty: Bool

--- a/Sources/TokamakStaticHTML/Views/HTML.swift
+++ b/Sources/TokamakStaticHTML/Views/HTML.swift
@@ -31,7 +31,7 @@ public struct HTMLAttribute: Hashable {
     self.isUpdatedAsProperty = isUpdatedAsProperty
   }
 
-  static func property(_ value: String) -> HTMLAttribute {
+  public static func property(_ value: String) -> HTMLAttribute {
     .init(value, isUpdatedAsProperty: true)
   }
 }

--- a/Sources/TokamakStaticHTML/Views/HTML.swift
+++ b/Sources/TokamakStaticHTML/Views/HTML.swift
@@ -17,10 +17,30 @@
 
 import TokamakCore
 
+public struct HTMLAttribute: Hashable {
+  public let value: String
+  public let isUpdatedAsProperty: Bool
+
+  public init(_ value: String, isUpdatedAsProperty: Bool) {
+    self.value = value
+    self.isUpdatedAsProperty = isUpdatedAsProperty
+  }
+}
+
+extension HTMLAttribute: CustomStringConvertible {
+  public var description: String { value }
+}
+
+extension HTMLAttribute: ExpressibleByStringLiteral {
+  public init(stringLiteral: String) {
+    self.init(stringLiteral, isUpdatedAsProperty: false)
+  }
+}
+
 public protocol AnyHTML {
   var innerHTML: String? { get }
   var tag: String { get }
-  var attributes: [String: String] { get }
+  var attributes: [HTMLAttribute: String] { get }
 }
 
 extension AnyHTML {
@@ -36,7 +56,7 @@ extension AnyHTML {
 
 public struct HTML<Content>: View, AnyHTML {
   public let tag: String
-  public let attributes: [String: String]
+  public let attributes: [HTMLAttribute: String]
   let content: Content
 
   public let innerHTML: String?
@@ -49,7 +69,7 @@ public struct HTML<Content>: View, AnyHTML {
 extension HTML where Content: StringProtocol {
   public init(
     _ tag: String,
-    _ attributes: [String: String] = [:],
+    _ attributes: [HTMLAttribute: String] = [:],
     content: Content
   ) {
     self.tag = tag
@@ -62,7 +82,7 @@ extension HTML where Content: StringProtocol {
 extension HTML: ParentView where Content: View {
   public init(
     _ tag: String,
-    _ attributes: [String: String] = [:],
+    _ attributes: [HTMLAttribute: String] = [:],
     @ViewBuilder content: () -> Content
   ) {
     self.tag = tag
@@ -79,7 +99,7 @@ extension HTML: ParentView where Content: View {
 extension HTML where Content == EmptyView {
   public init(
     _ tag: String,
-    _ attributes: [String: String] = [:]
+    _ attributes: [HTMLAttribute: String] = [:]
   ) {
     self = HTML(tag, attributes) { EmptyView() }
   }

--- a/Sources/TokamakStaticHTML/Views/HTML.swift
+++ b/Sources/TokamakStaticHTML/Views/HTML.swift
@@ -31,9 +31,7 @@ public struct HTMLAttribute: Hashable {
     self.isUpdatedAsProperty = isUpdatedAsProperty
   }
 
-  public static func property(_ value: String) -> HTMLAttribute {
-    .init(value, isUpdatedAsProperty: true)
-  }
+  public static let value = HTMLAttribute("value", isUpdatedAsProperty: true)
 }
 
 extension HTMLAttribute: CustomStringConvertible {

--- a/Sources/TokamakStaticHTML/Views/HTML.swift
+++ b/Sources/TokamakStaticHTML/Views/HTML.swift
@@ -30,6 +30,10 @@ public struct HTMLAttribute: Hashable {
     self.value = value
     self.isUpdatedAsProperty = isUpdatedAsProperty
   }
+
+  static func property(_ value: String) -> HTMLAttribute {
+    .init(value, isUpdatedAsProperty: true)
+  }
 }
 
 extension HTMLAttribute: CustomStringConvertible {

--- a/Sources/TokamakStaticHTML/Views/Layout/ZStack.swift
+++ b/Sources/TokamakStaticHTML/Views/Layout/ZStack.swift
@@ -15,7 +15,7 @@
 import TokamakCore
 
 struct _ZStack_ContentGridItem: ViewModifier, DOMViewModifier {
-  let attributes = ["style": "grid-area: a;"]
+  let attributes: [HTMLAttribute: String] = ["style": "grid-area: a;"]
 
   func body(content: Content) -> some View {
     content

--- a/Sources/TokamakStaticHTML/Views/Spacers/Divider.swift
+++ b/Sources/TokamakStaticHTML/Views/Spacers/Divider.swift
@@ -17,7 +17,7 @@ import TokamakCore
 extension Divider: AnyHTML {
   public var innerHTML: String? { nil }
   public var tag: String { "hr" }
-  public var attributes: [String: String] {
+  public var attributes: [HTMLAttribute: String] {
     [
       "style": """
       width: 100%; height: 0; margin: 0;

--- a/Sources/TokamakStaticHTML/Views/Text/Text.swift
+++ b/Sources/TokamakStaticHTML/Views/Text/Text.swift
@@ -91,7 +91,7 @@ extension Font: StylesConvertible {
 
 private struct TextSpan: AnyHTML {
   let content: String
-  let attributes: [String: String]
+  let attributes: [HTMLAttribute: String]
 
   var innerHTML: String? { content }
   var tag: String { "span" }
@@ -120,7 +120,7 @@ extension Text: AnyHTML {
   }
 
   public var tag: String { "span" }
-  public var attributes: [String: String] {
+  public var attributes: [HTMLAttribute: String] {
     let proxy = _TextProxy(self)
     return Self.attributes(
       from: proxy.modifiers,
@@ -133,7 +133,7 @@ extension Text {
   static func attributes(
     from modifiers: [_Modifier],
     environment: EnvironmentValues
-  ) -> [String: String] {
+  ) -> [HTMLAttribute: String] {
     let isRedacted = environment.redactionReasons.contains(.placeholder)
 
     var font: Font?


### PR DESCRIPTION
Property assignment does not update SVG elements. We may want to use properties instead of `setAttribute` in the future for optimizations. For now I think that `setAttribute` works in all cases, including SVG, and seems safer to me.

Resolves #278.