### PR TITLE
Fix compatibility with JavaScriptKit 0.7

### DIFF
--- a/.swift-version
+++ b/.swift-version
@@ -1,1 +1,1 @@
-wasm-5.3-SNAPSHOT-2020-07-27-a
+wasm-5.3-SNAPSHOT-2020-09-25-a

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "JavaScriptKit",
-        "repositoryURL": "https://github.com/kateinoigakukun/JavaScriptKit.git",
+        "repositoryURL": "https://github.com/swiftwasm/JavaScriptKit.git",
         "state": {
           "branch": null,
-          "revision": "c90e82fe1d576a2ccd1aae798380bf80be7885fb",
-          "version": "0.5.0"
+          "revision": "6e84a7003071ed3e9fa7f8d8266a272a36b84608",
+          "version": "0.7.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,10 @@ let package = Package(
   dependencies: [
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
-    .package(url: "https://github.com/kateinoigakukun/JavaScriptKit.git", from: "0.5.0"),
+    .package(
+      url: "https://github.com/swiftwasm/JavaScriptKit.git",
+      .upToNextMinor(from: "0.7.2")
+    ),
     .package(url: "https://github.com/MaxDesiatov/Runtime.git", from: "2.1.2"),
     .package(url: "https://github.com/MaxDesiatov/OpenCombine.git", from: "0.0.1"),
   ],

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ app.
 ## Requirements for app developers
 
 - macOS 10.15 and Xcode 11.4 or later.
-- [Swift 5.2 or later](https://swift.org/download/) for Linux.
+- [Swift 5.2 or later](https://swift.org/download/) and Ubuntu 18.04 if you'd like to use Linux.
+  Other Linux distributions are currently not supported.
 
 ## Requirements for app users
 
@@ -134,7 +135,7 @@ app by following these steps:
 brew install swiftwasm/tap/carton
 ```
 
-If you had `carton` installed before this, make sure you have version 0.5.0 or greater:
+If you had `carton` installed before this, make sure you have version 0.6.0 or greater:
 
 ```
 carton --version

--- a/Sources/TokamakCore/Shapes/Path.swift
+++ b/Sources/TokamakCore/Shapes/Path.swift
@@ -19,6 +19,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(WASI)
+import WASILibc
 #endif
 
 /// The outline of a 2D shape.

--- a/Sources/TokamakCore/Stubs/CGStubs.swift
+++ b/Sources/TokamakCore/Stubs/CGStubs.swift
@@ -19,6 +19,8 @@
 import Glibc
 #elseif canImport(Darwin)
 import Darwin
+#elseif os(WASI)
+import WASILibc
 #endif
 
 public typealias CGFloat = Double
@@ -230,9 +232,10 @@ public struct CGAffineTransform: Equatable {
   /// - Parameters:
   ///   - tx: The value by which to move x values with the affine transform.
   ///   - ty: The value by which to move y values with the affine transform.
-  public func translatedBy(x tx: CGFloat,
-                           y ty: CGFloat) -> Self
-  {
+  public func translatedBy(
+    x tx: CGFloat,
+    y ty: CGFloat
+  ) -> Self {
     .init(a: a, b: b, c: c, d: d, tx: self.tx + tx, ty: self.ty + ty)
   }
 
@@ -240,9 +243,10 @@ public struct CGAffineTransform: Equatable {
   /// - Parameters:
   ///   - sx: The value by which to scale x values of the affine transform.
   ///   - sy: The value by which to scale y values of the affine transform.
-  public func scaledBy(x sx: CGFloat,
-                       y sy: CGFloat) -> Self
-  {
+  public func scaledBy(
+    x sx: CGFloat,
+    y sy: CGFloat
+  ) -> Self {
     .init(a: a + sx, b: b, c: c, d: d + sy, tx: tx, ty: ty)
   }
 

--- a/Sources/TokamakCore/Stubs/CGStubs.swift
+++ b/Sources/TokamakCore/Stubs/CGStubs.swift
@@ -232,10 +232,7 @@ public struct CGAffineTransform: Equatable {
   /// - Parameters:
   ///   - tx: The value by which to move x values with the affine transform.
   ///   - ty: The value by which to move y values with the affine transform.
-  public func translatedBy(
-    x tx: CGFloat,
-    y ty: CGFloat
-  ) -> Self {
+  public func translatedBy(x tx: CGFloat, y ty: CGFloat) -> Self {
     .init(a: a, b: b, c: c, d: d, tx: self.tx + tx, ty: self.ty + ty)
   }
 
@@ -243,10 +240,7 @@ public struct CGAffineTransform: Equatable {
   /// - Parameters:
   ///   - sx: The value by which to scale x values of the affine transform.
   ///   - sy: The value by which to scale y values of the affine transform.
-  public func scaledBy(
-    x sx: CGFloat,
-    y sy: CGFloat
-  ) -> Self {
+  public func scaledBy(x sx: CGFloat, y sy: CGFloat) -> Self {
     .init(a: a + sx, b: b, c: c, d: d + sy, tx: tx, ty: ty)
   }
 

--- a/Sources/TokamakDOM/App/App.swift
+++ b/Sources/TokamakDOM/App/App.swift
@@ -35,7 +35,7 @@ extension App {
   public static func _launch(
     _ app: Self,
     _ rootEnvironment: EnvironmentValues,
-    _ body: JSObjectRef
+    _ body: JSObject
   ) {
     if body.style.object!.all == "" {
       body.style = "margin: 0;"

--- a/Sources/TokamakDOM/App/ColorSchemeObserver.swift
+++ b/Sources/TokamakDOM/App/ColorSchemeObserver.swift
@@ -23,10 +23,9 @@ enum ColorSchemeObserver {
   private static var closure: JSClosure?
   private static var cancellable: AnyCancellable?
 
-  static func observe(_ rootElement: JSObjectRef) {
+  static func observe(_ rootElement: JSObject) {
     let closure = JSClosure {
       publisher.value = .init(matchMediaDarkScheme: $0[0].object!)
-      return .undefined
     }
     _ = matchMediaDarkScheme.addListener!(closure)
     Self.closure = closure

--- a/Sources/TokamakDOM/App/ScenePhaseObserver.swift
+++ b/Sources/TokamakDOM/App/ScenePhaseObserver.swift
@@ -21,14 +21,13 @@ enum ScenePhaseObserver {
   private static var closure: JSClosure?
 
   static func observe() {
-    let closure = JSClosure { _ in
+    let closure = JSClosure { _ -> () in
       let visibilityState = document.visibilityState.string
       if visibilityState == "visible" {
         publisher.send(.active)
       } else if visibilityState == "hidden" {
         publisher.send(.background)
       }
-      return .undefined
     }
     _ = document.addEventListener!("visibilitychange", closure)
     Self.closure = closure

--- a/Sources/TokamakDOM/DOMNode.swift
+++ b/Sources/TokamakDOM/DOMNode.swift
@@ -42,18 +42,18 @@ extension AnyHTML {
 }
 
 final class DOMNode: Target {
-  let ref: JSObjectRef
+  let ref: JSObject
   private var listeners: [String: JSClosure]
   var view: AnyView
 
-  init<V: View>(_ view: V, _ ref: JSObjectRef, _ listeners: [String: Listener] = [:]) {
+  init<V: View>(_ view: V, _ ref: JSObject, _ listeners: [String: Listener] = [:]) {
     self.ref = ref
     self.listeners = [:]
     self.view = AnyView(view)
     reinstall(listeners)
   }
 
-  init(_ ref: JSObjectRef) {
+  init(_ ref: JSObject) {
     self.ref = ref
     view = AnyView(EmptyView())
     listeners = [:]
@@ -64,13 +64,13 @@ final class DOMNode: Target {
   func reinstall(_ listeners: [String: Listener]) {
     for (event, jsClosure) in self.listeners {
       _ = ref.removeEventListener!(event, jsClosure)
+      jsClosure.release()
     }
     self.listeners = [:]
 
     for (event, listener) in listeners {
       let jsClosure = JSClosure {
         listener($0[0].object!)
-        return .undefined
       }
       _ = ref.addEventListener!(event, jsClosure)
       self.listeners[event] = jsClosure

--- a/Sources/TokamakDOM/DOMRef.swift
+++ b/Sources/TokamakDOM/DOMRef.swift
@@ -19,8 +19,8 @@ extension View {
   /** Allows capturing DOM references of host views. The resulting reference is written
    to a given `binding`.
    */
-  public func _domRef(_ binding: Binding<JSObjectRef?>) -> some View {
-    // Convert `Binding<JSObjectRef?>` to `Binding<DOMNode?>` first.
+  public func _domRef(_ binding: Binding<JSObject?>) -> some View {
+    // Convert `Binding<JSObject?>` to `Binding<DOMNode?>` first.
     let targetBinding = Binding(
       get: { binding.wrappedValue.map(DOMNode.init) },
       set: { binding.wrappedValue = $0?.ref }

--- a/Sources/TokamakDOM/DOMRenderer.swift
+++ b/Sources/TokamakDOM/DOMRenderer.swift
@@ -88,9 +88,7 @@ final class DOMRenderer: Renderer {
       target: DOMNode(ref),
       environment: .defaultEnvironment,
       renderer: self
-    ) {
-      scheduler.schedule(options: nil, $0)
-    }
+    ) { scheduler.schedule(options: nil, $0) }
   }
 
   public func mountTarget(to parent: DOMNode, with host: MountedHost) -> DOMNode? {

--- a/Sources/TokamakDOM/DOMRenderer.swift
+++ b/Sources/TokamakDOM/DOMRenderer.swift
@@ -55,7 +55,7 @@ private extension AnyView {
   }
 }
 
-let global = JSObjectRef.global
+let global = JSObject.global
 let window = global.window.object!
 let matchMediaDarkScheme = window.matchMedia!("(prefers-color-scheme: dark)").object!
 let log = global.console.object!.log.function!
@@ -63,15 +63,7 @@ let document = global.document.object!
 let body = document.body.object!
 let head = document.head.object!
 
-private let timeoutScheduler = { (closure: @escaping () -> ()) in
-  let fn = JSClosure { _ in
-    closure()
-    return .undefined
-  }
-  _ = JSObjectRef.global.setTimeout!(fn, 0)
-}
-
-func appendRootStyle(_ rootNode: JSObjectRef) {
+func appendRootStyle(_ rootNode: JSObject) {
   rootNode.style = .string(rootNodeStyles)
   let rootStyle = document.createElement!("style").object!
   rootStyle.innerHTML = .string(tokamakStyles)
@@ -81,19 +73,24 @@ func appendRootStyle(_ rootNode: JSObjectRef) {
 final class DOMRenderer: Renderer {
   private(set) var reconciler: StackReconciler<DOMRenderer>?
 
-  private let rootRef: JSObjectRef
+  private let rootRef: JSObject
 
-  init<A: App>(_ app: A, _ ref: JSObjectRef, _ rootEnvironment: EnvironmentValues? = nil) {
+  private let scheduler: JSScheduler
+
+  init<A: App>(_ app: A, _ ref: JSObject, _ rootEnvironment: EnvironmentValues? = nil) {
     rootRef = ref
     appendRootStyle(ref)
 
+    let scheduler = JSScheduler()
+    self.scheduler = scheduler
     reconciler = StackReconciler(
       app: app,
       target: DOMNode(ref),
       environment: .defaultEnvironment,
-      renderer: self,
-      scheduler: timeoutScheduler
-    )
+      renderer: self
+    ) {
+      scheduler.schedule(options: nil, $0)
+    }
   }
 
   public func mountTarget(to parent: DOMNode, with host: MountedHost) -> DOMNode? {

--- a/Sources/TokamakDOM/JSScheduler.swift
+++ b/Sources/TokamakDOM/JSScheduler.swift
@@ -121,7 +121,14 @@ final class JSScheduler: Scheduler {
   private var scheduledTimers = [ObjectIdentifier: JSTimer]()
 
   func schedule(options: SchedulerOptions?, _ action: @escaping () -> ()) {
-    schedule(after: now, tolerance: minimumTolerance, options: options, action)
+    var timer: JSTimer!
+    timer = .init(millisecondsDelay: 0) { [weak self, weak timer] in
+      action()
+      if let timer = timer {
+        self?.scheduledTimers[ObjectIdentifier(timer)] = nil
+      }
+    }
+    scheduledTimers[ObjectIdentifier(timer)] = timer
   }
 
   func schedule(

--- a/Sources/TokamakDOM/JSScheduler.swift
+++ b/Sources/TokamakDOM/JSScheduler.swift
@@ -1,0 +1,169 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import JavaScriptKit
+import OpenCombine
+
+final class JSScheduler: Scheduler {
+  private final class CancellableTimer: Cancellable {
+    let cancellation: () -> ()
+
+    init(_ cancellation: @escaping () -> ()) {
+      self.cancellation = cancellation
+    }
+
+    func cancel() {
+      cancellation()
+    }
+  }
+
+  struct SchedulerTimeType: Strideable {
+    let millisecondsValue: Double
+
+    func advanced(by n: Stride) -> Self {
+      .init(millisecondsValue: millisecondsValue + n.magnitude)
+    }
+
+    func distance(to other: Self) -> Stride {
+      .init(millisecondsValue: other.millisecondsValue - millisecondsValue)
+    }
+
+    struct Stride: SchedulerTimeIntervalConvertible, Comparable, SignedNumeric {
+      /// Time interval magnitude in milliseconds
+      var magnitude: Double
+
+      init?<T>(exactly source: T) where T: BinaryInteger {
+        guard let magnitude = Double(exactly: source) else { return nil }
+        self.magnitude = magnitude
+      }
+
+      init(millisecondsValue: Double) {
+        magnitude = millisecondsValue
+      }
+
+      init(floatLiteral value: Double) {
+        self = .seconds(value)
+      }
+
+      init(integerLiteral value: Int) {
+        self = .seconds(value)
+      }
+
+      static func microseconds(_ us: Int) -> Self {
+        .init(millisecondsValue: 1.0 / (Double(us) * 1000))
+      }
+
+      static func milliseconds(_ ms: Int) -> Self {
+        .init(millisecondsValue: Double(ms))
+      }
+
+      static func nanoseconds(_ ns: Int) -> Self {
+        .init(millisecondsValue: 1.0 / (Double(ns) * 1_000_000))
+      }
+
+      static func seconds(_ s: Double) -> Self {
+        .init(millisecondsValue: s * 1000)
+      }
+
+      static func seconds(_ s: Int) -> Self {
+        .init(millisecondsValue: Double(s) * 1000)
+      }
+
+      public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.magnitude < rhs.magnitude
+      }
+
+      public static func * (lhs: Self, rhs: Self) -> Self {
+        .init(millisecondsValue: lhs.magnitude * rhs.magnitude)
+      }
+
+      public static func + (lhs: Self, rhs: Self) -> Self {
+        .init(millisecondsValue: lhs.magnitude + rhs.magnitude)
+      }
+
+      public static func - (lhs: Self, rhs: Self) -> Self {
+        .init(millisecondsValue: lhs.magnitude - rhs.magnitude)
+      }
+
+      public static func -= (lhs: inout Self, rhs: Self) {
+        lhs.magnitude -= rhs.magnitude
+      }
+
+      public static func *= (lhs: inout Self, rhs: Self) {
+        lhs.magnitude *= rhs.magnitude
+      }
+
+      public static func += (lhs: inout Self, rhs: Self) {
+        lhs.magnitude += rhs.magnitude
+      }
+    }
+  }
+
+  struct SchedulerOptions {}
+
+  var now: SchedulerTimeType { .init(millisecondsValue: JSDate.now()) }
+
+  var minimumTolerance: SchedulerTimeType.Stride {
+    .init(millisecondsValue: .leastNonzeroMagnitude)
+  }
+
+  private var scheduledTimers = [ObjectIdentifier: JSTimer]()
+
+  func schedule(options: SchedulerOptions?, _ action: @escaping () -> ()) {
+    schedule(after: now, tolerance: minimumTolerance, options: options, action)
+  }
+
+  func schedule(
+    after date: SchedulerTimeType,
+    tolerance: SchedulerTimeType.Stride,
+    options: SchedulerOptions?,
+    _ action: @escaping () -> ()
+  ) {
+    var timer: JSTimer!
+    timer = .init(
+      millisecondsDelay: date.millisecondsValue - JSDate.now()
+    ) { [weak self, weak timer] in
+      action()
+      if let timer = timer {
+        self?.scheduledTimers[ObjectIdentifier(timer)] = nil
+      }
+    }
+    scheduledTimers[ObjectIdentifier(timer)] = timer
+  }
+
+  func schedule(
+    after date: SchedulerTimeType,
+    interval: SchedulerTimeType.Stride,
+    tolerance: SchedulerTimeType.Stride,
+    options: SchedulerOptions?,
+    _ action: @escaping () -> ()
+  ) -> Cancellable {
+    var timeoutTimer, intervalTimer: JSTimer!
+
+    timeoutTimer = .init(
+      millisecondsDelay: date.millisecondsValue - JSDate.now()
+    ) { [weak self, weak timeoutTimer] in
+      intervalTimer = .init(millisecondsDelay: interval.magnitude) { action() }
+
+      self?.scheduledTimers[ObjectIdentifier(intervalTimer)] = intervalTimer
+
+      if let timeoutTimer = timeoutTimer {
+        self?.scheduledTimers[ObjectIdentifier(timeoutTimer)] = nil
+      }
+    }
+    scheduledTimers[ObjectIdentifier(timeoutTimer)] = timeoutTimer
+
+    return CancellableTimer { self.scheduledTimers[ObjectIdentifier(intervalTimer)] = nil }
+  }
+}

--- a/Sources/TokamakDOM/Storage/SessionStorage.swift
+++ b/Sources/TokamakDOM/Storage/SessionStorage.swift
@@ -19,20 +19,16 @@ import CombineShim
 import JavaScriptKit
 import TokamakCore
 
-public class SessionStorage: WebStorage, _StorageProvider {
-  let storage = JSObjectRef.global.sessionStorage.object!
+private let sessionStorage = JSObject.global.sessionStorage.object!
 
-  required init() {
-    subscription = Self.rootPublisher.sink { _ in
-      self.publisher.send()
-    }
-  }
+public class SessionStorage: WebStorage, _StorageProvider {
+  let storage = sessionStorage
+
+  required init() {}
 
   public static var standard: _StorageProvider {
     Self()
   }
 
-  var subscription: AnyCancellable?
-  static let rootPublisher = ObservableObjectPublisher()
   public let publisher = ObservableObjectPublisher()
 }

--- a/Sources/TokamakDOM/Storage/WebStorage.swift
+++ b/Sources/TokamakDOM/Storage/WebStorage.swift
@@ -20,19 +20,18 @@ import JavaScriptKit
 import TokamakCore
 
 protocol WebStorage {
-  var storage: JSObjectRef { get }
+  var storage: JSObject { get }
   init()
 
   func setItem<Value>(key: String, value: Value?)
   func getItem<Value>(key: String, _ initialize: (String) -> Value?) -> Value?
 
-  static var rootPublisher: ObservableObjectPublisher { get }
   var publisher: ObservableObjectPublisher { get }
 }
 
 extension WebStorage {
   func setItem<Value>(key: String, value: Value?) {
-    Self.rootPublisher.send()
+    publisher.send()
     if let value = value {
       _ = storage.setItem!(key, String(describing: value))
     }

--- a/Sources/TokamakDOM/Styles/ColorScheme.swift
+++ b/Sources/TokamakDOM/Styles/ColorScheme.swift
@@ -15,7 +15,7 @@
 import JavaScriptKit
 
 extension ColorScheme {
-  init(matchMediaDarkScheme: JSObjectRef) {
+  init(matchMediaDarkScheme: JSObject) {
     self = matchMediaDarkScheme.matches.boolean == true ? .dark : .light
   }
 }

--- a/Sources/TokamakDOM/Views/DynamicHTML.swift
+++ b/Sources/TokamakDOM/Views/DynamicHTML.swift
@@ -21,7 +21,7 @@ import TokamakStaticHTML
 
 public typealias HTML = TokamakStaticHTML.HTML
 
-public typealias Listener = (JSObjectRef) -> ()
+public typealias Listener = (JSObject) -> ()
 
 protocol AnyDynamicHTML: AnyHTML {
   var listeners: [String: Listener] { get }

--- a/Sources/TokamakDOM/Views/Layout/GeometryReader.swift
+++ b/Sources/TokamakDOM/Views/Layout/GeometryReader.swift
@@ -16,7 +16,7 @@ import JavaScriptKit
 import TokamakCore
 import TokamakStaticHTML
 
-private let ResizeObserver = JSObjectRef.global.ResizeObserver.function!
+private let ResizeObserver = JSObject.global.ResizeObserver.function!
 
 extension GeometryReader: ViewDeferredToRenderer {
   public var deferredBody: AnyView {
@@ -32,10 +32,10 @@ struct _GeometryReader<Content: View>: View {
     var closure: JSClosure?
 
     /// A reference to a DOM node being observed for size updates.
-    var observedNodeRef: JSObjectRef?
+    var observedNodeRef: JSObject?
 
     /// A reference to a `ResizeObserver` instance.
-    var observerRef: JSObjectRef?
+    var observerRef: JSObject?
 
     /// The last known size of the `observedNodeRef` DOM node.
     @Published var size: CGSize?
@@ -55,18 +55,16 @@ struct _GeometryReader<Content: View>: View {
     }
     ._domRef($state.observedNodeRef)
     ._onMount {
-      let closure = JSClosure { [weak state] args in
+      let closure = JSClosure { [weak state] args -> () in
         // FIXME: `JSArrayRef` is not a `RandomAccessCollection` for some reason, which forces
         // us to use a string subscript
         guard
           let rect = args[0].object?[dynamicMember: "0"].object?.contentRect.object,
           let width = rect.width.number,
           let height = rect.height.number
-        else { return .undefined }
+        else { return }
 
         state?.size = .init(width: width, height: height)
-
-        return .undefined
       }
       state.closure = closure
 

--- a/Sources/TokamakDemo/DOMRefDemo.swift
+++ b/Sources/TokamakDemo/DOMRefDemo.swift
@@ -17,7 +17,7 @@ import JavaScriptKit
 import TokamakShim
 
 struct DOMRefDemo: View {
-  @State var button: JSObjectRef?
+  @State var button: JSObject?
 
   var body: some View {
     Button("Click me") {

--- a/Sources/TokamakTestRenderer/TestRenderer.swift
+++ b/Sources/TokamakTestRenderer/TestRenderer.swift
@@ -28,7 +28,7 @@ public func testScheduler(closure: @escaping () -> ()) {
     closure()
     return .undefined
   }
-  _ = JSObjectRef.global.setTimeout!(fn, 0)
+  _ = JSObject.global.setTimeout!(fn, 0)
   #else
   DispatchQueue.main.async(execute: closure)
   #endif


### PR DESCRIPTION
This PR requires `carton` 0.6.0 that you can install from Homebrew as usual.

To cleanly manage scheduler closures, new `JSScheduler` class is introduced that conforms to OpenCombine's `Scheduler` protocol. I think it will be moved to OpenCombineJS in the future.

~Basic things seem to work, but I think there's a noticeable performance regression somewhere. When I switch between navigation views, it takes almost a second to load everything. I've been staring at profiling data for a bit, `JSString` which was introduced in JavaScriptKit 0.7 is there somewhere, but I'm not sure what exactly is the culprit yet.~
Update: I no longer can get the performance regression reproduced. 🤷‍♂️