### PR TITLE
Use v5.3 tag of `swiftwasm-action` in `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: swiftwasm/swiftwasm-action@master
+      - uses: swiftwasm/swiftwasm-action@v5.3
         with:
           shell-action: swift build --triple wasm32-unknown-wasi --product TokamakDemo
 


### PR DESCRIPTION
`swiftwasm-action@master` no longer exists, and we should use a tag to rely on more stable action code anyway.