### PR TITLE
Expose TokamakCore as a library (for GTK renderer)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,10 @@ let package = Package(
       targets: ["TokamakDOM"]
     ),
     .library(
+      name: "TokamakCore",
+      targets: ["TokamakCore"]
+    ),
+    .library(
       name: "TokamakShim",
       targets: ["TokamakShim"]
     ),


### PR DESCRIPTION
Expose TokamakCore as a library so that it can be used directly as an external dependency.

I tried building a GTK wrapper using TokamakCore and lack the possibility of referencing the library directly.