### PR TITLE
Remove extra `path` element

### DIFF
--- a/Sources/TokamakCore/MountedViews/MountedElement.swift
+++ b/Sources/TokamakCore/MountedViews/MountedElement.swift
@@ -76,10 +76,10 @@ public class MountedElement<R: Renderer> {
   var typeConstructorName: String {
     switch element {
     case .app: fatalError("""
-      `App` values aren't supposed to be reconciled, thus the type constructor name is not stored \
-      for `App` elements. Please report this crash as a bug at \
-      https://github.com/swiftwasm/Tokamak/issues/new
-      """)
+    `App` values aren't supposed to be reconciled, thus the type constructor name is not stored \
+    for `App` elements. Please report this crash as a bug at \
+    https://github.com/swiftwasm/Tokamak/issues/new
+    """)
     case let .scene(scene): return scene.typeConstructorName
     case let .view(view): return view.typeConstructorName
     }
@@ -172,7 +172,7 @@ extension TypeInfo {
     // swiftlint:disable force_try
     // Extract the view from the AnyView for modification, apply Environment changes:
     if genericTypes.contains(where: { $0 is EnvironmentModifier.Type }),
-       let modifier = try! property(named: "modifier").get(from: element) as? EnvironmentModifier
+      let modifier = try! property(named: "modifier").get(from: element) as? EnvironmentModifier
     {
       modifier.modifyEnvironment(&modifiedEnv)
     }

--- a/Sources/TokamakCore/MountedViews/MountedScene.swift
+++ b/Sources/TokamakCore/MountedViews/MountedScene.swift
@@ -99,7 +99,7 @@ extension _AnyScene {
   ) -> MountedScene<R> {
     var title: String?
     if let titledSelf = scene as? TitledScene,
-       let text = titledSelf.title
+      let text = titledSelf.title
     {
       title = _TextProxy(text).rawText
     }

--- a/Sources/TokamakCore/Views/Selectors/Picker.swift
+++ b/Sources/TokamakCore/Views/Selectors/Picker.swift
@@ -67,7 +67,7 @@ public struct Picker<Label: View, SelectionValue: Hashable, Content: View>: View
       // update the binding.
       ForEach(0..<children.count) { index in
         if let forEach = mapAnyView(children[index], transform: { (v: ForEachProtocol) in v }),
-           forEach.elementType == SelectionValue.self
+          forEach.elementType == SelectionValue.self
         {
           let nestedChildren = forEach.children
 

--- a/Sources/TokamakDOM/Core.swift
+++ b/Sources/TokamakDOM/Core.swift
@@ -132,6 +132,7 @@ public typealias AnyView = TokamakCore.AnyView
 public typealias EmptyView = TokamakCore.EmptyView
 
 // MARK: Text
+
 public typealias TextAlignment = TokamakCore.TextAlignment
 
 // MARK: App & Scene

--- a/Sources/TokamakDemo/ColorDemo.swift
+++ b/Sources/TokamakDemo/ColorDemo.swift
@@ -20,8 +20,8 @@ import TokamakShim
 public struct ColorDemo: View {
   var color: Color {
     guard let v0d = Double(v0),
-          let v1d = Double(v1),
-          let v2d = Double(v2)
+      let v1d = Double(v1),
+      let v2d = Double(v2)
     else {
       return .white
     }

--- a/Sources/TokamakStaticHTML/Modifiers/ModifiedContent.swift
+++ b/Sources/TokamakStaticHTML/Modifiers/ModifiedContent.swift
@@ -34,7 +34,7 @@ extension ModifiedContent: ViewDeferredToRenderer where Content: View, Modifier:
   public var deferredBody: AnyView {
     if let domModifier = modifier as? DOMViewModifier {
       if let adjacentModifier = content as? AnyModifiedContent,
-         !(adjacentModifier.anyModifier.isOrderDependent || domModifier.isOrderDependent)
+        !(adjacentModifier.anyModifier.isOrderDependent || domModifier.isOrderDependent)
       {
         // Flatten non-order-dependent modifiers
         var attr = domModifier.attributes

--- a/Sources/TokamakStaticHTML/Shapes/Path.swift
+++ b/Sources/TokamakStaticHTML/Shapes/Path.swift
@@ -95,6 +95,7 @@ extension Path: ViewDeferredToRenderer {
     elements: [Element],
     strokeStyle: StrokeStyle = .zero
   ) -> AnyView {
+    if elements.isEmpty { return AnyView(EmptyView()) }
     var d = [String]()
     for element in elements {
       switch element {


### PR DESCRIPTION
The blue capsule in the PathDemo, rendered to HTML:

```diff
 <svg style="width: 100%;height: 100%; overflow: visible;">
   <rect
     x="0.0"
     height="100%"
     width="100%"
     y="0.0"
     ry="50%"
     stroke-width="0.0"
   ></rect>
-  <path style="stroke-width: 0.0;" d=""></path>
 </svg>
```
