### PR TITLE
GTK shape support WIP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-LINKER_FLAGS := $(shell pkg-config --libs gtk+-3.0)
-C_FLAGS := $(shell pkg-config --cflags gtk+-3.0)
+LINKER_FLAGS := $(shell pkg-config --libs gtk+-3.0 gdk-3.0 pangocairo pangoft2 pango gio-unix-2.0 glib-2.0)
+C_FLAGS := $(shell pkg-config --cflags gtk+-3.0 gdk-3.0 pangocairo pangoft2 pango gio-unix-2.0 glib-2.0)
 SWIFT_LINKER_FLAGS ?= -Xlinker $(shell echo $(LINKER_FLAGS) | sed -e "s/ / -Xlinker /g" | sed -e "s/-Xlinker -Wl,-framework,/-Xlinker -framework -Xlinker /g")
 SWIFT_C_FLAGS ?= -Xcc $(shell echo $(C_FLAGS) | sed -e "s/ / -Xcc /g")
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-LINKER_FLAGS := $(shell pkg-config --libs gtk+-3.0 gdk-3.0 pangocairo pangoft2 pango gio-unix-2.0 glib-2.0)
-C_FLAGS := $(shell pkg-config --cflags gtk+-3.0 gdk-3.0 pangocairo pangoft2 pango gio-unix-2.0 glib-2.0)
+LINKER_FLAGS := $(shell pkg-config --libs gtk+-3.0 gdk-3.0)
+C_FLAGS := $(shell pkg-config --cflags gtk+-3.0)
 SWIFT_LINKER_FLAGS ?= -Xlinker $(shell echo $(LINKER_FLAGS) | sed -e "s/ / -Xlinker /g" | sed -e "s/-Xlinker -Wl,-framework,/-Xlinker -framework -Xlinker /g")
 SWIFT_C_FLAGS ?= -Xcc $(shell echo $(C_FLAGS) | sed -e "s/ / -Xcc /g")
 

--- a/Package.swift
+++ b/Package.swift
@@ -91,7 +91,13 @@ let package = Package(
       pkgConfig: "gdk-3.0 pangocairo pangoft2 pango gio-unix-2.0 glib-2.0",
       providers: [
         .brew(["gtk+3", "glib", "glib-networking", "gobject-introspection"]),
-        .apt(["libgtk-3-dev", "libglib2.0-dev", "glib-networking", "gobject-introspection", "libgirepository1.0-dev"])
+        .apt([
+              "libgtk-3-dev",
+              "libglib2.0-dev",
+              "glib-networking",
+              "gobject-introspection",
+              "libgirepository1.0-dev"
+        ])
       ]),
     .target(
       name: "TokamakGTKCHelpers",

--- a/Package.swift
+++ b/Package.swift
@@ -86,13 +86,20 @@ let package = Package(
         .brew(["gtk+3"]),
       ]
     ),
+    .systemLibrary(
+      name: "CGDK",
+      pkgConfig: "gdk-3.0 pangocairo pangoft2 pango gio-unix-2.0 glib-2.0",
+      providers: [
+        .brew(["gtk+3", "glib", "glib-networking", "gobject-introspection"]),
+        .apt(["libgtk-3-dev", "libglib2.0-dev", "glib-networking", "gobject-introspection", "libgirepository1.0-dev"])
+      ]),
     .target(
       name: "TokamakGTKCHelpers",
       dependencies: ["CGTK"]
     ),
     .target(
       name: "TokamakGTK",
-      dependencies: ["TokamakCore", "CGTK", "TokamakGTKCHelpers", "CombineShim"]
+      dependencies: ["TokamakCore", "CGTK", "CGDK", "TokamakGTKCHelpers", "CombineShim"]
     ),
     .target(
       name: "TokamakGTKDemo",

--- a/Package.swift
+++ b/Package.swift
@@ -88,17 +88,13 @@ let package = Package(
     ),
     .systemLibrary(
       name: "CGDK",
-      pkgConfig: "gdk-3.0 pangocairo pangoft2 pango gio-unix-2.0 glib-2.0",
+      pkgConfig: "gdk-3.0",
       providers: [
-        .brew(["gtk+3", "glib", "glib-networking", "gobject-introspection"]),
-        .apt([
-              "libgtk-3-dev",
-              "libglib2.0-dev",
-              "glib-networking",
-              "gobject-introspection",
-              "libgirepository1.0-dev"
-        ])
-      ]),
+        .apt(["libgtk+-3.0", "gtk+-3.0"]),
+        // .yum(["gtk3-devel"]),
+        .brew(["gtk+3"]),
+      ]
+    ),
     .target(
       name: "TokamakGTKCHelpers",
       dependencies: ["CGTK"]

--- a/Sources/CGDK/CGDK-Bridging-Header.h
+++ b/Sources/CGDK/CGDK-Bridging-Header.h
@@ -1,0 +1,1 @@
+#include <gdk/gdk.h>

--- a/Sources/CGDK/module.modulemap
+++ b/Sources/CGDK/module.modulemap
@@ -1,0 +1,8 @@
+module CGDK {
+    header "./termios-Header.h"
+    header "./CGDK-Bridging-Header.h"
+    
+    link "gdk-3"
+
+    export *
+}

--- a/Sources/CGDK/termios-Header.h
+++ b/Sources/CGDK/termios-Header.h
@@ -1,0 +1,1 @@
+#include <termios.h>

--- a/Sources/TokamakCore/Shapes/Path.swift
+++ b/Sources/TokamakCore/Shapes/Path.swift
@@ -59,7 +59,7 @@ public struct Path: Equatable, LosslessStringConvertible {
     case empty
     case rect(CGRect)
     case ellipse(CGRect)
-    case roundedRect(FixedRoundedRect)
+    indirect case roundedRect(FixedRoundedRect)
     indirect case stroked(StrokedPath)
     indirect case trimmed(TrimmedPath)
     case path(PathBox)

--- a/Sources/TokamakCore/Shapes/Path.swift
+++ b/Sources/TokamakCore/Shapes/Path.swift
@@ -458,7 +458,6 @@ public extension Path {
   ) {}
 
   mutating func addPath(_ path: Path, transform: CGAffineTransform = .identity) {
-    // TODO: handle transform
     append(path.storage, transform: transform)
   }
 

--- a/Sources/TokamakCore/Shapes/Path.swift
+++ b/Sources/TokamakCore/Shapes/Path.swift
@@ -240,10 +240,14 @@ public extension Path.Storage {
       }
 
     case .roundedRect(let roundedRect):
-      // TODO: Check that zero is the default value in SwiftUI
-      let cornerSize = roundedRect.cornerSize ?? .zero
-      let cornerStyle = roundedRect.style
+      // A cornerSize of nil means that we are drawing a Capsule
+      // In other words the corner size should be half of the min
+      // of the size and width
       let rect = roundedRect.rect
+      let cornerSize = roundedRect.cornerSize ??
+        CGSize(width: min(rect.size.width, rect.size.height) / 2,
+               height: min(rect.size.width, rect.size.height) / 2)
+      let cornerStyle = roundedRect.style
       switch cornerStyle {
       case .continuous:
         return [

--- a/Sources/TokamakCore/Shapes/Path.swift
+++ b/Sources/TokamakCore/Shapes/Path.swift
@@ -162,7 +162,8 @@ public struct Path: Equatable, LosslessStringConvertible {
       let minY = yPos.first ?? 0
       let maxY = yPos.last ?? 0
 
-      return CGRect(origin: CGPoint(x: minX, y: minY), size: CGSize(width: maxX - minX, height: maxY - minY))
+      return CGRect(origin: CGPoint(x: minX, y: minY),
+                    size: CGSize(width: maxX - minX, height: maxY - minY))
     }
   }
 
@@ -288,7 +289,8 @@ public extension Path.Storage {
         return
           [
             [
-              .move(to: CGPoint(x: rect.size.width, y: rect.size.height / 2).offset(by: rect.origin)),
+              .move(to: CGPoint(x: rect.size.width, y: rect.size.height / 2)
+                      .offset(by: rect.origin)),
               .line(
                 to: CGPoint(x: rect.size.width, y: rect.size.height - cornerSize.height)
                   .offset(by: rect.origin)
@@ -301,7 +303,8 @@ public extension Path.Storage {
                    startAngle: Angle(radians: 0),
                    endAngle: Angle(radians: Double.pi / 2),
                    clockwise: false),
-            [.line(to: CGPoint(x: cornerSize.width, y: rect.size.height).offset(by: rect.origin))],
+            [.line(to: CGPoint(x: cornerSize.width, y: rect.size.height)
+                    .offset(by: rect.origin))],
             getArc(center: CGPoint(x: cornerSize.width,
                                    y: rect.size.height - cornerSize.height)
                     .offset(by: rect.origin),
@@ -309,7 +312,8 @@ public extension Path.Storage {
                    startAngle: Angle(radians: Double.pi / 2),
                    endAngle: Angle(radians: Double.pi),
                    clockwise: false),
-            [.line(to: CGPoint(x: 0, y: cornerSize.height).offset(by: rect.origin))],
+            [.line(to: CGPoint(x: 0, y: cornerSize.height)
+                    .offset(by: rect.origin))],
             getArc(center: CGPoint(x: cornerSize.width,
                                    y: cornerSize.height)
                     .offset(by: rect.origin),
@@ -317,7 +321,8 @@ public extension Path.Storage {
                    startAngle: Angle(radians: Double.pi),
                    endAngle: Angle(radians: 3 * Double.pi / 2),
                    clockwise: false),
-            [.line(to: CGPoint(x: rect.size.width - cornerSize.width, y: 0).offset(by: rect.origin))],
+            [.line(to: CGPoint(x: rect.size.width - cornerSize.width, y: 0)
+                    .offset(by: rect.origin))],
             getArc(center: CGPoint(x: rect.size.width - cornerSize.width,
                                    y: cornerSize.height)
                     .offset(by: rect.origin),

--- a/Sources/TokamakCore/Shapes/Path.swift
+++ b/Sources/TokamakCore/Shapes/Path.swift
@@ -25,9 +25,9 @@ import WASILibc
 
 /// The outline of a 2D shape.
 public struct Path: Equatable, LosslessStringConvertible {
-  public class PathBox: Equatable {
+  public class _PathBox: Equatable {
     var elements: [Element] = []
-    public static func == (lhs: Path.PathBox, rhs: Path.PathBox) -> Bool {
+    public static func == (lhs: Path._PathBox, rhs: Path._PathBox) -> Bool {
       return lhs.elements == rhs.elements
     }
     init() {
@@ -62,7 +62,7 @@ public struct Path: Equatable, LosslessStringConvertible {
     indirect case roundedRect(FixedRoundedRect)
     indirect case stroked(StrokedPath)
     indirect case trimmed(TrimmedPath)
-    case path(PathBox)
+    case path(_PathBox)
   }
 
   public enum Element: Equatable {
@@ -383,7 +383,7 @@ public extension Path {
       pathBox.elements.append(contentsOf: elements_)
 
     default:
-      storage = .path(PathBox(elements: storage.elements + elements_))
+      storage = .path(_PathBox(elements: storage.elements + elements_))
     }
   }
 
@@ -495,7 +495,7 @@ public extension Path {
   func applying(_ transform: CGAffineTransform) -> Path {
     guard transform != .identity else { return self }
     let elements = self.elements.map { transform.transform(element: $0) }
-    let box = PathBox(elements: elements)
+    let box = _PathBox(elements: elements)
     return Path(storage: .path(box), sizing: .fixed)
   }
 

--- a/Sources/TokamakGTK/GSignal.swift
+++ b/Sources/TokamakGTK/GSignal.swift
@@ -39,6 +39,26 @@ extension UnsafeMutablePointer where Pointee == GtkWidget {
     ))
   }
 
+  /// Connect with a c function pointer, but with an extra opaque pointer.
+  @discardableResult
+  func connect(
+    signal: UnsafePointer<gchar>,
+    data: gpointer? = nil,
+    handler: @convention(c) @escaping (UnsafeMutablePointer<GtkWidget>?, OpaquePointer, UnsafeRawPointer) -> Bool,
+    destroy: @convention(c) @escaping (UnsafeRawPointer, UnsafeRawPointer) -> ()
+  ) -> Int {
+    let handler = unsafeBitCast(handler, to: GCallback.self)
+    let destroy = unsafeBitCast(destroy, to: GClosureNotify.self)
+    return Int(g_signal_connect_data(
+      self,
+      signal,
+      handler,
+      data,
+      destroy,
+      GConnectFlags(rawValue: 0)
+    ))
+  }
+
   /// Connect with a context-capturing closure.
   @discardableResult
   func connect(
@@ -77,34 +97,14 @@ extension UnsafeMutablePointer where Pointee == GtkWidget {
     })
   }
 
-  /// Connect with a c function pointer.
+  /// Connect with a context-capturing closure (with the GtkWidget and an OpaquePointer passed through)
   @discardableResult
-  func connectA(
-    signal: UnsafePointer<gchar>,
-    data: gpointer? = nil,
-    handler: @convention(c) @escaping (UnsafeMutablePointer<GtkWidget>?, OpaquePointer, UnsafeRawPointer) -> Bool,
-    destroy: @convention(c) @escaping (UnsafeRawPointer, UnsafeRawPointer) -> ()
-  ) -> Int {
-    let handler = unsafeBitCast(handler, to: GCallback.self)
-    let destroy = unsafeBitCast(destroy, to: GClosureNotify.self)
-    return Int(g_signal_connect_data(
-      self,
-      signal,
-      handler,
-      data,
-      destroy,
-      GConnectFlags(rawValue: 0)
-    ))
-  }
-
-  /// Connect with a context-capturing closure (with the GtkWidget passed through)
-  @discardableResult
-  func connect2(
+  func connect(
     signal: UnsafePointer<gchar>,
     closure: @escaping (UnsafeMutablePointer<GtkWidget>?, OpaquePointer) -> ()
   ) -> Int {
     let closureBox = Unmanaged.passRetained(DualParamClosureBox(closure)).retain().toOpaque()
-    return connectA(signal: signal, data: closureBox, handler: { widget, context, closureBox in
+    return connect(signal: signal, data: closureBox, handler: { widget, context, closureBox in
       let unpackedAction = Unmanaged<DualParamClosureBox<UnsafeMutablePointer<GtkWidget>?, OpaquePointer, ()>>
         .fromOpaque(closureBox)
       if let widget = widget {

--- a/Sources/TokamakGTK/GSignal.swift
+++ b/Sources/TokamakGTK/GSignal.swift
@@ -16,7 +16,6 @@
 //
 
 import CGTK
-import CGDK
 
 extension UnsafeMutablePointer where Pointee == GtkWidget {
   /// Connect with a c function pointer.

--- a/Sources/TokamakGTK/GSignal.swift
+++ b/Sources/TokamakGTK/GSignal.swift
@@ -44,7 +44,9 @@ extension UnsafeMutablePointer where Pointee == GtkWidget {
   func connect(
     signal: UnsafePointer<gchar>,
     data: gpointer? = nil,
-    handler: @convention(c) @escaping (UnsafeMutablePointer<GtkWidget>?, OpaquePointer, UnsafeRawPointer) -> Bool,
+    handler: @convention(c) @escaping (UnsafeMutablePointer<GtkWidget>?,
+                                       OpaquePointer,
+                                       UnsafeRawPointer) -> Bool,
     destroy: @convention(c) @escaping (UnsafeRawPointer, UnsafeRawPointer) -> ()
   ) -> Int {
     let handler = unsafeBitCast(handler, to: GCallback.self)
@@ -97,7 +99,8 @@ extension UnsafeMutablePointer where Pointee == GtkWidget {
     })
   }
 
-  /// Connect with a context-capturing closure (with the GtkWidget and an OpaquePointer passed through)
+  /// Connect with a context-capturing closure (with the GtkWidget and an
+  /// OpaquePointer passed through)
   @discardableResult
   func connect(
     signal: UnsafePointer<gchar>,
@@ -105,14 +108,16 @@ extension UnsafeMutablePointer where Pointee == GtkWidget {
   ) -> Int {
     let closureBox = Unmanaged.passRetained(DualParamClosureBox(closure)).retain().toOpaque()
     return connect(signal: signal, data: closureBox, handler: { widget, context, closureBox in
-      let unpackedAction = Unmanaged<DualParamClosureBox<UnsafeMutablePointer<GtkWidget>?, OpaquePointer, ()>>
+      let unpackedAction = Unmanaged<DualParamClosureBox<UnsafeMutablePointer<GtkWidget>?,
+                                                         OpaquePointer, ()>>
         .fromOpaque(closureBox)
       if let widget = widget {
         unpackedAction.takeUnretainedValue().closure(widget, context)
       }
       return true
     }, destroy: { closureBox, _ in
-      let unpackedAction = Unmanaged<DualParamClosureBox<UnsafeMutablePointer<GtkWidget>?, OpaquePointer, ()>>
+      let unpackedAction = Unmanaged<DualParamClosureBox<UnsafeMutablePointer<GtkWidget>?,
+                                                         OpaquePointer, ()>>
         .fromOpaque(closureBox)
       unpackedAction.release()
     })

--- a/Sources/TokamakGTK/GSignal.swift
+++ b/Sources/TokamakGTK/GSignal.swift
@@ -16,6 +16,7 @@
 //
 
 import CGTK
+import CGDK
 
 extension UnsafeMutablePointer where Pointee == GtkWidget {
   /// Connect with a c function pointer.
@@ -76,6 +77,47 @@ extension UnsafeMutablePointer where Pointee == GtkWidget {
     })
   }
 
+  /// Connect with a c function pointer.
+  @discardableResult
+  func connectA(
+    signal: UnsafePointer<gchar>,
+    data: gpointer? = nil,
+    handler: @convention(c) @escaping (UnsafeMutablePointer<GtkWidget>?, OpaquePointer, UnsafeRawPointer) -> Bool,
+    destroy: @convention(c) @escaping (UnsafeRawPointer, UnsafeRawPointer) -> ()
+  ) -> Int {
+    let handler = unsafeBitCast(handler, to: GCallback.self)
+    let destroy = unsafeBitCast(destroy, to: GClosureNotify.self)
+    return Int(g_signal_connect_data(
+      self,
+      signal,
+      handler,
+      data,
+      destroy,
+      GConnectFlags(rawValue: 0)
+    ))
+  }
+
+  /// Connect with a context-capturing closure (with the GtkWidget passed through)
+  @discardableResult
+  func connect2(
+    signal: UnsafePointer<gchar>,
+    closure: @escaping (UnsafeMutablePointer<GtkWidget>?, OpaquePointer) -> ()
+  ) -> Int {
+    let closureBox = Unmanaged.passRetained(DualParamClosureBox(closure)).retain().toOpaque()
+    return connectA(signal: signal, data: closureBox, handler: { widget, context, closureBox in
+      let unpackedAction = Unmanaged<DualParamClosureBox<UnsafeMutablePointer<GtkWidget>?, OpaquePointer, ()>>
+        .fromOpaque(closureBox)
+      if let widget = widget {
+        unpackedAction.takeUnretainedValue().closure(widget, context)
+      }
+      return true
+    }, destroy: { closureBox, _ in
+      let unpackedAction = Unmanaged<DualParamClosureBox<UnsafeMutablePointer<GtkWidget>?, OpaquePointer, ()>>
+        .fromOpaque(closureBox)
+      unpackedAction.release()
+    })
+  }
+
   func disconnect(
     gtype: GType,
     signal: UnsafePointer<gchar>
@@ -99,4 +141,10 @@ final class SingleParamClosureBox<T, U> {
   let closure: (T) -> U
 
   init(_ closure: @escaping (T) -> U) { self.closure = closure }
+}
+
+final class DualParamClosureBox<T, U, V> {
+  let closure: (T, U) -> V
+
+  init(_ closure: @escaping (T, U) -> V) { self.closure = closure }
 }

--- a/Sources/TokamakGTK/GSignal.swift
+++ b/Sources/TokamakGTK/GSignal.swift
@@ -43,9 +43,11 @@ extension UnsafeMutablePointer where Pointee == GtkWidget {
   func connect(
     signal: UnsafePointer<gchar>,
     data: gpointer? = nil,
-    handler: @convention(c) @escaping (UnsafeMutablePointer<GtkWidget>?,
-                                       OpaquePointer,
-                                       UnsafeRawPointer) -> Bool,
+    handler: @convention(c) @escaping (
+      UnsafeMutablePointer<GtkWidget>?,
+      OpaquePointer,
+      UnsafeRawPointer
+    ) -> Bool,
     destroy: @convention(c) @escaping (UnsafeRawPointer, UnsafeRawPointer) -> ()
   ) -> Int {
     let handler = unsafeBitCast(handler, to: GCallback.self)
@@ -107,16 +109,22 @@ extension UnsafeMutablePointer where Pointee == GtkWidget {
   ) -> Int {
     let closureBox = Unmanaged.passRetained(DualParamClosureBox(closure)).retain().toOpaque()
     return connect(signal: signal, data: closureBox, handler: { widget, context, closureBox in
-      let unpackedAction = Unmanaged<DualParamClosureBox<UnsafeMutablePointer<GtkWidget>?,
-                                                         OpaquePointer, ()>>
+      let unpackedAction = Unmanaged<DualParamClosureBox<
+        UnsafeMutablePointer<GtkWidget>?,
+        OpaquePointer,
+        ()
+      >>
         .fromOpaque(closureBox)
       if let widget = widget {
         unpackedAction.takeUnretainedValue().closure(widget, context)
       }
       return true
     }, destroy: { closureBox, _ in
-      let unpackedAction = Unmanaged<DualParamClosureBox<UnsafeMutablePointer<GtkWidget>?,
-                                                         OpaquePointer, ()>>
+      let unpackedAction = Unmanaged<DualParamClosureBox<
+        UnsafeMutablePointer<GtkWidget>?,
+        OpaquePointer,
+        ()
+      >>
         .fromOpaque(closureBox)
       unpackedAction.release()
     })

--- a/Sources/TokamakGTK/Modifiers/WidgetModifier.swift
+++ b/Sources/TokamakGTK/Modifiers/WidgetModifier.swift
@@ -31,16 +31,20 @@ extension WidgetAttributeModifier {
     let context = gtk_widget_get_style_context(widget)
     let provider = gtk_css_provider_new()
 
-    let renderedStyle = attributes.reduce("", { $0 + "\($1.0):\($1.1);"})
+    let renderedStyle = attributes.reduce("") { $0 + "\($1.0):\($1.1);" }
 
-    gtk_css_provider_load_from_data(provider,
-                                    "* { \(renderedStyle) }",
-                                    -1,
-                                    nil)
+    gtk_css_provider_load_from_data(
+      provider,
+      "* { \(renderedStyle) }",
+      -1,
+      nil
+    )
 
-    gtk_style_context_add_provider(context,
-                                   OpaquePointer(provider),
-                                   1 /* GTK_STYLE_PROVIDER_PRIORITY_FALLBACK */)
+    gtk_style_context_add_provider(
+      context,
+      OpaquePointer(provider),
+      1 /* GTK_STYLE_PROVIDER_PRIORITY_FALLBACK */
+    )
 
     g_object_unref(provider)
   }
@@ -54,8 +58,8 @@ extension ModifiedContent: ViewDeferredToRenderer where Content: View {
     let anyWidget: AnyWidget
     if let anyView = content as? ViewDeferredToRenderer,
        let _anyWidget = mapAnyView(
-        anyView.deferredBody,
-        transform: { (widget: AnyWidget) in widget }
+         anyView.deferredBody,
+         transform: { (widget: AnyWidget) in widget }
        )
     {
       anyWidget = _anyWidget
@@ -71,12 +75,12 @@ extension ModifiedContent: ViewDeferredToRenderer where Content: View {
       return contentWidget
     }
 
-    let update: (Widget) -> Void = { widget in
+    let update: (Widget) -> () = { widget in
       anyWidget.update(widget: widget)
 
       // Is it correct to apply the modifier again after updating?
       // I assume so since the modifier parameters may have changed.
-      if case .widget(let w) = widget.storage {
+      if case let .widget(w) = widget.storage {
         widgetModifier.modify(widget: w)
       }
     }
@@ -95,7 +99,8 @@ extension ModifiedContent: ViewDeferredToRenderer where Content: View {
             ForEach(Array(parentView.children.enumerated()), id: \.offset) { _, view in
               view
             }
-          })
+          }
+        )
       )
     } else if let parentView = anyWidget as? ParentView, parentView.children.count == 1 {
       return AnyView(
@@ -104,7 +109,8 @@ extension ModifiedContent: ViewDeferredToRenderer where Content: View {
           update: update,
           content: {
             parentView.children[0]
-          })
+          }
+        )
       )
     } else {
       return AnyView(
@@ -113,7 +119,8 @@ extension ModifiedContent: ViewDeferredToRenderer where Content: View {
           update: update,
           content: {
             EmptyView()
-          })
+          }
+        )
       )
     }
   }

--- a/Sources/TokamakGTK/Shapes/Shape.swift
+++ b/Sources/TokamakGTK/Shapes/Shape.swift
@@ -30,7 +30,7 @@ extension _ShapeView: ViewDeferredToRenderer {
   }
 
   func bindAction(to drawingArea: UnsafeMutablePointer<GtkWidget>) {
-    drawingArea.connect2(signal: "draw", closure: { widget, cr in
+    drawingArea.connect(signal: "draw", closure: { widget, cr in
       cairo_save(cr)
 
       let width = gtk_widget_get_allocated_width (widget)

--- a/Sources/TokamakGTK/Shapes/Shape.swift
+++ b/Sources/TokamakGTK/Shapes/Shape.swift
@@ -73,7 +73,7 @@ extension _ShapeView: ViewDeferredToRenderer {
       var environment = EnvironmentValues()
       environment[_ColorSchemeKey] = .light
 
-      var color = _ColorProxy(c).resolve(in: environment).cairo
+      var color = c.resolveToCairo(in: environment)
 
       gdk_cairo_set_source_rgba(cr, &color)
 
@@ -159,5 +159,11 @@ extension AnyColorBox.ResolvedValue {
             green: Double(green),
             blue: Double(blue),
             alpha: Double(opacity))
+  }
+}
+
+extension Color {
+  func resolveToCairo(in environment: EnvironmentValues) -> GdkRGBA {
+    _ColorProxy(self).resolve(in: environment).cairo
   }
 }

--- a/Sources/TokamakGTK/Shapes/Shape.swift
+++ b/Sources/TokamakGTK/Shapes/Shape.swift
@@ -64,8 +64,8 @@ extension _ShapeView: ViewDeferredToRenderer {
     drawingArea.connect(signal: "draw", closure: { widget, cr in
       cairo_save(cr)
 
-      let width = gtk_widget_get_allocated_width (widget)
-      let height = gtk_widget_get_allocated_height (widget)
+      let width = gtk_widget_get_allocated_width(widget)
+      let height = gtk_widget_get_allocated_height(widget)
 
       let c = (style as? Color) ?? foregroundColor ?? Color.black
 
@@ -78,10 +78,12 @@ extension _ShapeView: ViewDeferredToRenderer {
                           green: Double(rgba.green),
                           blue: Double(rgba.blue),
                           alpha: Double(rgba.opacity))
-      
-      gdk_cairo_set_source_rgba (cr, &color)
 
-      let path = shape.path(in: CGRect(origin: .zero, size: CGSize(width: Double(width), height: Double(height))))
+      gdk_cairo_set_source_rgba(cr, &color)
+
+      let path = shape.path(in: CGRect(origin: .zero,
+                                       size: CGSize(width: Double(width),
+                                                    height: Double(height))))
       let elements: [Path.Element]
       let stroke: Bool
       if case let .stroked(strokedPath) = path.storage {
@@ -106,8 +108,6 @@ extension _ShapeView: ViewDeferredToRenderer {
         // This is already the default
 //        cairo_set_fill_rule(cr, cairo_fill_rule_t(rawValue: 0) /* CAIRO_FILL_RULE_WINDING */)
       }
-
-//      dump(elements)
 
       createPath(from: elements, in: cr)
 

--- a/Sources/TokamakGTK/Shapes/Shape.swift
+++ b/Sources/TokamakGTK/Shapes/Shape.swift
@@ -1,6 +1,16 @@
+// Copyright 2020 Tokamak contributors
 //
-//  File.swift
-//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Morten Bek Ditlevsen on 29/12/2020.
 //

--- a/Sources/TokamakGTK/Shapes/Shape.swift
+++ b/Sources/TokamakGTK/Shapes/Shape.swift
@@ -1,0 +1,233 @@
+//
+//  File.swift
+//  
+//
+//  Created by Morten Bek Ditlevsen on 29/12/2020.
+//
+
+import CGTK
+import CGDK
+import TokamakCore
+
+protocol ShapeAttributes {
+}
+
+extension _StrokedShape: ShapeAttributes {
+}
+
+//extension _ShapeView: ViewDeferredToRenderer {
+//  public var deferredBody: AnyView {
+//    let path = shape.path(in: .zero).deferredBody
+//    if let shapeAttributes = shape as? ShapeAttributes {
+//      return AnyView(HTML("div", shapeAttributes.attributes(style)) { path })
+//    } else if let color = style as? Color {
+//      return AnyView(HTML("div", [
+//        "style": "fill: \(color.cssValue(environment));",
+//      ]) { path })
+//    } else if let foregroundColor = foregroundColor {
+//      return AnyView(HTML("div", [
+//        "style": "fill: \(foregroundColor.cssValue(environment));",
+//      ]) { path })
+//    } else {
+//      return path
+//    }
+//  }
+//}
+
+extension _ShapeView: ViewDeferredToRenderer {
+  public var deferredBody: AnyView {
+    dump(self.environment)
+
+    return AnyView(WidgetView(build: { _ in
+      let w = gtk_drawing_area_new()
+      bindAction(to: w!)
+      return w!
+    }) {
+    })
+  }
+
+  func bindAction(to drawingArea: UnsafeMutablePointer<GtkWidget>) {
+    drawingArea.connect2(signal: "draw", closure: { widget, cr in
+//      dump(widget)
+//      dump(cr)
+
+      let width = gtk_widget_get_allocated_width (widget)
+      let height = gtk_widget_get_allocated_height (widget)
+//      print("W", width, "H", height)
+
+      let c = (style as? Color) ?? foregroundColor ?? Color.black
+//      dump(c)
+
+      // XXX TODO, don't know why my environment doesn't work.
+      var environment = EnvironmentValues()
+      environment[_ColorSchemeKey] = .light
+
+      dump(environment)
+      let rgba = _ColorProxy(c).resolve(in: environment)
+      dump(rgba)
+
+      var color = GdkRGBA(red: Double(rgba.red),
+                          green: Double(rgba.green),
+                          blue: Double(rgba.blue),
+                          alpha: Double(rgba.opacity))
+      
+      gdk_cairo_set_source_rgba (cr, &color)
+
+      let path = shape.path(in: CGRect(origin: .zero, size: CGSize(width: Double(width), height: Double(height))))
+//      let transform = CGAffineTransform(scaleX: Double(width), y: Double(height))
+      let elements: [Path.Element]
+      let stroke: Bool
+      if case let .stroked(strokedPath) = path.storage {
+        elements = strokedPath.path.elements
+        stroke = true
+        let style = strokedPath.style
+
+        cairo_set_line_width(cr, style.lineWidth)
+        cairo_set_line_join(cr, style.lineJoin.cairo)
+        cairo_set_line_cap(cr, style.lineCap.cairo)
+        cairo_set_miter_limit(cr, style.miterLimit)
+        cairo_set_dash(cr, style.dash, Int32(style.dash.count), style.dashPhase)
+
+      } else {
+        elements = path.elements
+        stroke = false
+      }
+
+      if fillStyle.isEOFilled {
+        cairo_set_fill_rule(cr, cairo_fill_rule_t(rawValue: 1) /* CAIRO_FILL_RULE_EVEN_ODD */)
+      } else {
+        // This is already the default
+//        cairo_set_fill_rule(cr, cairo_fill_rule_t(rawValue: 0) /* CAIRO_FILL_RULE_WINDING */)
+      }
+
+      dump(elements)
+
+      var current: CGPoint = .zero
+      var start: CGPoint = .zero
+      for element in elements {
+        switch element {
+        case let .move(to: p):
+          cairo_move_to(cr, p.x, p.y)
+          current = p
+          start = p
+
+        case let .line(to: p):
+          cairo_line_to(cr, p.x, p.y)
+          current = p
+
+        case .closeSubpath:
+          cairo_close_path(cr)
+          current = start
+
+        case let .curve(to: p, control1: c1, control2: c2):
+          cairo_curve_to(cr, c1.x, c1.y, c2.x, c2.y, p.x, p.y)
+          current = p
+
+        case let .quadCurve(to: p, control: c):
+          let c1 = CGPoint(x: (current.x + 2 * c.x) / 3, y: (current.y + 2 * c.y) / 3)
+          let c2 = CGPoint(x: (p.x + 2 * c.x) / 3, y: (p.y + 2 * c.y) / 3)
+          cairo_curve_to(cr, c1.x, c1.y, c2.x, c2.y, p.x, p.y)
+          current = p
+        }
+      }
+
+//      switch (path.storage) {
+//      case .rect(let rect):
+//        cairo_rectangle(cr, rect.origin.x, rect.origin.y, rect.size.width, rect.size.height)
+//      case .ellipse(let rect):
+//        guard rect.size.width > 0, rect.size.height > 0 else { return }
+//        let size = min(rect.size.width, rect.size.height)
+//        var xScale: Double = 1
+//        var yScale: Double = 1
+//        if rect.size.width < rect.size.height {
+//          yScale = rect.size.height / rect.size.width
+//        } else if rect.size.height < rect.size.width {
+//          xScale = rect.size.width / rect.size.height
+//        }
+//        cairo_scale(cr, xScale, yScale)
+//        cairo_arc(cr, rect.size.width / (2 * xScale), rect.size.height / (2 * yScale), size / 2, 0, 2 * Double.pi)
+//
+//      case .empty:
+//        return
+//
+//      case .roundedRect(let rect):
+////        dump(rect)
+//        // TODO: Respect style
+//        // TODO: Respect cornerSize instead of just a single radius. SwiftUI appears to draw 'skewed' arcs...
+//
+//        let radius = rect.cornerSize?.width ?? 10
+//        let degrees = Double.pi / 180
+//        let x = rect.rect.origin.x
+//        let y = rect.rect.origin.y
+//        let width = rect.rect.size.width
+//        let height = rect.rect.size.height
+//
+//        cairo_new_sub_path (cr)
+//        cairo_arc (cr, x + width - radius, y + radius, radius, -90 * degrees, 0 * degrees)
+//        cairo_arc (cr, x + width - radius, y + height - radius, radius, 0 * degrees, 90 * degrees)
+//        cairo_arc (cr, x + radius, y + height - radius, radius, 90 * degrees, 180 * degrees)
+//        cairo_arc (cr, x + radius, y + radius, radius, 180 * degrees, 270 * degrees)
+//        cairo_close_path (cr)
+//
+//
+//      case .path(let box):
+//
+//
+//      default:
+//
+//        fatalError("Not implemented")
+//      }
+
+      if stroke {
+        cairo_stroke(cr)
+      } else {
+        cairo_fill(cr)
+      }
+//      dump(self)
+//      let sko = shape.path(in: .zero)
+//      dump(width)
+//
+//      let lineWidth: Double = 0.5
+//
+//      cairo_set_line_width (cr,
+//                            lineWidth)
+//
+//      cairo_rectangle(cr, lineWidth / 2, lineWidth / 2, Double(width) - lineWidth, Double(height) - lineWidth)
+////      cairo_arc (cr,
+////                 20, 20,
+////                 20,
+////                 0, 2 * Double.pi);
+//
+//      cairo_stroke(cr)
+
+
+
+    })
+  }
+}
+
+extension CGLineJoin {
+  var cairo: cairo_line_join_t {
+    switch self {
+    case .miter:
+      return cairo_line_join_t(rawValue: 0)
+    case .round:
+      return cairo_line_join_t(rawValue: 1)
+    case .bevel:
+      return cairo_line_join_t(rawValue: 2)
+    }
+  }
+}
+
+extension CGLineCap {
+  var cairo: cairo_line_cap_t {
+    switch self {
+    case .butt:
+      return cairo_line_cap_t(rawValue: 0)
+    case .round:
+      return cairo_line_cap_t(rawValue: 1)
+    case .square:
+      return cairo_line_cap_t(rawValue: 2)
+    }
+  }
+}

--- a/Sources/TokamakGTK/Shapes/Shape.swift
+++ b/Sources/TokamakGTK/Shapes/Shape.swift
@@ -102,12 +102,7 @@ extension _ShapeView: ViewDeferredToRenderer {
         stroke = false
       }
 
-      if fillStyle.isEOFilled {
-        cairo_set_fill_rule(cr, cairo_fill_rule_t(rawValue: 1) /* CAIRO_FILL_RULE_EVEN_ODD */)
-      } else {
-        // This is already the default
-//        cairo_set_fill_rule(cr, cairo_fill_rule_t(rawValue: 0) /* CAIRO_FILL_RULE_WINDING */)
-      }
+      cairo_set_fill_rule(cr, fillStyle.cairo)
 
       createPath(from: elements, in: cr)
 
@@ -130,11 +125,11 @@ extension CGLineJoin {
   var cairo: cairo_line_join_t {
     switch self {
     case .miter:
-      return cairo_line_join_t(rawValue: 0)
+      return cairo_line_join_t(rawValue: 0) /* CAIRO_LINE_JOIN_MITER */
     case .round:
-      return cairo_line_join_t(rawValue: 1)
+      return cairo_line_join_t(rawValue: 1) /* CAIRO_LINE_JOIN_ROUND */
     case .bevel:
-      return cairo_line_join_t(rawValue: 2)
+      return cairo_line_join_t(rawValue: 2) /* CAIRO_LINE_JOIN_BEVEL */
     }
   }
 }
@@ -143,11 +138,21 @@ extension CGLineCap {
   var cairo: cairo_line_cap_t {
     switch self {
     case .butt:
-      return cairo_line_cap_t(rawValue: 0)
+      return cairo_line_cap_t(rawValue: 0) /* CAIRO_LINE_CAP_BUTT */
     case .round:
-      return cairo_line_cap_t(rawValue: 1)
+      return cairo_line_cap_t(rawValue: 1) /* CAIRO_LINE_CAP_ROUND */
     case .square:
-      return cairo_line_cap_t(rawValue: 2)
+      return cairo_line_cap_t(rawValue: 2) /* CAIRO_LINE_CAP_SQUARE */
+    }
+  }
+}
+
+extension FillStyle {
+  var cairo: cairo_fill_rule_t {
+    if isEOFilled {
+      return cairo_fill_rule_t(rawValue: 1) /* CAIRO_FILL_RULE_EVEN_ODD */
+    } else {
+      return cairo_fill_rule_t(rawValue: 0) /* CAIRO_FILL_RULE_WINDING */
     }
   }
 }

--- a/Sources/TokamakGTK/Shapes/Shape.swift
+++ b/Sources/TokamakGTK/Shapes/Shape.swift
@@ -9,31 +9,6 @@ import CGTK
 import CGDK
 import TokamakCore
 
-protocol ShapeAttributes {
-}
-
-extension _StrokedShape: ShapeAttributes {
-}
-
-//extension _ShapeView: ViewDeferredToRenderer {
-//  public var deferredBody: AnyView {
-//    let path = shape.path(in: .zero).deferredBody
-//    if let shapeAttributes = shape as? ShapeAttributes {
-//      return AnyView(HTML("div", shapeAttributes.attributes(style)) { path })
-//    } else if let color = style as? Color {
-//      return AnyView(HTML("div", [
-//        "style": "fill: \(color.cssValue(environment));",
-//      ]) { path })
-//    } else if let foregroundColor = foregroundColor {
-//      return AnyView(HTML("div", [
-//        "style": "fill: \(foregroundColor.cssValue(environment));",
-//      ]) { path })
-//    } else {
-//      return path
-//    }
-//  }
-//}
-
 extension _ShapeView: ViewDeferredToRenderer {
   public var deferredBody: AnyView {
     dump(self.environment)
@@ -48,24 +23,17 @@ extension _ShapeView: ViewDeferredToRenderer {
 
   func bindAction(to drawingArea: UnsafeMutablePointer<GtkWidget>) {
     drawingArea.connect2(signal: "draw", closure: { widget, cr in
-//      dump(widget)
-//      dump(cr)
 
       let width = gtk_widget_get_allocated_width (widget)
       let height = gtk_widget_get_allocated_height (widget)
-//      print("W", width, "H", height)
 
       let c = (style as? Color) ?? foregroundColor ?? Color.black
-//      dump(c)
 
       // XXX TODO, don't know why my environment doesn't work.
       var environment = EnvironmentValues()
       environment[_ColorSchemeKey] = .light
 
-      dump(environment)
       let rgba = _ColorProxy(c).resolve(in: environment)
-      dump(rgba)
-
       var color = GdkRGBA(red: Double(rgba.red),
                           green: Double(rgba.green),
                           blue: Double(rgba.blue),
@@ -74,7 +42,6 @@ extension _ShapeView: ViewDeferredToRenderer {
       gdk_cairo_set_source_rgba (cr, &color)
 
       let path = shape.path(in: CGRect(origin: .zero, size: CGSize(width: Double(width), height: Double(height))))
-//      let transform = CGAffineTransform(scaleX: Double(width), y: Double(height))
       let elements: [Path.Element]
       let stroke: Bool
       if case let .stroked(strokedPath) = path.storage {
@@ -131,77 +98,11 @@ extension _ShapeView: ViewDeferredToRenderer {
         }
       }
 
-//      switch (path.storage) {
-//      case .rect(let rect):
-//        cairo_rectangle(cr, rect.origin.x, rect.origin.y, rect.size.width, rect.size.height)
-//      case .ellipse(let rect):
-//        guard rect.size.width > 0, rect.size.height > 0 else { return }
-//        let size = min(rect.size.width, rect.size.height)
-//        var xScale: Double = 1
-//        var yScale: Double = 1
-//        if rect.size.width < rect.size.height {
-//          yScale = rect.size.height / rect.size.width
-//        } else if rect.size.height < rect.size.width {
-//          xScale = rect.size.width / rect.size.height
-//        }
-//        cairo_scale(cr, xScale, yScale)
-//        cairo_arc(cr, rect.size.width / (2 * xScale), rect.size.height / (2 * yScale), size / 2, 0, 2 * Double.pi)
-//
-//      case .empty:
-//        return
-//
-//      case .roundedRect(let rect):
-////        dump(rect)
-//        // TODO: Respect style
-//        // TODO: Respect cornerSize instead of just a single radius. SwiftUI appears to draw 'skewed' arcs...
-//
-//        let radius = rect.cornerSize?.width ?? 10
-//        let degrees = Double.pi / 180
-//        let x = rect.rect.origin.x
-//        let y = rect.rect.origin.y
-//        let width = rect.rect.size.width
-//        let height = rect.rect.size.height
-//
-//        cairo_new_sub_path (cr)
-//        cairo_arc (cr, x + width - radius, y + radius, radius, -90 * degrees, 0 * degrees)
-//        cairo_arc (cr, x + width - radius, y + height - radius, radius, 0 * degrees, 90 * degrees)
-//        cairo_arc (cr, x + radius, y + height - radius, radius, 90 * degrees, 180 * degrees)
-//        cairo_arc (cr, x + radius, y + radius, radius, 180 * degrees, 270 * degrees)
-//        cairo_close_path (cr)
-//
-//
-//      case .path(let box):
-//
-//
-//      default:
-//
-//        fatalError("Not implemented")
-//      }
-
       if stroke {
         cairo_stroke(cr)
       } else {
         cairo_fill(cr)
       }
-//      dump(self)
-//      let sko = shape.path(in: .zero)
-//      dump(width)
-//
-//      let lineWidth: Double = 0.5
-//
-//      cairo_set_line_width (cr,
-//                            lineWidth)
-//
-//      cairo_rectangle(cr, lineWidth / 2, lineWidth / 2, Double(width) - lineWidth, Double(height) - lineWidth)
-////      cairo_arc (cr,
-////                 20, 20,
-////                 20,
-////                 0, 2 * Double.pi);
-//
-//      cairo_stroke(cr)
-
-
-
     })
   }
 }

--- a/Sources/TokamakGTK/Shapes/Shape.swift
+++ b/Sources/TokamakGTK/Shapes/Shape.swift
@@ -15,8 +15,8 @@
 //  Created by Morten Bek Ditlevsen on 29/12/2020.
 //
 
-import CGTK
 import CGDK
+import CGTK
 import TokamakCore
 
 func createPath(from elements: [Path.Element], in cr: OpaquePointer) {
@@ -52,12 +52,11 @@ func createPath(from elements: [Path.Element], in cr: OpaquePointer) {
 
 extension _ShapeView: ViewDeferredToRenderer {
   public var deferredBody: AnyView {
-    return AnyView(WidgetView(build: { _ in
+    AnyView(WidgetView(build: { _ in
       let w = gtk_drawing_area_new()
       bindAction(to: w!)
       return w!
-    }) {
-    })
+    }) {})
   }
 
   func bindAction(to drawingArea: UnsafeMutablePointer<GtkWidget>) {
@@ -73,9 +72,13 @@ extension _ShapeView: ViewDeferredToRenderer {
 
       gdk_cairo_set_source_rgba(cr, &color)
 
-      let path = shape.path(in: CGRect(origin: .zero,
-                                       size: CGSize(width: Double(width),
-                                                    height: Double(height))))
+      let path = shape.path(in: CGRect(
+        origin: .zero,
+        size: CGSize(
+          width: Double(width),
+          height: Double(height)
+        )
+      ))
       let elements: [Path.Element]
       let stroke: Bool
       if case let .stroked(strokedPath) = path.storage {
@@ -151,10 +154,12 @@ extension FillStyle {
 
 extension AnyColorBox.ResolvedValue {
   var cairo: GdkRGBA {
-    GdkRGBA(red: Double(red),
-            green: Double(green),
-            blue: Double(blue),
-            alpha: Double(opacity))
+    GdkRGBA(
+      red: Double(red),
+      green: Double(green),
+      blue: Double(blue),
+      alpha: Double(opacity)
+    )
   }
 }
 

--- a/Sources/TokamakGTK/Shapes/Shape.swift
+++ b/Sources/TokamakGTK/Shapes/Shape.swift
@@ -21,8 +21,6 @@ import TokamakCore
 
 extension _ShapeView: ViewDeferredToRenderer {
   public var deferredBody: AnyView {
-    dump(self.environment)
-
     return AnyView(WidgetView(build: { _ in
       let w = gtk_drawing_area_new()
       bindAction(to: w!)

--- a/Sources/TokamakGTK/Shapes/Shape.swift
+++ b/Sources/TokamakGTK/Shapes/Shape.swift
@@ -73,11 +73,7 @@ extension _ShapeView: ViewDeferredToRenderer {
       var environment = EnvironmentValues()
       environment[_ColorSchemeKey] = .light
 
-      let rgba = _ColorProxy(c).resolve(in: environment)
-      var color = GdkRGBA(red: Double(rgba.red),
-                          green: Double(rgba.green),
-                          blue: Double(rgba.blue),
-                          alpha: Double(rgba.opacity))
+      var color = _ColorProxy(c).resolve(in: environment).cairo
 
       gdk_cairo_set_source_rgba(cr, &color)
 
@@ -154,5 +150,14 @@ extension FillStyle {
     } else {
       return cairo_fill_rule_t(rawValue: 0) /* CAIRO_FILL_RULE_WINDING */
     }
+  }
+}
+
+extension AnyColorBox.ResolvedValue {
+  var cairo: GdkRGBA {
+    GdkRGBA(red: Double(red),
+            green: Double(green),
+            blue: Double(blue),
+            alpha: Double(opacity))
   }
 }

--- a/Sources/TokamakGTK/Shapes/Shape.swift
+++ b/Sources/TokamakGTK/Shapes/Shape.swift
@@ -23,6 +23,7 @@ extension _ShapeView: ViewDeferredToRenderer {
 
   func bindAction(to drawingArea: UnsafeMutablePointer<GtkWidget>) {
     drawingArea.connect2(signal: "draw", closure: { widget, cr in
+      cairo_save(cr)
 
       let width = gtk_widget_get_allocated_width (widget)
       let height = gtk_widget_get_allocated_height (widget)
@@ -67,7 +68,7 @@ extension _ShapeView: ViewDeferredToRenderer {
 //        cairo_set_fill_rule(cr, cairo_fill_rule_t(rawValue: 0) /* CAIRO_FILL_RULE_WINDING */)
       }
 
-      dump(elements)
+//      dump(elements)
 
       var current: CGPoint = .zero
       var start: CGPoint = .zero
@@ -98,11 +99,17 @@ extension _ShapeView: ViewDeferredToRenderer {
         }
       }
 
+      // It kind of appears to be ok to reset the clip (in order to draw outside the frame)...
+      // This could be error prone, however, and a source of future bugs...
+      cairo_reset_clip(cr)
+
       if stroke {
         cairo_stroke(cr)
       } else {
         cairo_fill(cr)
       }
+
+      cairo_restore(cr)
     })
   }
 }

--- a/Sources/TokamakGTK/Shapes/Shape.swift
+++ b/Sources/TokamakGTK/Shapes/Shape.swift
@@ -69,10 +69,6 @@ extension _ShapeView: ViewDeferredToRenderer {
 
       let c = (style as? Color) ?? foregroundColor ?? Color.black
 
-      // XXX TODO, don't know why my environment doesn't work.
-      var environment = EnvironmentValues()
-      environment[_ColorSchemeKey] = .light
-
       var color = c.resolveToCairo(in: environment)
 
       gdk_cairo_set_source_rgba(cr, &color)

--- a/Sources/TokamakGTK/Views/File.swift
+++ b/Sources/TokamakGTK/Views/File.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Morten Bek Ditlevsen on 27/12/2020.
+//
+
+import Foundation

--- a/Sources/TokamakStaticHTML/Shapes/Path.swift
+++ b/Sources/TokamakStaticHTML/Shapes/Path.swift
@@ -119,45 +119,7 @@ extension Path: ViewDeferredToRenderer {
     ]))
   }
 
-  var storageSize: CGSize {
-    switch storage {
-    case .empty:
-      return .zero
-    case let .rect(rect), let .ellipse(rect):
-      return rect.size
-    case let .roundedRect(rect):
-      return rect.rect.size
-    case let .stroked(path):
-      return path.path.size
-    case let .trimmed(path):
-      return path.path.size
-    case let .path(pathBox):
-      return elementsSize
-    }
-  }
-
-  var elementsSize: CGSize {
-    // Curves may clip without an explicit size
-    let positions = elements.compactMap { elem -> CGPoint? in
-      switch elem {
-      case let .move(to: pos): return pos
-      case let .line(to: pos): return pos
-      case let .curve(to: pos, control1: _, control2: _): return pos
-      case let .quadCurve(to: pos, control: _): return pos
-      case .closeSubpath: return nil
-      }
-    }
-    let xPos = positions.map(\.x).sorted(by: <)
-    let minX = xPos.first ?? 0
-    let maxX = xPos.last ?? 0
-    let yPos = positions.map(\.y).sorted(by: <)
-    let minY = yPos.first ?? 0
-    let maxY = yPos.last ?? 0
-
-    return CGSize(width: abs(maxX - min(0, minX)), height: abs(maxY - min(0, minY)))
-  }
-
-  var size: CGSize { storageSize }
+  var size: CGSize { boundingRect.size }
 
   @ViewBuilder
   func svgBody(

--- a/Sources/TokamakStaticHTML/Shapes/Path.swift
+++ b/Sources/TokamakStaticHTML/Shapes/Path.swift
@@ -88,8 +88,8 @@ extension Path: ViewDeferredToRenderer {
         storage: trimmed.path.storage,
         strokeStyle: strokeStyle
       ) // TODO: Trim the path
-    case let .path(pathBox):
-      return svgFrom(elements: pathBox.elements, strokeStyle: strokeStyle)
+    case .path:
+      return svgFrom(elements: elements, strokeStyle: strokeStyle)
     }
   }
 

--- a/Sources/TokamakStaticHTML/Shapes/Path.swift
+++ b/Sources/TokamakStaticHTML/Shapes/Path.swift
@@ -88,6 +88,8 @@ extension Path: ViewDeferredToRenderer {
         storage: trimmed.path.storage,
         strokeStyle: strokeStyle
       ) // TODO: Trim the path
+    case let .path(pathBox):
+      return svgFrom(elements: pathBox.elements, strokeStyle: strokeStyle)
     }
   }
 
@@ -117,15 +119,6 @@ extension Path: ViewDeferredToRenderer {
     ]))
   }
 
-  func svgFrom(
-    subpaths: [_SubPath],
-    strokeStyle: StrokeStyle = .zero
-  ) -> AnyView {
-    AnyView(ForEach(Array(subpaths.enumerated()), id: \.offset) { _, path in
-      path.path.svgBody(strokeStyle: strokeStyle)
-    })
-  }
-
   var storageSize: CGSize {
     switch storage {
     case .empty:
@@ -138,6 +131,8 @@ extension Path: ViewDeferredToRenderer {
       return path.path.size
     case let .trimmed(path):
       return path.path.size
+    case let .path(pathBox):
+      return elementsSize
     }
   }
 
@@ -162,20 +157,13 @@ extension Path: ViewDeferredToRenderer {
     return CGSize(width: abs(maxX - min(0, minX)), height: abs(maxY - min(0, minY)))
   }
 
-  var size: CGSize {
-    .init(
-      width: max(storageSize.width, elementsSize.width),
-      height: max(storageSize.height, elementsSize.height)
-    )
-  }
+  var size: CGSize { storageSize }
 
   @ViewBuilder
   func svgBody(
     strokeStyle: StrokeStyle = .zero
   ) -> some View {
     svgFrom(storage: storage, strokeStyle: strokeStyle)
-    svgFrom(elements: elements, strokeStyle: strokeStyle)
-    svgFrom(subpaths: subpaths, strokeStyle: strokeStyle)
   }
 
   public var deferredBody: AnyView {


### PR DESCRIPTION
SECOND UPDATE:

* The empty environment issue is the same as #322, so I removed the workaround and added a comment to that issue.

The final thing on my todo for this PR is to test the `Path` size changes in `TokamakStaticHTML`.

UPDATE:

I marked the PR as ready for review.
There are a few issues that I am uncertain of:
* I am getting an empty environment in the `_ShapeView`, so I have hacked around that for now, which is of course not very good.
* Are the `GSignal` changes sound? Do we just keep adding overloads of `connect` for each new signal handler shape?
* Is my solution of removing `_SubPath` acceptable? (I think it makes sense).
* Is my `CGDK` systemPackage definition ok? It appears to do the trick (on macOS at least).
* I have only made brief tests on TokamakStaticHTML, but I could add an ellipse to a path and rotate it a bit (and in this case it is turned into a .path() Storage) - and this drew nicely, so something is working.

I hope to get time to install virtualbox and play around with everything on Ubuntu too.

---

Adding support for `Shape` in GTK using `gtk_drawing_area`.

Modified `Path.swift` from TokamakCore to support a few more path modifications.
I also had to remove the `_SubPath` type in the process since I could not find a way for this to work together with path modification.
The code proposed in this PR behaves (as far as I can tell) like SwiftUI in the following respects:
Adding path elements to an existing path will convert the storage to be the generic `.path` case.
Adding path storage building blocks to an empty path just sets the storage.
For instance:
adding a rectangle to an empty path will result in a path with .rectangle storage.

The current implementation of `PathBox` is just a class containing an array of `Element`... I wonder what the intention of the type is in SwiftUI - I'd expect that a `CGPath` or an array of `Element` directly as the associated value would suffice.

Still lacking is:
.trimmed and .stroked are incomplete.
In SwiftUI it's possible to get the stroked path and the trimmed path (in fact it appears that the `.description` returns a description of the 'rendered' path).
Adding stroking and trimming is very, very hard. Stroking requires the possibility of offsetting a quadratic and cubic curve, which there is not a single correct way to do.
Trimming requires measuring the length of curves, which also turns out to be difficult (but can be done by approximating a curve with line segments) as well as splitting curves.

So basically the implementation requires a lot of what is already built in to `CGPath`.
I guess that it can be added eventually by getting inspiration from something like Cairo or other open source drawing APIs.

Since the current 'backends' can stroke paths, that part isn't a huge issue, but stroking a path twice would require the functionality.

Another issue with the current implementation is that in SwiftUI, a Shape can draw outside of the frame of the shape, but that is not currently possible with the gtk version.
UPDATE: a shape can now draw out of bounds - implemented by resetting the clipping area of the widget in the drawing routine. This could probably mess up some graphics updates. I will look for a better solution once I get started on mimicking SwiftUI view sizing and layout.