### PR TITLE
Add a "bug report" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: MaxDesiatov
+
+---
+
+Replace the placeholders below with details that help us to reproduce the bug.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+If this is a layout/rendering issue, please provide a self-contained code snippet that reproduces it.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If this is a layout/rendering issue, please provide screenshots for both Tokamak and SwiftUI that highlight the difference.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. macOS]
+ - Browser [e.g. chrome, safari]
+ - Version of the browser [e.g. 22]
+ - Version of Tokamak [e.g. 0.6.1]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version of the browser [e.g. 22]
+ - Version of Tokamak [e.g. 0.6.1]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: MaxDesiatov
 
 ---
 
-Replace the placeholders below with details that help us to reproduce the bug.
+<!-- Replace the placeholders below with details that help us to reproduce the bug. -->
 
 **Describe the bug**
 A clear and concise description of what the bug is.
@@ -19,7 +19,7 @@ Steps to reproduce the behavior:
 3. Scroll down to '....'
 4. See error
 
-If this is a layout/rendering issue, please provide a self-contained code snippet that reproduces it.
+<!-- If this is a layout/rendering issue, please provide a self-contained code snippet that reproduces it. -->
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.


### PR DESCRIPTION
We currently receive bug reports that don't always provide a self-contained code sample or screenshots to help us reproduce issues quickly or to add test cases. I hope that this issue template alleviates that.