### PR TITLE
Fixed a small issue with re-renderers being dropped

### DIFF
--- a/Sources/TokamakCore/StackReconciler.swift
+++ b/Sources/TokamakCore/StackReconciler.swift
@@ -123,11 +123,13 @@ public final class StackReconciler<R: Renderer> {
   }
 
   private func updateStateAndReconcile() {
-    for mountedView in queuedRerenders {
+    let queued = queuedRerenders
+    queuedRerenders.removeAll()
+    
+    for mountedView in queued {
       mountedView.update(with: self)
     }
 
-    queuedRerenders.removeAll()
     performPostrenderCallbacks()
   }
 


### PR DESCRIPTION
The code was clearing the queuedRerenders set after processing all of the updates on each re-renderer.  However, during processing it is possible that new values were enqueued.  By clearing the set afterwards, these newly queued re-renderers were accidentally dropped.

This would cause some Views to not update when @State was changed.