### PR TITLE
Removed an extra space that cause Safari to issue "Invalid value"

### DIFF
--- a/Sources/TokamakStaticHTML/Shapes/Path.swift
+++ b/Sources/TokamakStaticHTML/Shapes/Path.swift
@@ -62,7 +62,7 @@ extension Path: ViewDeferredToRenderer {
         if let cornerSize = roundedRect.cornerSize {
           return [
             "rx": "\(cornerSize.width)",
-            "ry": " \(roundedRect.style == .continuous ? cornerSize.width : cornerSize.height)",
+            "ry": "\(roundedRect.style == .continuous ? cornerSize.width : cornerSize.height)",
           ]
         } else {
           // For this to support vertical capsules, we need


### PR DESCRIPTION
An extra space was added at the beginning of the 'ry' attribute value of a rect.  Safari reported: Error: Invalid value for <rect> attribute ry=" 25.0".