### PR TITLE
Use `macos-latest` agent for the GTK build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
             xcpretty --color
 
   gtk_macos_build:
-    runs-on: macos-11.0
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
`macos-latest` still points to macOS 10.15 right now, which has more agent's capacity, and macOS 11.0 agents are slow and unreliable. At the same time, we have to keep using macOS 11.0 for the core build to have access to the new `App` lifecycle in the native demo project.