### PR TITLE
Added TextField support for GTK using GtkEntry

### DIFF
--- a/Sources/TokamakGTK/Views/TextField.swift
+++ b/Sources/TokamakGTK/Views/TextField.swift
@@ -1,0 +1,83 @@
+//
+//  File.swift
+//
+//
+//  Created by Morten Bek Ditlevsen on 27/12/2020.
+//
+
+import CGTK
+import Foundation
+import TokamakCore
+
+extension TextField: ViewDeferredToRenderer where Label == Text {
+  public var deferredBody: AnyView {
+    AnyView(WidgetView(build: { _ in
+      let proxy = _TextFieldProxy(self)
+      let entry = gtk_entry_new()!
+      entry.withMemoryRebound(to: GtkEntry.self, capacity: 1) {
+        gtk_entry_set_text($0, _TextFieldProxy(self).textBinding.wrappedValue)
+      }
+      return entry
+    }, update: { _ in
+
+    }) {})
+  }
+
+//  func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget> {
+//    let proxy = _TextFieldProxy(self)
+//    let entry = gtk_entry_new()!
+//    entry.withMemoryRebound(to: GtkEntry.self, capacity: 1) {
+//      gtk_entry_set_text($0, _TextFieldProxy(self).textBinding.wrappedValue)
+//    }
+//    return entry
+//  }
+//
+//  func update(widget: Widget) {
+//    if case let .widget(w) = widget.storage {
+//      w.withMemoryRebound(to: GtkEntry.self, capacity: 1) {
+//        gtk_entry_set_text($0, _TextFieldProxy(self).textBinding.wrappedValue)
+//      }
+//    }
+//  }
+
+//  func css(for style: TextFieldStyle) -> String {
+//    if style is PlainTextFieldStyle {
+//      return """
+//      background: transparent;
+//      border: none;
+//      """
+//    } else {
+//      return ""
+//    }
+//  }
+//
+//  func className(for style: TextFieldStyle) -> String {
+//    switch style {
+//    case is DefaultTextFieldStyle, is RoundedBorderTextFieldStyle:
+//      return "_tokamak-formcontrol"
+//    default:
+//      return ""
+//    }
+//  }
+
+//  public var deferredBody: AnyView {
+//    let proxy = _TextFieldProxy(self)
+//
+//    return AnyView(DynamicHTML("input", [
+//      "type": proxy.textFieldStyle is RoundedBorderTextFieldStyle ? "search" : "text",
+//      .value: proxy.textBinding.wrappedValue,
+//      "placeholder": proxy.label.rawText,
+//      "style": css(for: proxy.textFieldStyle),
+//      "class": className(for: proxy.textFieldStyle),
+//    ], listeners: [
+//      "focus": { _ in proxy.onEditingChanged(true) },
+//      "blur": { _ in proxy.onEditingChanged(false) },
+//      "keypress": { event in if event.key == "Enter" { proxy.onCommit() } },
+//      "input": { event in
+//        if let newValue = event.target.object?.value.string {
+//          proxy.textBinding.wrappedValue = newValue
+//        }
+//      },
+//    ]))
+//  }
+}


### PR DESCRIPTION
Note, that in the 'update' block I do not disconnect and reconnect the signal as it is done in the gtk `Button` implementation.
I am a bit uncertain whether or not that is actually needed in some special case.
If it's not needed, perhaps it can be removed from the `Button` implementation too.