### PR TITLE
Fix crashes in views with optional content

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,7 @@
     {
       "label": "swift test",
       "type": "shell",
-      "command": "swift test"
+      "command": "swift build --product TokamakPackageTests && `xcrun --find xctest` .build/debug/TokamakPackageTests.xctest"
     },
     {
       "label": "carton dev",

--- a/Package.swift
+++ b/Package.swift
@@ -154,5 +154,9 @@ let package = Package(
       name: "TokamakTests",
       dependencies: ["TokamakTestRenderer"]
     ),
+    .testTarget(
+      name: "TokamakStaticHTMLTests",
+      dependencies: ["TokamakStaticHTML"]
+    ),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -154,9 +154,14 @@ let package = Package(
       name: "TokamakTests",
       dependencies: ["TokamakTestRenderer"]
     ),
-    .testTarget(
-      name: "TokamakStaticHTMLTests",
-      dependencies: ["TokamakStaticHTML"]
-    ),
+    // FIXME: re-enable when `ViewDeferredToRenderer` conformance conflicts issue is resolved
+    // Currently, when multiple modules that have conflicting `ViewDeferredToRenderer`
+    // implementations are linked in the same binary, only a single one is used with no defined
+    // behavior for that. We need to replace `ViewDeferredToRenderer` with a different solution
+    // that isn't prone to these hard to debug errors.
+    // .testTarget(
+    //   name: "TokamakStaticHTMLTests",
+    //   dependencies: ["TokamakStaticHTML"]
+    // ),
   ]
 )

--- a/Sources/TokamakCore/StackReconciler.swift
+++ b/Sources/TokamakCore/StackReconciler.swift
@@ -125,7 +125,7 @@ public final class StackReconciler<R: Renderer> {
   private func updateStateAndReconcile() {
     let queued = queuedRerenders
     queuedRerenders.removeAll()
-    
+
     for mountedView in queued {
       mountedView.update(with: self)
     }

--- a/Sources/TokamakCore/Views/AnyView.swift
+++ b/Sources/TokamakCore/Views/AnyView.swift
@@ -59,8 +59,16 @@ public struct AnyView: View {
       bodyType = V.Body.self
       self.view = view
       if view is ViewDeferredToRenderer {
-        // swiftlint:disable:next force_cast
-        bodyClosure = { ($0 as! ViewDeferredToRenderer).deferredBody }
+        bodyClosure = {
+          let deferredView: Any
+          if let opt = $0 as? AnyOptional, let value = opt.value {
+            deferredView = value
+          } else {
+            deferredView = $0
+          }
+          // swiftlint:disable:next force_cast
+          return (deferredView as! ViewDeferredToRenderer).deferredBody
+        }
       } else {
         // swiftlint:disable:next force_cast
         bodyClosure = { AnyView(($0 as! V).body) }

--- a/Sources/TokamakCore/Views/ViewBuilder.swift
+++ b/Sources/TokamakCore/Views/ViewBuilder.swift
@@ -62,6 +62,19 @@ extension Optional: View where Wrapped: View {
   }
 }
 
+protocol AnyOptional {
+  var value: Any? { get }
+}
+
+extension Optional: AnyOptional {
+  var value: Any? {
+    switch self {
+    case let .some(value): return value
+    case .none: return nil
+    }
+  }
+}
+
 @_functionBuilder public enum ViewBuilder {
   public static func buildBlock() -> EmptyView { EmptyView() }
 

--- a/Sources/TokamakGTK/Views/TextField.swift
+++ b/Sources/TokamakGTK/Views/TextField.swift
@@ -59,25 +59,29 @@ private func bindAction(to entry: UnsafeMutablePointer<GtkWidget>, textBinding: 
 extension SecureField: ViewDeferredToRenderer where Label == Text {
   public var deferredBody: AnyView {
     let proxy = _SecureFieldProxy(self)
-    return AnyView(WidgetView(build: { _ in
-      build(textBinding: proxy.textBinding, label: proxy.label, visible: false)
-    },
-    update: { w in
-      guard case let .widget(entry) = w.storage else { return }
-      update(entry: entry, textBinding: proxy.textBinding, label: proxy.label)
-    }) {})
+    return AnyView(WidgetView(
+      build: { _ in
+        build(textBinding: proxy.textBinding, label: proxy.label, visible: false)
+      },
+      update: { w in
+        guard case let .widget(entry) = w.storage else { return }
+        update(entry: entry, textBinding: proxy.textBinding, label: proxy.label)
+      }
+    ) {})
   }
 }
 
 extension TextField: ViewDeferredToRenderer where Label == Text {
   public var deferredBody: AnyView {
     let proxy = _TextFieldProxy(self)
-    return AnyView(WidgetView(build: { _ in
-      build(textBinding: proxy.textBinding, label: proxy.label)
-    },
-    update: { a in
-      guard case let .widget(widget) = a.storage else { return }
-      update(entry: widget, textBinding: proxy.textBinding, label: proxy.label)
-    }) {})
+    return AnyView(WidgetView(
+      build: { _ in
+        build(textBinding: proxy.textBinding, label: proxy.label)
+      },
+      update: { a in
+        guard case let .widget(widget) = a.storage else { return }
+        update(entry: widget, textBinding: proxy.textBinding, label: proxy.label)
+      }
+    ) {})
   }
 }

--- a/Tests/TokamakStaticHTMLTests/HTMLTests.swift
+++ b/Tests/TokamakStaticHTMLTests/HTMLTests.swift
@@ -1,0 +1,45 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Max Desiatov on 07/12/2018.
+//
+
+import TokamakStaticHTML
+import XCTest
+
+final class ReconcilerTests: XCTestCase {
+  struct Model {
+    let text: Text
+  }
+
+  private struct OptionalBody: View {
+    var model: Model?
+
+    var body: some View {
+      if let text = model?.text {
+        VStack {
+          text
+
+          Spacer()
+        }
+      }
+    }
+  }
+
+  func testOptional() {
+    let renderer = StaticHTMLRenderer(OptionalBody(model: Model(text: Text("text"))))
+
+    XCTAssertEqual(renderer.html.count, 2777)
+  }
+}


### PR DESCRIPTION
Weirdly enough, a view of type `Optional<Button<Text>>` can return `true` for `view is ViewDeferredToRenderer` check, but crash on a force typecast to this same `ViewDeferredToRenderer` existential. I've introduced new `AnyOptional` protocol to handle this type cast failure gracefully.

Also, during an attempt to add a test for this I discovered an issue, where just *linking* `TokamakStaticHTML` into the test product made all existing tests that use `TestRenderer` fail. This is caused by `TokamakStaticHTML` introducing new `ViewDeferredToRenderer` conformances, which `TestRenderer` and tests written with it don't expect. For now I'm disabling `TokamakStaticHTMLTests`, but keeping their source code to be re-enabled in the future when the issue is fixed.

This is a very unexpected behavior, and I'm thinking of replacing `ViewDeferredToRenderer` with something different in the future to work around this (I wasn't happy with the requirement to return `AnyView` for it anyway). Maybe with [explicit protocol witnesses](https://www.youtube.com/watch?v=3BVkbWXcFS4)? 🤔

Also applied `swiftformat` on some files that didn't have it.

Closes #362.