### PR TITLE
Add a benchmark target and a script to run it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           xcodebuild -scheme iOS -destination 'generic/platform=iOS' \
             CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
             xcpretty --color
+          cd ..
 
           ./benchmark.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
         run: |
           set -ex
-          sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer/
+          sudo xcode-select --switch /Applications/Xcode_12.3.app/Contents/Developer/
           # avoid building unrelated products for testing by specifying the test product explicitly
           swift build --product TokamakPackageTests
           `xcrun --find xctest` .build/debug/TokamakPackageTests.xctest
@@ -43,6 +43,8 @@ jobs:
             CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
             xcpretty --color
 
+          ./benchmark.sh
+
   gtk_macos_build:
     runs-on: macos-11.0
 
@@ -52,7 +54,7 @@ jobs:
         shell: bash
         run: |
           set -ex
-          sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer/
+          sudo xcode-select --switch /Applications/Xcode_12.3.app/Contents/Developer/
 
           brew install gtk+3
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,6 +19,11 @@
       "command": "carton dev --product TokamakDemo"
     },
     {
+      "label": "benchmark",
+      "type": "shell",
+      "command": "./benchmark.sh"
+    },
+    {
       "label": "make",
       "type": "shell",
       "command": "make",

--- a/Package.resolved
+++ b/Package.resolved
@@ -36,6 +36,24 @@
           "revision": "a617ead8a125a97e69d6100e4d27922006e82e0a",
           "version": "2.1.2"
         }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
+          "version": "0.3.2"
+        }
+      },
+      {
+        "package": "Benchmark",
+        "repositoryURL": "https://github.com/google/swift-benchmark",
+        "state": {
+          "branch": null,
+          "revision": "8e0ef8bb7482ab97dcd2cd1d6855bd38921c345d",
+          "version": "0.1.0"
+        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,10 @@ let package = Package(
       name: "TokamakShim",
       targets: ["TokamakShim"]
     ),
+    .executable(
+      name: "TokamakStaticHTMLBenchmark",
+      targets: ["TokamakStaticHTMLBenchmark"]
+    ),
   ],
   dependencies: [
     // Dependencies declare other packages that this package depends on.
@@ -52,6 +56,7 @@ let package = Package(
     .package(url: "https://github.com/MaxDesiatov/Runtime.git", from: "2.1.2"),
     .package(url: "https://github.com/TokamakUI/OpenCombine.git", from: "0.12.0-alpha3"),
     .package(url: "https://github.com/swiftwasm/OpenCombineJS.git", .upToNextMinor(from: "0.0.2")),
+    .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define
@@ -112,6 +117,13 @@ let package = Package(
       name: "TokamakStaticHTML",
       dependencies: [
         "TokamakCore",
+      ]
+    ),
+    .target(
+      name: "TokamakStaticHTMLBenchmark",
+      dependencies: [
+        "Benchmark",
+        "TokamakStaticHTML",
       ]
     ),
     .target(

--- a/Sources/TokamakCore/Views/Text/TextEditor.swift
+++ b/Sources/TokamakCore/Views/Text/TextEditor.swift
@@ -19,7 +19,7 @@ public struct TextEditor: View {
     textBinding = text
   }
 
-  public var body: some View {
+  public var body: Never {
     neverBody("TextEditor")
   }
 }

--- a/Sources/TokamakStaticHTMLBenchmark/main.swift
+++ b/Sources/TokamakStaticHTMLBenchmark/main.swift
@@ -1,0 +1,12 @@
+import Benchmark
+import TokamakStaticHTML
+
+benchmark("render Text") {
+  _ = StaticHTMLRenderer(Text("text"))
+}
+
+benchmark("render List") {
+  _ = StaticHTMLRenderer(List(1..<100) { Text("\($0)") })
+}
+
+Benchmark.main()

--- a/Sources/TokamakStaticHTMLBenchmark/main.swift
+++ b/Sources/TokamakStaticHTMLBenchmark/main.swift
@@ -5,6 +5,18 @@ benchmark("render Text") {
   _ = StaticHTMLRenderer(Text("text"))
 }
 
+struct BenchmarkApp: App {
+  var body: some Scene {
+    WindowGroup("Benchmark") {
+      Text("Hello, World!")
+    }
+  }
+}
+
+benchmark("render App") {
+  _ = StaticHTMLRenderer(BenchmarkApp())
+}
+
 benchmark("render List") {
   _ = StaticHTMLRenderer(List(1..<100) { Text("\($0)") })
 }

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eux
+
+swift build -c release --product TokamakStaticHTMLBenchmark
+./.build/release/TokamakStaticHTMLBenchmark


### PR DESCRIPTION
Benchmarks need to be built in the release mode, I created a separate `benchmark.sh` script to build it and run it.

I've also cleaned up a compiler warning in `TextEditor.swift` and bumped macOS agents to use Xcode 12.3 instead of 12.2

After this is merged to `main` I want to set it up an [similarly to what we have in JavaScriptKit](https://github.com/swiftwasm/JavaScriptKit/blob/main/.github/workflows/perf.yml) where benchmarks run on both a PR branch and `main` and difference between them is posted as a comment.