### PR TITLE
Replace uses of the Runtime library with stdlib

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -120,6 +120,13 @@ let package = Package(
       ]
     ),
     .target(
+      name: "TokamakCoreBenchmark",
+      dependencies: [
+        "Benchmark",
+        "TokamakCore",
+      ]
+    ),
+    .target(
       name: "TokamakStaticHTMLBenchmark",
       dependencies: [
         "Benchmark",

--- a/Sources/TokamakCore/App/App.swift
+++ b/Sources/TokamakCore/App/App.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Tokamak contributors
+// Copyright 2020-2021 Tokamak contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 //
 
 import CombineShim
-import Runtime
 
 /// Provides the ability to set the title of the Scene.
 public protocol _TitledApp {

--- a/Sources/TokamakCore/App/_AnyScene.swift
+++ b/Sources/TokamakCore/App/_AnyScene.swift
@@ -63,13 +63,8 @@ public struct _AnyScene: Scene {
         // swiftlint:disable:next force_cast
         bodyClosure = { .scene(_AnyScene(($0 as! S).body)) }
       }
-      // FIXME: no idea if using `mangledName` is reliable, but seems to be the only way to get
-      // a name of a type constructor in runtime. Should definitely check if these are different
-      // across modules, otherwise can cause problems with scenes with same names in different
-      // modules.
 
-      // swiftlint:disable:next force_try
-      typeConstructorName = try! typeInfo(of: type).mangledName
+      typeConstructorName = TokamakCore.typeConstructorName(type)
     }
   }
 

--- a/Sources/TokamakCore/App/_AnyScene.swift
+++ b/Sources/TokamakCore/App/_AnyScene.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Tokamak contributors
+// Copyright 2020-2021 Tokamak contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
 //
 //  Created by Carson Katri on 7/19/20.
 //
-
-import Runtime
 
 public struct _AnyScene: Scene {
   /** The result type of `bodyClosure` allowing to disambiguate between scenes that

--- a/Sources/TokamakCore/DynamicProperty.swift
+++ b/Sources/TokamakCore/DynamicProperty.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Tokamak contributors
+// Copyright 2020-2021 Tokamak contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
 //
 //  Created by Carson Katri on 7/17/20.
 //
-
-import Runtime
 
 public protocol DynamicProperty {
   mutating func update()

--- a/Sources/TokamakCore/MountedViews/MountedApp.swift
+++ b/Sources/TokamakCore/MountedViews/MountedApp.swift
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Tokamak contributors
+// Copyright 2018-2021 Tokamak contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 //
 
 import CombineShim
-import Runtime
 
 // This is very similar to `MountedCompositeView`. However, the `mountedBody`
 // is the computed content of the specified `Scene`, instead of having child

--- a/Sources/TokamakCore/MountedViews/MountedCompositeView.swift
+++ b/Sources/TokamakCore/MountedViews/MountedCompositeView.swift
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Tokamak contributors
+// Copyright 2018-2021 Tokamak contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 //
 
 import CombineShim
-import Runtime
 
 final class MountedCompositeView<R: Renderer>: MountedCompositeElement<R> {
   override func mount(

--- a/Sources/TokamakCore/MountedViews/MountedElement.swift
+++ b/Sources/TokamakCore/MountedViews/MountedElement.swift
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Tokamak contributors
+// Copyright 2018-2021 Tokamak contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 import Runtime
 
 /// The container for any of the possible `MountedElement` types
-enum MountedElementKind {
+private enum MountedElementKind {
   case app(_AnyApp)
   case scene(_AnyScene)
   case view(AnyView)

--- a/Sources/TokamakCore/MountedViews/MountedHostView.swift
+++ b/Sources/TokamakCore/MountedViews/MountedHostView.swift
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Tokamak contributors
+// Copyright 2018-2021 Tokamak contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
 //
 //  Created by Max Desiatov on 03/12/2018.
 //
-
-import Runtime
 
 /* A representation of a `View`, which has a `body` of type `Never`, stored in the tree of mounted
  views by `StackReconciler`.

--- a/Sources/TokamakCore/MountedViews/MountedScene.swift
+++ b/Sources/TokamakCore/MountedViews/MountedScene.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Tokamak contributors
+// Copyright 2020-2021 Tokamak contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-import Runtime
 
 final class MountedScene<R: Renderer>: MountedCompositeElement<R> {
   let title: String?

--- a/Sources/TokamakCore/Reflection/TypeInfo.swift
+++ b/Sources/TokamakCore/Reflection/TypeInfo.swift
@@ -17,7 +17,7 @@
  they are treated the same, thus the `Button` part of the type (the type constructor)
  is returned.
  */
-func typeConstructorName(_ type: Any.Type) -> String {
+public func typeConstructorName(_ type: Any.Type) -> String {
   // FIXME: no idea if this calculation is reliable, but seems to be the only way to get
   // a name of a type constructor in runtime. Should definitely check if these are different
   // across modules, otherwise can cause problems with views with same names in different

--- a/Sources/TokamakCore/Reflection/TypeInfo.swift
+++ b/Sources/TokamakCore/Reflection/TypeInfo.swift
@@ -1,0 +1,12 @@
+/** Returns name of a given unapplied generic type. `Button<Text>` and
+ `Button<Image>` types are different, but when reconciling the tree of mounted views
+ they are treated the same, thus the `Button` part of the type (the type constructor)
+ is returned.
+ */
+func typeConstructorName(_ type: Any.Type) -> String {
+  // FIXME: no idea if this calculation is reliable, but seems to be the only way to get
+  // a name of a type constructor in runtime. Should definitely check if these are different
+  // across modules, otherwise can cause problems with views with same names in different
+  // modules.
+  String(String(describing: type).prefix { $0 != "<" })
+}

--- a/Sources/TokamakCore/Reflection/TypeInfo.swift
+++ b/Sources/TokamakCore/Reflection/TypeInfo.swift
@@ -1,3 +1,17 @@
+// Copyright 2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /** Returns name of a given unapplied generic type. `Button<Text>` and
  `Button<Image>` types are different, but when reconciling the tree of mounted views
  they are treated the same, thus the `Button` part of the type (the type constructor)

--- a/Sources/TokamakCore/StackReconciler.swift
+++ b/Sources/TokamakCore/StackReconciler.swift
@@ -203,7 +203,7 @@ public final class StackReconciler<R: Renderer> {
     }.store(in: &mountedApp.persistentSubscriptions)
   }
 
-  func render<T>(
+  private func render<T>(
     compositeElement: MountedCompositeElement<R>,
     body bodyKeypath: ReferenceWritableKeyPath<MountedCompositeElement<R>, Any>,
     result: KeyPath<MountedCompositeElement<R>, (Any) -> T>

--- a/Sources/TokamakCore/StackReconciler.swift
+++ b/Sources/TokamakCore/StackReconciler.swift
@@ -265,14 +265,8 @@ public final class StackReconciler<R: Renderer> {
     case let (mountedChild?, childBody):
       let childBodyType = getElementType(childBody)
 
-      // FIXME: no idea if using `mangledName` is reliable, but seems to be the only way to get
-      // a name of a type constructor in runtime. Should definitely check if these are different
-      // across modules, otherwise can cause problems with views with same names in different
-      // modules.
-
       // new child has the same type as existing child
-      // swiftlint:disable:next force_try
-      if try! mountedChild.typeConstructorName == typeInfo(of: childBodyType).mangledName {
+      if mountedChild.typeConstructorName == typeConstructorName(childBodyType) {
         updateChild(mountedChild)
         mountedChild.update(with: self)
       } else {

--- a/Sources/TokamakCore/Views/AnyView.swift
+++ b/Sources/TokamakCore/Views/AnyView.swift
@@ -48,13 +48,7 @@ public struct AnyView: View {
     } else {
       type = V.self
 
-      // FIXME: no idea if using `mangledName` is reliable, but seems to be the only way to get
-      // a name of a type constructor in runtime. Should definitely check if these are different
-      // across modules, otherwise can cause problems with views with same names in different
-      // modules.
-
-      // swiftlint:disable:next force_try
-      typeConstructorName = try! typeInfo(of: type).mangledName
+      typeConstructorName = TokamakCore.typeConstructorName(type)
 
       bodyType = V.Body.self
       self.view = view

--- a/Sources/TokamakCore/Views/AnyView.swift
+++ b/Sources/TokamakCore/Views/AnyView.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Tokamak contributors
+// Copyright 2020-2021 Tokamak contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
 //
 //  Created by Max Desiatov on 08/04/2020.
 //
-
-import Runtime
 
 /// A type-erased view.
 public struct AnyView: View {

--- a/Sources/TokamakCoreBenchmark/main.swift
+++ b/Sources/TokamakCoreBenchmark/main.swift
@@ -1,0 +1,16 @@
+import Benchmark
+import Runtime
+import TokamakCore
+
+private let bigType = NavigationView<HStack<VStack<Button<Text>>>>.self
+
+benchmark("mangledName Runtime") {
+  // swiftlint:disable:next force_try
+  _ = try! typeInfo(of: bigType).mangledName
+}
+
+benchmark("typeConstructorName TokamakCore") {
+  _ = typeConstructorName(bigType)
+}
+
+Benchmark.main()

--- a/Sources/TokamakStaticHTML/Modifiers/ModifiedContent.swift
+++ b/Sources/TokamakStaticHTML/Modifiers/ModifiedContent.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Tokamak contributors
+// Copyright 2020-2021 Tokamak contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Runtime
 import TokamakCore
 
 private protocol AnyModifiedContent {

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -2,5 +2,7 @@
 
 set -eux
 
+swift build -c release --product TokamakCoreBenchmark
+./.build/release/TokamakCoreBenchmark
 swift build -c release --product TokamakStaticHTMLBenchmark
 ./.build/release/TokamakStaticHTMLBenchmark


### PR DESCRIPTION
This should allow us to remove the Runtime dependency eventually, which seems to be unstable, especially across different platforms and Swift versions.

Seems to resolve in one instance https://github.com/TokamakUI/Tokamak/issues/367. There are a few other places where `typeInfo` is still used, I'll clean that up in a follow-up PR.