### PR TITLE
Add checks for metadata state

### DIFF
--- a/Sources/TokamakCore/Reflection/Metadata/MetadataState.swift
+++ b/Sources/TokamakCore/Reflection/Metadata/MetadataState.swift
@@ -1,0 +1,42 @@
+// Copyright 2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+enum MetadataState: UInt {
+  case complete = 0x00
+  case nonTransitiveComplete = 0x01
+  case layoutComplete = 0x3F
+  case abstract = 0xFF
+}
+
+private let isBlockingMask: UInt = 0x100
+
+struct MetadataRequest {
+  private let bits: UInt
+
+  init(desiredState: MetadataState, isBlocking: Bool) {
+    if isBlocking {
+      bits = desiredState.rawValue | isBlockingMask
+    } else {
+      bits = desiredState.rawValue & ~isBlockingMask
+    }
+  }
+}
+
+struct MetadataResponse {
+  let metadata: UnsafePointer<StructMetadata>
+  let state: MetadataState
+}
+
+@_silgen_name("swift_checkMetadataState")
+func _checkMetadataState(_ request: MetadataRequest, _ type: StructMetadata) -> MetadataResponse

--- a/Sources/TokamakCore/Reflection/Metadata/StructMetadata.swift
+++ b/Sources/TokamakCore/Reflection/Metadata/StructMetadata.swift
@@ -129,10 +129,15 @@ struct StructMetadata {
 extension StructMetadata {
   init(type: Any.Type) {
     self = Self(pointer: unsafeBitCast(type, to: UnsafePointer<StructMetadataLayout>.self))
-    let response = _checkMetadataState(
-      .init(desiredState: .layoutComplete, isBlocking: false),
-      self
+    assert(
+      _checkMetadataState(
+        .init(desiredState: .layoutComplete, isBlocking: false),
+        self
+      ).state.rawValue < MetadataState.layoutComplete.rawValue,
+      """
+      Struct metadata for \(type) is in incomplete state, \
+      proceeding would result in an undefined behavior.
+      """
     )
-    precondition(response.state.rawValue < MetadataState.layoutComplete.rawValue)
   }
 }

--- a/Sources/TokamakCore/Reflection/Metadata/StructMetadata.swift
+++ b/Sources/TokamakCore/Reflection/Metadata/StructMetadata.swift
@@ -129,14 +129,10 @@ struct StructMetadata {
 extension StructMetadata {
   init(type: Any.Type) {
     self = Self(pointer: unsafeBitCast(type, to: UnsafePointer<StructMetadataLayout>.self))
-    print(
-      """
-      state is \(_checkMetadataState(
-        .init(desiredState: .layoutComplete, isBlocking: false),
-        self
-      )
-      )
-      """
+    let response = _checkMetadataState(
+      .init(desiredState: .layoutComplete, isBlocking: false),
+      self
     )
+    precondition(response.state.rawValue < MetadataState.layoutComplete.rawValue)
   }
 }

--- a/Sources/TokamakCore/Reflection/Metadata/StructMetadata.swift
+++ b/Sources/TokamakCore/Reflection/Metadata/StructMetadata.swift
@@ -129,5 +129,14 @@ struct StructMetadata {
 extension StructMetadata {
   init(type: Any.Type) {
     self = Self(pointer: unsafeBitCast(type, to: UnsafePointer<StructMetadataLayout>.self))
+    print(
+      """
+      state is \(_checkMetadataState(
+        .init(desiredState: .layoutComplete, isBlocking: false),
+        self
+      )
+      )
+      """
+    )
   }
 }

--- a/Sources/TokamakCoreBenchmark/main.swift
+++ b/Sources/TokamakCoreBenchmark/main.swift
@@ -1,3 +1,17 @@
+// Copyright 2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Benchmark
 import TokamakCore
 

--- a/Sources/TokamakCoreBenchmark/main.swift
+++ b/Sources/TokamakCoreBenchmark/main.swift
@@ -3,6 +3,10 @@ import TokamakCore
 
 private let bigType = NavigationView<HStack<VStack<Button<Text>>>>.self
 
+benchmark("mangledName Runtime") {
+  _ = typeInfo(of: bigType)!.mangledName
+}
+
 benchmark("typeConstructorName TokamakCore") {
   _ = typeConstructorName(bigType)
 }

--- a/Sources/TokamakStaticHTMLBenchmark/main.swift
+++ b/Sources/TokamakStaticHTMLBenchmark/main.swift
@@ -1,3 +1,17 @@
+// Copyright 2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Benchmark
 import TokamakStaticHTML
 


### PR DESCRIPTION
Type metadata actually *is* mutable, is updated by the runtime, and we need to be careful when reading from it. See https://github.com/apple/swift/blob/main/docs/ABI/TypeMetadata.rst#metadata-requests-and-responses for more.