### PR TITLE
WIP: Experiments and hacks attempting to implement SwiftUI-like layout flow

### DIFF
--- a/Sources/TokamakCore/Modifiers/StyleModifiers.swift
+++ b/Sources/TokamakCore/Modifiers/StyleModifiers.swift
@@ -58,6 +58,30 @@ public extension View {
   }
 }
 
+public struct _Overlay<Content, Overlay>: View
+where Overlay: View, Content: View
+{
+  public var environment: EnvironmentValues!
+    public var content: Content
+  public var overlay: Overlay
+  public var alignment: Alignment
+
+    public init(content: Content, overlay: Overlay, alignment: Alignment = .center) {
+    self.overlay = overlay
+        self.content = content
+    self.alignment = alignment
+  }
+
+    public var body: some View {
+    neverBody("_Overlay")
+//    // FIXME: Clip to content shape.
+//    ZStack(alignment: alignment) {
+//      content
+//      overlay
+//    }
+  }
+}
+
 public struct _OverlayModifier<Overlay>: ViewModifier, EnvironmentReader
   where Overlay: View
 {
@@ -71,11 +95,12 @@ public struct _OverlayModifier<Overlay>: ViewModifier, EnvironmentReader
   }
 
   public func body(content: Content) -> some View {
-    // FIXME: Clip to content shape.
-    ZStack(alignment: alignment) {
-      content
-      overlay
-    }
+    _Overlay(content: content, overlay: overlay, alignment: alignment)
+//    // FIXME: Clip to content shape.
+//    ZStack(alignment: alignment) {
+//      content
+//      overlay
+//    }
   }
 
   mutating func setContent(from values: EnvironmentValues) {
@@ -93,7 +118,8 @@ public extension View {
   func overlay<Overlay>(_ overlay: Overlay, alignment: Alignment = .center) -> some View
     where Overlay: View
   {
-    modifier(_OverlayModifier(overlay: overlay, alignment: alignment))
+    _Overlay(content: self, overlay: overlay, alignment: alignment)
+//    modifier(_OverlayModifier(overlay: overlay, alignment: alignment))
   }
 
   func border<S>(_ content: S, width: CGFloat = 1) -> some View where S: ShapeStyle {

--- a/Sources/TokamakCore/MountedViews/MountedElement.swift
+++ b/Sources/TokamakCore/MountedViews/MountedElement.swift
@@ -84,7 +84,7 @@ public class MountedElement<R: Renderer> {
     }
   }
 
-  var mountedChildren = [MountedElement<R>]()
+  public var mountedChildren = [MountedElement<R>]()
   var environmentValues: EnvironmentValues
 
   unowned var parent: MountedElement<R>?

--- a/Sources/TokamakCore/MountedViews/MountedHostView.swift
+++ b/Sources/TokamakCore/MountedViews/MountedHostView.swift
@@ -27,7 +27,7 @@ public final class MountedHostView<R: Renderer>: MountedElement<R> {
   private let parentTarget: R.TargetType
 
   /// Target of this host view supplied by a renderer after mounting has completed.
-  private(set) var target: R.TargetType?
+  private(set) public var target: R.TargetType?
 
   init(
     _ view: AnyView,

--- a/Sources/TokamakGTK/Modifiers/WidgetModifier.swift
+++ b/Sources/TokamakGTK/Modifiers/WidgetModifier.swift
@@ -69,10 +69,10 @@ extension ModifiedContent: ViewDeferredToRenderer where Content: View {
       return AnyView(content)
     }
 
-    let build: (UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget> = {
-      let contentWidget = anyWidget.new($0)
-      widgetModifier.modify(widget: contentWidget)
-      return contentWidget
+    let build: (UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget>? = {
+        guard let contentWidget = anyWidget.new($0) else { return nil }
+        widgetModifier.modify(widget: contentWidget)
+        return contentWidget
     }
 
     let update: (Widget) -> () = { widget in

--- a/Sources/TokamakGTK/Scenes/SceneContainerView.swift
+++ b/Sources/TokamakGTK/Scenes/SceneContainerView.swift
@@ -25,7 +25,7 @@ struct SceneContainerView<Content: View>: View, AnyWidget {
     neverBody("SceneContainerView")
   }
 
-  func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget> {
+  func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget>? {
     print("Making window")
     let window: UnsafeMutablePointer<GtkWidget>
     window = gtk_application_window_new(application)

--- a/Sources/TokamakGTK/Scenes/WindowGroup.swift
+++ b/Sources/TokamakGTK/Scenes/WindowGroup.swift
@@ -19,10 +19,12 @@ import TokamakCore
 
 extension WindowGroup: SceneDeferredToRenderer {
   public var deferredBody: AnyView {
-    AnyView(VStack(alignment: .center) {
-      HStack(alignment: .center) {
-        content
-      }.frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
-    }.frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity))
+    AnyView(
+//      VStack(alignment: .center) {
+//        HStack(alignment: .center) {
+          content
+//        }.frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
+//    }.frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
+    )
   }
 }

--- a/Sources/TokamakGTK/Shapes/Shape.swift
+++ b/Sources/TokamakGTK/Shapes/Shape.swift
@@ -53,6 +53,7 @@ func createPath(from elements: [Path.Element], in cr: OpaquePointer) {
 extension _ShapeView: ViewDeferredToRenderer {
   public var deferredBody: AnyView {
     AnyView(WidgetView(build: { _ in
+        print("SHAPE?")
       let w = gtk_drawing_area_new()
       bindAction(to: w!)
       return w!

--- a/Sources/TokamakGTK/Views/Button.swift
+++ b/Sources/TokamakGTK/Views/Button.swift
@@ -20,7 +20,7 @@ import Foundation
 import TokamakCore
 
 extension _Button: AnyWidget, ParentView {
-  func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget> {
+  func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget>? {
     let btn = gtk_button_new()!
     bindAction(to: btn)
     return btn

--- a/Sources/TokamakGTK/Views/Image.swift
+++ b/Sources/TokamakGTK/Views/Image.swift
@@ -20,7 +20,7 @@ import Foundation
 import TokamakCore
 
 extension Image: AnyWidget {
-  func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget> {
+  func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget>? {
     let proxy = _ImageProxy(self)
     let imagePath = proxy.path ?? proxy.name
     let img = gtk_image_new_from_file(imagePath)!

--- a/Sources/TokamakGTK/Views/Picker.swift
+++ b/Sources/TokamakGTK/Views/Picker.swift
@@ -16,7 +16,7 @@ import CGTK
 import TokamakCore
 
 extension _PickerContainer: AnyWidget {
-  func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget> {
+  func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget>? {
     let comboBox = gtk_combo_box_text_new()!
     comboBox.withMemoryRebound(to: GtkComboBoxText.self, capacity: 1) { gtkComboBox in
       for element in elements {

--- a/Sources/TokamakGTK/Views/Stack.swift
+++ b/Sources/TokamakGTK/Views/Stack.swift
@@ -23,6 +23,26 @@ protocol StackProtocol {
   var alignment: Alignment { get }
 }
 
+extension _Overlay: AnyWidget where Content: AnyWidget, Overlay: AnyWidget {
+    func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget>? {
+      nil
+    }
+
+    func update(widget: Widget) {}
+
+    func layout<T>(size: CGSize, element: MountedHostView<T>) {
+        content.layout(size: size, element: element)
+        let childSize = overlay.size(for: ProposedSize(width: size.width, height: size.height), element: element)
+        overlay.layout(size: childSize, element: element)
+    }
+
+  func size<T>(for proposedSize: ProposedSize, element: MountedHostView<T>) -> CGSize {
+    print("SIZING _OVERLAY CONTENT")
+    return content.size(for: proposedSize, element: element)
+  }
+
+}
+
 struct Box<Content: View>: View, ParentView, AnyWidget, StackProtocol {
   let content: Content
   let orientation: GtkOrientation
@@ -31,14 +51,8 @@ struct Box<Content: View>: View, ParentView, AnyWidget, StackProtocol {
 
   let expand = true
 
-  func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget> {
-    let grid = gtk_grid_new()!
-    gtk_orientable_set_orientation(OpaquePointer(grid), orientation)
-    grid.withMemoryRebound(to: GtkGrid.self, capacity: 1) {
-      gtk_grid_set_row_spacing($0, UInt32(spacing))
-      gtk_grid_set_column_spacing($0, UInt32(spacing))
-    }
-    return grid
+  func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget>? {
+    nil
   }
 
   func update(widget: Widget) {}
@@ -50,7 +64,76 @@ struct Box<Content: View>: View, ParentView, AnyWidget, StackProtocol {
   public var children: [AnyView] {
     [AnyView(content)]
   }
+
+    func getChildren<T>(hostView: MountedElement<T>) -> [MountedHostView<T>] {
+        var children: [MountedHostView<T>] = []
+        for childElement in hostView.mountedChildren {
+            guard let childView = childElement as? MountedHostView<T> else {
+                print("CHILD", childElement)
+                children.append(contentsOf: getChildren(hostView: childElement))
+
+                continue
+            }
+            if let anyWidget = mapAnyView(
+                childView.view,
+              transform: { (widget: AnyWidget) in widget }
+            ) {
+                print("CHILD 2", anyWidget)
+                children.append(childView)
+            } else {
+                print("CHILD 3", childView)
+                children.append(contentsOf: getChildren(hostView: childView))
+            }
+        }
+        return children
+    }
+
+    func layout<T>(size: CGSize, element: MountedHostView<T>) {
+        let children = getChildren(hostView: element)
+        guard !children.isEmpty else { return }
+        print("CHILDREN", children, size)
+        var i: Int32 = 0
+        let proposedSize = ProposedSize(width: size.width, height: size.height / CGFloat(children.count))
+        for childElement in children {
+            guard let childView = childElement as? MountedHostView<T>,
+                  let anyWidget = mapAnyView(
+                      childView.view,
+                    transform: { (widget: AnyWidget) in widget }
+                  ) else {
+                continue
+            }
+
+            let size = anyWidget.size(for: proposedSize, element: childView)
+            print(size)
+            if let widget = element.target as? Widget, let childWidget = childView.target as? Widget {
+                if case let .widget(w) = childWidget.storage {
+                    widget.context.parent.withMemoryRebound(to: GtkFixed.self, capacity: 1) {
+                        gtk_fixed_move($0, w, 0, i)
+                    }
+                }
+            }
+            anyWidget.layout(size: size, element: childView)
+            i += Int32(size.height)
+
+        }
+
+    }
+
+
+  func size<T>(for proposedSize: ProposedSize, element: MountedHostView<T>) -> CGSize {
+    // TODO: Measure size of children, perform layout and return answer
+    if let parentView = content as? ParentView {
+      print("CONTENT IS PARENT")
+      for child in children {
+        print("CHILD", child)
+      }
+    } else {
+      print("CONTENT IS NOT PARENT")
+    }
+    return .zero
+  }
 }
+
 
 extension VStack: ViewDeferredToRenderer {
   public var deferredBody: AnyView {

--- a/Sources/TokamakGTK/Views/Text.swift
+++ b/Sources/TokamakGTK/Views/Text.swift
@@ -20,7 +20,7 @@ import Foundation
 import TokamakCore
 
 extension Text: AnyWidget {
-  func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget> {
+  func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget>? {
     let proxy = _TextProxy(self)
     return gtk_label_new(proxy.rawText)
   }
@@ -32,4 +32,43 @@ extension Text: AnyWidget {
       }
     }
   }
+
+    func size<T>(for proposedSize: ProposedSize, element: MountedHostView<T>) -> CGSize {
+        print("OVERRIDE SIZE FOR TEXT")
+        guard let widget = element.target as? Widget else { return proposedSize.orDefault }
+        guard case let .widget(w) = widget.storage else { return proposedSize.orDefault }
+
+        var minSize = GtkRequisition()
+        var naturalSize = GtkRequisition()
+        gtk_widget_get_preferred_size (w, &minSize, &naturalSize)
+        print("MIN", minSize)
+
+        var width: TokamakCore.CGFloat = 0
+        var height: TokamakCore.CGFloat = 0
+        if let proposedWidth = proposedSize.width {
+            if proposedWidth < TokamakCore.CGFloat(minSize.width) {
+                width = TokamakCore.CGFloat(minSize.width)
+            } else if proposedWidth > TokamakCore.CGFloat(naturalSize.width) {
+                width = TokamakCore.CGFloat(naturalSize.width)
+            } else {
+                width = proposedWidth
+            }
+        } else {
+            width = TokamakCore.CGFloat(naturalSize.width)
+        }
+        if let proposedHeight = proposedSize.height {
+            if proposedHeight < TokamakCore.CGFloat(minSize.height) {
+                height = TokamakCore.CGFloat(minSize.height)
+            } else if proposedHeight > TokamakCore.CGFloat(naturalSize.height) {
+                height = TokamakCore.CGFloat(naturalSize.height)
+            } else {
+                height = proposedHeight
+            }
+        } else {
+            height = TokamakCore.CGFloat(naturalSize.height)
+        }
+
+        return CGSize(width: width, height: height)
+    }
+    
 }

--- a/Sources/TokamakGTKDemo/main.swift
+++ b/Sources/TokamakGTKDemo/main.swift
@@ -50,14 +50,18 @@ struct PickerDemo: View {
 struct TokamakGTKDemo: App {
   var body: some Scene {
     WindowGroup("Test Scene") {
-      List {
-        Image("logo-header.png", bundle: Bundle.module, label: Text("Tokamak Demo"))
-        Counter()
-        PickerDemo()
-        ForEach(1..<100) {
-          Text("Item #\($0)")
+        VStack {
+            Rectangle()
+            Text("SKO") // .overlay(Rectangle().stroke())
         }
-      }
+//      List {
+//        Image("logo-header.png", bundle: Bundle.module, label: Text("Tokamak Demo"))
+//        Counter()
+//        PickerDemo()
+//        ForEach(1..<100) {
+//          Text("Item #\($0)")
+//        }
+//      }
     }
   }
 }


### PR DESCRIPTION
Please don't look at this yet - it's horrible! :-)

Currently I made a lot of types in `TokamakCore` public in order to perform the layout in the renderer. The layout should actually reside in `TokamakCore` with only a slim api to the renderer.

The GTK renderer is my current experimentation playground.
Instead of always returning a `GtkWidget` for the `AnyWidget` conformance it's now ok to be a 'virtual' (pure layout) widget and not return any actual control.
A 'context' is used to keep a stack of offsets used during layout - as well as a reference to the last actual widget container where all child elements should be added.
The only implementation of the sizing/layout is for `Text` where the GtkWidget is actually measured to return it's size, as well as `_ShapeView` whose size doesn't rely on any actual measuring.
`Box` (a helper type used by `HStack` and `VStack` in the GTK renderer) implements an extremely naive version of a layout. It's completely wrong, but shows how the sizing/layout could be tied together.
For the actual algorithm I propose to use the MIT licensed `NotSwiftUI` sample code from Objc.io. Perhaps only paying members of the Swift Talk video series have access, but I do have access through my work.
This naturally requires Tokamak to include the LICENSE text with copyright notice from objc.io.

I am currently experimenting with `Overlay`, but I think now is the time to move the `size` and `layout` protocol requirements into `TokamakCore`.

Apologies for the extremely rough/messy state of this draft PR. :-)