### PR TITLE
Use immediate scheduler in TestRenderer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,14 @@ on:
     branches: [main]
 
 jobs:
-  swiftwasm_build:
+  swiftwasm_test:
     runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
       - uses: swiftwasm/swiftwasm-action@v5.3
         with:
-          shell-action: carton bundle --product TokamakDemo
+          shell-action: carton test && carton bundle --product TokamakDemo
 
   core_macos_build:
     runs-on: macos-11.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ on:
     branches: [main]
 
 jobs:
+  swiftwasm_bundle:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: swiftwasm/swiftwasm-action@v5.3
+        with:
+          shell-action: carton bundle --product TokamakDemo
+
   swiftwasm_test:
     runs-on: ubuntu-20.04
 
@@ -13,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: swiftwasm/swiftwasm-action@v5.3
         with:
-          shell-action: carton test && carton bundle --product TokamakDemo
+          shell-action: carton test
 
   core_macos_build:
     runs-on: macos-11.0

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ file or class name and description of purpose be included on the
 same "printed page" as the copyright notice for easier
 identification within third-party archives.
 
-Copyright 2018-2020 Digital Signal Limited and Tokamak Contributors
+Copyright 2018-2021 Digital Signal Limited and Tokamak Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/TokamakTestRenderer/TestRenderer.swift
+++ b/Sources/TokamakTestRenderer/TestRenderer.swift
@@ -15,23 +15,11 @@
 //  Created by Max Desiatov on 21/12/2018.
 //
 
-#if os(WASI)
-import JavaScriptKit
-#else
-import Dispatch
-#endif
 import TokamakCore
 
 public func testScheduler(closure: @escaping () -> ()) {
-  #if os(WASI)
-  let fn = JSClosure { _ -> JSValue in
-    closure()
-    return .undefined
-  }
-  _ = JSObject.global.setTimeout!(fn, 0)
-  #else
-  DispatchQueue.main.async(execute: closure)
-  #endif
+  // immediate scheduler on all platforms for easier debugging and support on all platforms
+  closure()
 }
 
 public final class TestRenderer: Renderer {

--- a/Tests/TokamakTests/ReconcilerTests.swift
+++ b/Tests/TokamakTests/ReconcilerTests.swift
@@ -77,24 +77,16 @@ final class ReconcilerTests: XCTestCase {
 
     button.action()
 
-    let e = expectation(description: "rerender")
-
-    testScheduler {
-      XCTAssertTrue(root.view.view is EmptyView)
-      XCTAssertEqual(root.subviews.count, 1)
-      let newStack = root.subviews[0].subviews[0]
-      XCTAssert(stack === newStack)
-      XCTAssertTrue(stack.view.view is VStack<TupleView<(Button<Text>, Text)>>)
-      XCTAssertEqual(stack.subviews.count, 2)
-      XCTAssertTrue(stack.subviews[0].view.view is _Button<Text>)
-      XCTAssertTrue(stack.subviews[1].view.view is Text)
-      XCTAssertTrue(originalLabel === newStack.subviews[1])
-      XCTAssertEqual((stack.subviews[1].view.view as? Text)?.verbatim, "43")
-
-      e.fulfill()
-    }
-
-    wait(for: [e], timeout: 30)
+    XCTAssertTrue(root.view.view is EmptyView)
+    XCTAssertEqual(root.subviews.count, 1)
+    let newStack = root.subviews[0].subviews[0]
+    XCTAssert(stack === newStack)
+    XCTAssertTrue(stack.view.view is VStack<TupleView<(Button<Text>, Text)>>)
+    XCTAssertEqual(stack.subviews.count, 2)
+    XCTAssertTrue(stack.subviews[0].view.view is _Button<Text>)
+    XCTAssertTrue(stack.subviews[1].view.view is Text)
+    XCTAssertTrue(originalLabel === newStack.subviews[1])
+    XCTAssertEqual((stack.subviews[1].view.view as? Text)?.verbatim, "43")
   }
 
   func testDoubleUpdate() {
@@ -111,44 +103,34 @@ final class ReconcilerTests: XCTestCase {
 
     button.action()
 
-    let e = expectation(description: "rerender")
+    XCTAssertTrue(root.view.view is EmptyView)
+    XCTAssertEqual(root.subviews.count, 1)
+    let newStack = root.subviews[0].subviews[0]
+    XCTAssert(stack === newStack)
+    XCTAssertTrue(stack.view.view is VStack<TupleView<(Button<Text>, Text)>>)
+    XCTAssertEqual(stack.subviews.count, 2)
+    XCTAssertTrue(stack.subviews[0].view.view is _Button<Text>)
+    XCTAssertTrue(stack.subviews[1].view.view is Text)
+    XCTAssertTrue(originalLabel === newStack.subviews[1])
+    XCTAssertEqual((stack.subviews[1].view.view as? Text)?.verbatim, "43")
 
-    testScheduler {
-      XCTAssertTrue(root.view.view is EmptyView)
-      XCTAssertEqual(root.subviews.count, 1)
-      let newStack = root.subviews[0].subviews[0]
-      XCTAssert(stack === newStack)
-      XCTAssertTrue(stack.view.view is VStack<TupleView<(Button<Text>, Text)>>)
-      XCTAssertEqual(stack.subviews.count, 2)
-      XCTAssertTrue(stack.subviews[0].view.view is _Button<Text>)
-      XCTAssertTrue(stack.subviews[1].view.view is Text)
-      XCTAssertTrue(originalLabel === newStack.subviews[1])
-      XCTAssertEqual((stack.subviews[1].view.view as? Text)?.verbatim, "43")
-
-      guard let button = stack.subviews[0].view.view as? _Button<Text> else {
-        XCTAssert(false, "counter has no button")
-        return
-      }
-
-      button.action()
-
-      testScheduler {
-        XCTAssertTrue(root.view.view is EmptyView)
-        XCTAssertEqual(root.subviews.count, 1)
-        let newStack = root.subviews[0].subviews[0]
-        XCTAssert(stack === newStack)
-        XCTAssertTrue(stack.view.view is VStack<TupleView<(Button<Text>, Text)>>)
-        XCTAssertEqual(stack.subviews.count, 2)
-        XCTAssertTrue(stack.subviews[0].view.view is _Button<Text>)
-        XCTAssertTrue(stack.subviews[1].view.view is Text)
-        XCTAssertTrue(originalLabel === newStack.subviews[1])
-        XCTAssertEqual((stack.subviews[1].view.view as? Text)?.verbatim, "44")
-
-        e.fulfill()
-      }
+    guard let newButton = stack.subviews[0].view.view as? _Button<Text> else {
+      XCTAssert(false, "counter has no button")
+      return
     }
 
-    wait(for: [e], timeout: 1)
+    newButton.action()
+
+    XCTAssertTrue(root.view.view is EmptyView)
+    XCTAssertEqual(root.subviews.count, 1)
+    let newestStack = root.subviews[0].subviews[0]
+    XCTAssert(stack === newestStack)
+    XCTAssertTrue(stack.view.view is VStack<TupleView<(Button<Text>, Text)>>)
+    XCTAssertEqual(stack.subviews.count, 2)
+    XCTAssertTrue(stack.subviews[0].view.view is _Button<Text>)
+    XCTAssertTrue(stack.subviews[1].view.view is Text)
+    XCTAssertTrue(originalLabel === newStack.subviews[1])
+    XCTAssertEqual((stack.subviews[1].view.view as? Text)?.verbatim, "44")
   }
 
   func testUnmount() {
@@ -163,38 +145,25 @@ final class ReconcilerTests: XCTestCase {
 
     button.action()
 
-    let e = expectation(description: "rerender")
-
-    testScheduler {
-      // rerender completed here, schedule another one
-      guard let button = stack.subviews[0].view.view as? _Button<Text> else {
-        XCTAssert(false, "counter has no button")
-        return
-      }
-
-      button.action()
-
-      testScheduler {
-        guard let button = stack.subviews[0].view.view as? _Button<Text> else {
-          XCTAssert(false, "counter has no button")
-          return
-        }
-
-        button.action()
-
-        testScheduler {
-          XCTAssertTrue(root.view.view is EmptyView)
-          XCTAssertEqual(root.subviews.count, 1)
-          let newStack = root.subviews[0].subviews[0]
-          XCTAssert(stack === newStack)
-          XCTAssertTrue(stack.view.view is VStack<Text>)
-          XCTAssertEqual(stack.subviews.count, 1)
-
-          e.fulfill()
-        }
-      }
+    guard let newButton = stack.subviews[0].view.view as? _Button<Text> else {
+      XCTAssert(false, "counter has no button")
+      return
     }
 
-    wait(for: [e], timeout: 1)
+    newButton.action()
+
+    guard let newestButton = stack.subviews[0].view.view as? _Button<Text> else {
+      XCTAssert(false, "counter has no button")
+      return
+    }
+
+    newestButton.action()
+
+    XCTAssertTrue(root.view.view is EmptyView)
+    XCTAssertEqual(root.subviews.count, 1)
+    let newStack = root.subviews[0].subviews[0]
+    XCTAssert(stack === newStack)
+    XCTAssertTrue(stack.view.view is VStack<Text>)
+    XCTAssertEqual(stack.subviews.count, 1)
   }
 }


### PR DESCRIPTION
This allows running our test suite on WASI too, which doesn't have Dispatch and also can't wait on XCTest expectations. Previously none of our tests (especially runtime reflection tests) ran on WASI.