### PR TITLE
Stop assuming pointer type for generic arguments

### DIFF
--- a/Sources/TokamakCore/Reflection/Layouts/FieldDescriptor.swift
+++ b/Sources/TokamakCore/Reflection/Layouts/FieldDescriptor.swift
@@ -54,14 +54,14 @@ extension UnsafePointer where Pointee == FieldRecord {
 
   func type(
     genericContext: UnsafeRawPointer?,
-    genericArguments: UnsafeRawPointer?
+    genericArguments: UnsafeRawPointer
   ) -> Any.Type {
     let typeName = advance(offset: \._mangledTypeName)
     return _getTypeByMangledNameInContext(
       typeName,
       getSymbolicMangledNameLength(typeName),
       genericContext,
-      genericArguments?.assumingMemoryBound(to: UnsafeRawPointer?.self)
+      genericArguments
     )!
   }
 }

--- a/Sources/TokamakCore/Reflection/Metadata/StructMetadata.swift
+++ b/Sources/TokamakCore/Reflection/Metadata/StructMetadata.swift
@@ -77,22 +77,9 @@ struct StructMetadata {
     }
   }
 
-  func genericArguments() -> UnsafeBufferPointer<Any.Type> {
-    guard isGeneric else { return .init(start: nil, count: 0) }
-
-    let count = pointer.pointee
-      .typeDescriptor
-      .pointee
-      .genericContextHeader
-      .base
-      .numberOfParams
-    return genericArgumentVector().buffer(n: Int(count))
-  }
-
-  func genericArgumentVector() -> UnsafePointer<Any.Type> {
+  func genericArgumentVector() -> UnsafeRawPointer {
     pointer
       .raw.advanced(by: genericArgumentOffset * MemoryLayout<UnsafeRawPointer>.size)
-      .assumingMemoryBound(to: Any.Type.self)
   }
 
   var type: Any.Type {

--- a/Sources/TokamakCore/Reflection/Models/TypeInfo.swift
+++ b/Sources/TokamakCore/Reflection/Models/TypeInfo.swift
@@ -29,7 +29,6 @@ public struct TypeInfo {
   public let size: Int
   public let alignment: Int
   public let stride: Int
-  public let genericTypes: [Any.Type]
 
   init(metadata: StructMetadata) {
     kind = metadata.kind
@@ -40,7 +39,6 @@ public struct TypeInfo {
     stride = metadata.stride
     properties = metadata.properties()
     mangledName = metadata.mangledName()
-    genericTypes = Array(metadata.genericArguments())
   }
 
   public func property(named: String) -> PropertyInfo? {

--- a/Tests/TokamakTests/MetadataTests.swift
+++ b/Tests/TokamakTests/MetadataTests.swift
@@ -27,13 +27,7 @@ final class MetadataTests: XCTestCase {
   func testGenericStruct() {
     struct A<B, C, D, E, F, G, H> { let b: B }
     let md = StructMetadata(type: A<Int, String, Bool, Int, Int, Int, Int>.self)
-    let args = md.genericArguments()
     let props = md.properties()
-    XCTAssert(args.count == 7)
-    XCTAssert(args[0] == Int.self)
-    XCTAssert(args[1] == String.self)
-    XCTAssert(args[2] == Bool.self)
-    XCTAssert(args[3] == Int.self)
     XCTAssert(props.count == 1)
     XCTAssert(props[0].type == Int.self)
   }
@@ -46,7 +40,6 @@ final class MetadataTests: XCTestCase {
 
     let md = StructMetadata(type: A.self)
     let info = md.toTypeInfo()
-    XCTAssert(info.genericTypes.count == 0)
     XCTAssert(info.kind == .struct)
     XCTAssert(info.type == A.self)
     XCTAssert(info.properties.count == 5)
@@ -67,7 +60,6 @@ final class MetadataTests: XCTestCase {
 
       let md = StructMetadata(type: NestedA.self)
       let info = md.toTypeInfo()
-      XCTAssert(info.genericTypes.count == 0)
       XCTAssert(info.kind == .struct)
       XCTAssert(info.type == NestedA.self)
       XCTAssert(info.properties.count == 5)


### PR DESCRIPTION
Seems to fully resolve https://github.com/TokamakUI/Tokamak/issues/367.

You were right @foscomputerservices, this was a strict aliasing issue. 😅 This [forum post](https://forums.swift.org/t/is-it-safe-to-use-a-variable-after-modifying-via-a-rebound-pointer/44848/6) made it crystal clear to me:

>Binding a local variable's memory to a different type poisons that local variable