### PR TITLE
Add '_spi(TokamakCore)' to ideally internal public members.

### DIFF
--- a/Sources/TokamakCore/App/AppStorage.swift
+++ b/Sources/TokamakCore/App/AppStorage.swift
@@ -173,6 +173,7 @@ struct DefaultAppStorageEnvironmentKey: EnvironmentKey {
 }
 
 public extension EnvironmentValues {
+  @_spi(TokamakCore)
   var _defaultAppStorage: _StorageProvider? {
     get {
       self[DefaultAppStorageEnvironmentKey.self]

--- a/Sources/TokamakCore/App/Scenes/WindowGroup.swift
+++ b/Sources/TokamakCore/App/Scenes/WindowGroup.swift
@@ -62,7 +62,7 @@ public struct WindowGroup<Content>: Scene, TitledScene where Content: View {
     self.title = Text(title)
     self.content = content()
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverScene("WindowGroup")

--- a/Sources/TokamakCore/App/Scenes/WindowGroup.swift
+++ b/Sources/TokamakCore/App/Scenes/WindowGroup.swift
@@ -62,7 +62,8 @@ public struct WindowGroup<Content>: Scene, TitledScene where Content: View {
     self.title = Text(title)
     self.content = content()
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverScene("WindowGroup")
   }

--- a/Sources/TokamakCore/App/Scenes/_SceneModifier.swift
+++ b/Sources/TokamakCore/App/Scenes/_SceneModifier.swift
@@ -25,7 +25,6 @@ public struct _SceneModifier_Content<Modifier>: Scene where Modifier: _SceneModi
   public let modifier: Modifier
   public let scene: _AnyScene
 
-    
   @_spi(TokamakCore)
   public var body: Never {
     neverScene("_SceneModifier_Content")

--- a/Sources/TokamakCore/App/Scenes/_SceneModifier.swift
+++ b/Sources/TokamakCore/App/Scenes/_SceneModifier.swift
@@ -25,6 +25,8 @@ public struct _SceneModifier_Content<Modifier>: Scene where Modifier: _SceneModi
   public let modifier: Modifier
   public let scene: _AnyScene
 
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverScene("_SceneModifier_Content")
   }

--- a/Sources/TokamakCore/App/_AnyApp.swift
+++ b/Sources/TokamakCore/App/_AnyApp.swift
@@ -30,7 +30,7 @@ public struct _AnyApp: App {
     bodyClosure = { _AnyScene(($0 as! A).body) }
     bodyType = A.Body.self
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverScene("_AnyApp")
@@ -40,22 +40,22 @@ public struct _AnyApp: App {
   public init() {
     fatalError("`_AnyApp` cannot be initialized without an underlying `App` type.")
   }
-    
+
   @_spi(TokamakCore)
   public static func _launch(_ app: Self, _ rootEnvironment: EnvironmentValues) {
     fatalError("`_AnyApp` cannot be launched. Access underlying `app` value.")
   }
-    
+
   @_spi(TokamakCore)
   public static func _setTitle(_ title: String) {
     fatalError("`title` cannot be set for `AnyApp`. Access underlying `app` value.")
   }
-    
+
   @_spi(TokamakCore)
   public var _phasePublisher: AnyPublisher<ScenePhase, Never> {
     fatalError("`_AnyApp` cannot monitor scenePhase. Access underlying `app` value.")
   }
-    
+
   @_spi(TokamakCore)
   public var _colorSchemePublisher: AnyPublisher<ColorScheme, Never> {
     fatalError("`_AnyApp` cannot monitor colorScheme. Access underlying `app` value.")

--- a/Sources/TokamakCore/App/_AnyApp.swift
+++ b/Sources/TokamakCore/App/_AnyApp.swift
@@ -30,27 +30,33 @@ public struct _AnyApp: App {
     bodyClosure = { _AnyScene(($0 as! A).body) }
     bodyType = A.Body.self
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverScene("_AnyApp")
   }
 
+  @_spi(TokamakCore)
   public init() {
     fatalError("`_AnyApp` cannot be initialized without an underlying `App` type.")
   }
-
+    
+  @_spi(TokamakCore)
   public static func _launch(_ app: Self, _ rootEnvironment: EnvironmentValues) {
     fatalError("`_AnyApp` cannot be launched. Access underlying `app` value.")
   }
-
+    
+  @_spi(TokamakCore)
   public static func _setTitle(_ title: String) {
     fatalError("`title` cannot be set for `AnyApp`. Access underlying `app` value.")
   }
-
+    
+  @_spi(TokamakCore)
   public var _phasePublisher: AnyPublisher<ScenePhase, Never> {
     fatalError("`_AnyApp` cannot monitor scenePhase. Access underlying `app` value.")
   }
-
+    
+  @_spi(TokamakCore)
   public var _colorSchemePublisher: AnyPublisher<ColorScheme, Never> {
     fatalError("`_AnyApp` cannot monitor colorScheme. Access underlying `app` value.")
   }

--- a/Sources/TokamakCore/App/_AnyScene.swift
+++ b/Sources/TokamakCore/App/_AnyScene.swift
@@ -65,7 +65,7 @@ public struct _AnyScene: Scene {
       typeConstructorName = TokamakCore.typeConstructorName(type)
     }
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverScene("_AnyScene")

--- a/Sources/TokamakCore/App/_AnyScene.swift
+++ b/Sources/TokamakCore/App/_AnyScene.swift
@@ -65,7 +65,8 @@ public struct _AnyScene: Scene {
       typeConstructorName = TokamakCore.typeConstructorName(type)
     }
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverScene("_AnyScene")
   }

--- a/Sources/TokamakCore/App/_TupleScene.swift
+++ b/Sources/TokamakCore/App/_TupleScene.swift
@@ -23,7 +23,7 @@ struct _TupleScene<T>: Scene, GroupScene {
     self.value = value
     self.children = children
   }
-    
+
   var body: Never {
     neverScene("_TupleScene")
   }

--- a/Sources/TokamakCore/App/_TupleScene.swift
+++ b/Sources/TokamakCore/App/_TupleScene.swift
@@ -23,7 +23,8 @@ struct _TupleScene<T>: Scene, GroupScene {
     self.value = value
     self.children = children
   }
-
+    
+  @_spi(TokamakCore)
   var body: Never {
     neverScene("_TupleScene")
   }

--- a/Sources/TokamakCore/App/_TupleScene.swift
+++ b/Sources/TokamakCore/App/_TupleScene.swift
@@ -24,7 +24,6 @@ struct _TupleScene<T>: Scene, GroupScene {
     self.children = children
   }
     
-  @_spi(TokamakCore)
   var body: Never {
     neverScene("_TupleScene")
   }

--- a/Sources/TokamakCore/Modifiers/LifecycleModifier.swift
+++ b/Sources/TokamakCore/Modifiers/LifecycleModifier.swift
@@ -14,10 +14,12 @@
 
 // FIXME: these should have standalone implementations
 public extension View {
+  @_spi(TokamakCore)
   func _onMount(perform action: (() -> ())? = nil) -> some View {
     modifier(_AppearanceActionModifier(appear: action))
   }
 
+  @_spi(TokamakCore)
   func _onUnmount(perform action: (() -> ())? = nil) -> some View {
     modifier(_AppearanceActionModifier(disappear: action))
   }

--- a/Sources/TokamakCore/Preferences/PreferenceKey.swift
+++ b/Sources/TokamakCore/Preferences/PreferenceKey.swift
@@ -96,12 +96,6 @@ public protocol _PreferenceWritingModifierProtocol: ViewModifier
   func body(_ content: Self.Content, with preferenceStore: inout _PreferenceStore) -> AnyView
 }
 
-public extension _PreferenceWritingViewProtocol where Self: View {
-  var body: Never {
-    neverBody(String(describing: Self.self))
-  }
-}
-
 public extension _PreferenceWritingModifierProtocol {
   func body(content: Content) -> AnyView {
     content.view

--- a/Sources/TokamakCore/Shapes/Path.swift
+++ b/Sources/TokamakCore/Shapes/Path.swift
@@ -25,7 +25,6 @@ import WASILibc
 
 /// The outline of a 2D shape.
 public struct Path: Equatable, LosslessStringConvertible {
-  @_spi(TokamakCore)
   public class _PathBox: Equatable {
     var elements: [Element] = []
     public static func == (lhs: Path._PathBox, rhs: Path._PathBox) -> Bool {

--- a/Sources/TokamakCore/Shapes/Path.swift
+++ b/Sources/TokamakCore/Shapes/Path.swift
@@ -25,6 +25,7 @@ import WASILibc
 
 /// The outline of a 2D shape.
 public struct Path: Equatable, LosslessStringConvertible {
+  @_spi(TokamakCore)
   public class _PathBox: Equatable {
     var elements: [Element] = []
     public static func == (lhs: Path._PathBox, rhs: Path._PathBox) -> Bool {

--- a/Sources/TokamakCore/Shapes/Shape.swift
+++ b/Sources/TokamakCore/Shapes/Shape.swift
@@ -46,7 +46,7 @@ public struct FillStyle: Equatable, ShapeStyle {
   }
 }
 
-public struct _ShapeView<Content, Style>: View where Content: Shape, Style: ShapeStyle {
+public struct _ShapeView<Content, Style>: PrimitiveView where Content: Shape, Style: ShapeStyle {
   @Environment(\.self) public var environment
   @Environment(\.foregroundColor) public var foregroundColor
   public var shape: Content
@@ -57,11 +57,6 @@ public struct _ShapeView<Content, Style>: View where Content: Shape, Style: Shap
     self.shape = shape
     self.style = style
     self.fillStyle = fillStyle
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("_ShapeView")
   }
 }
 

--- a/Sources/TokamakCore/Shapes/Shape.swift
+++ b/Sources/TokamakCore/Shapes/Shape.swift
@@ -58,7 +58,8 @@ public struct _ShapeView<Content, Style>: View where Content: Shape, Style: Shap
     self.style = style
     self.fillStyle = fillStyle
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("_ShapeView")
   }

--- a/Sources/TokamakCore/Shapes/Shape.swift
+++ b/Sources/TokamakCore/Shapes/Shape.swift
@@ -58,7 +58,7 @@ public struct _ShapeView<Content, Style>: View where Content: Shape, Style: Shap
     self.style = style
     self.fillStyle = fillStyle
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("_ShapeView")

--- a/Sources/TokamakCore/State/TargetRef.swift
+++ b/Sources/TokamakCore/State/TargetRef.swift
@@ -33,6 +33,7 @@ public struct _TargetRef<V: View, T>: View, TargetRefType {
 public extension View {
   /** Allows capturing target instance of aclosest descendant host view. The resulting instance
    is written to a given `binding`. */
+  @_spi(TokamakCore)
   func _targetRef<T: Target>(_ binding: Binding<T?>) -> _TargetRef<Self, T> {
     .init(binding: binding, view: self)
   }

--- a/Sources/TokamakCore/Styles/ButtonStyle.swift
+++ b/Sources/TokamakCore/Styles/ButtonStyle.swift
@@ -17,6 +17,8 @@
 public struct ButtonStyleConfiguration {
   public struct Label: View {
     let content: AnyView
+    
+    @_spi(TokamakCore)
     public var body: Never {
       neverBody("ButtonStyleConfiguration.Label")
     }
@@ -34,6 +36,7 @@ public struct DefaultButtonStyle: ButtonStyle {
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
+@_spi(TokamakCore)
 public struct _ButtonStyleConfigurationProxy {
   public struct Label {
     public typealias Subject = ButtonStyleConfiguration.Label

--- a/Sources/TokamakCore/Styles/ButtonStyle.swift
+++ b/Sources/TokamakCore/Styles/ButtonStyle.swift
@@ -17,7 +17,7 @@
 public struct ButtonStyleConfiguration {
   public struct Label: View {
     let content: AnyView
-    
+
     @_spi(TokamakCore)
     public var body: Never {
       neverBody("ButtonStyleConfiguration.Label")

--- a/Sources/TokamakCore/Styles/ButtonStyle.swift
+++ b/Sources/TokamakCore/Styles/ButtonStyle.swift
@@ -36,7 +36,6 @@ public struct DefaultButtonStyle: ButtonStyle {
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
-@_spi(TokamakCore)
 public struct _ButtonStyleConfigurationProxy {
   public struct Label {
     public typealias Subject = ButtonStyleConfiguration.Label

--- a/Sources/TokamakCore/Styles/ButtonStyle.swift
+++ b/Sources/TokamakCore/Styles/ButtonStyle.swift
@@ -15,13 +15,8 @@
 //  Created by Gene Z. Ragan on 07/22/2020.
 
 public struct ButtonStyleConfiguration {
-  public struct Label: View {
+  public struct Label: PrimitiveView {
     let content: AnyView
-
-    @_spi(TokamakCore)
-    public var body: Never {
-      neverBody("ButtonStyleConfiguration.Label")
-    }
   }
 
   public let label: Label

--- a/Sources/TokamakCore/Styles/NavigationLinkStyle.swift
+++ b/Sources/TokamakCore/Styles/NavigationLinkStyle.swift
@@ -68,6 +68,7 @@ extension EnvironmentValues {
 }
 
 public extension View {
+  @_spi(TokamakCore)
   func _navigationLinkStyle<S: _NavigationLinkStyle>(_ style: S) -> some View {
     environment(\._navigationLinkStyle, _AnyNavigationLinkStyle(style))
   }

--- a/Sources/TokamakCore/Tokens/Color.swift
+++ b/Sources/TokamakCore/Tokens/Color.swift
@@ -345,6 +345,7 @@ public extension Color {
 
 extension Color: ShapeStyle {}
 extension Color: View {
+  @_spi(BubbleCore)
   public var body: some View {
     _ShapeView(shape: Rectangle(), style: self)
   }

--- a/Sources/TokamakCore/Tokens/Color.swift
+++ b/Sources/TokamakCore/Tokens/Color.swift
@@ -345,7 +345,7 @@ public extension Color {
 
 extension Color: ShapeStyle {}
 extension Color: View {
-  @_spi(BubbleCore)
+  @_spi(TokamakCore)
   public var body: some View {
     _ShapeView(shape: Rectangle(), style: self)
   }

--- a/Sources/TokamakCore/Tokens/Color.swift
+++ b/Sources/TokamakCore/Tokens/Color.swift
@@ -241,6 +241,7 @@ public struct Color: Hashable, Equatable {
   }
 
   /// Create a `Color` dependent on the current `ColorScheme`.
+  @_spi(TokamakCore)
   public static func _withScheme(_ resolver: @escaping (ColorScheme) -> Self) -> Self {
     .init(_EnvironmentDependentColorBox {
       resolver($0.colorScheme)

--- a/Sources/TokamakCore/Tokens/Font.swift
+++ b/Sources/TokamakCore/Tokens/Font.swift
@@ -33,6 +33,7 @@ public protocol AnyFontBoxDeferredToRenderer: AnyFontBox {
 }
 
 public class AnyFontBox: AnyTokenBox, Hashable, Equatable {
+  @_spi(TokamakCore)
   public struct _Font: Hashable, Equatable {
     public var _name: String
     public var _size: CGFloat

--- a/Sources/TokamakCore/Tokens/Font.swift
+++ b/Sources/TokamakCore/Tokens/Font.swift
@@ -33,7 +33,6 @@ public protocol AnyFontBoxDeferredToRenderer: AnyFontBox {
 }
 
 public class AnyFontBox: AnyTokenBox, Hashable, Equatable {
-  @_spi(TokamakCore)
   public struct _Font: Hashable, Equatable {
     public var _name: String
     public var _size: CGFloat

--- a/Sources/TokamakCore/Views/AnyView.swift
+++ b/Sources/TokamakCore/Views/AnyView.swift
@@ -16,7 +16,7 @@
 //
 
 /// A type-erased view.
-public struct AnyView: View {
+public struct AnyView: PrimitiveView {
   /// The type of the underlying `view`.
   let type: Any.Type
 
@@ -66,11 +66,6 @@ public struct AnyView: View {
         bodyClosure = { AnyView(($0 as! V).body) }
       }
     }
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("AnyView")
   }
 }
 

--- a/Sources/TokamakCore/Views/AnyView.swift
+++ b/Sources/TokamakCore/Views/AnyView.swift
@@ -67,7 +67,7 @@ public struct AnyView: View {
       }
     }
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("AnyView")

--- a/Sources/TokamakCore/Views/AnyView.swift
+++ b/Sources/TokamakCore/Views/AnyView.swift
@@ -67,7 +67,8 @@ public struct AnyView: View {
       }
     }
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("AnyView")
   }
@@ -80,6 +81,7 @@ public func mapAnyView<T, V>(_ anyView: AnyView, transform: (V) -> T) -> T? {
 }
 
 extension AnyView: ParentView {
+  @_spi(TokamakCore)
   public var children: [AnyView] {
     (view as? ParentView)?.children ?? []
   }

--- a/Sources/TokamakCore/Views/Buttons/Button.swift
+++ b/Sources/TokamakCore/Views/Buttons/Button.swift
@@ -57,7 +57,7 @@ public struct _Button<Label>: View where Label: View {
     self.label = label
     self.action = action
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("_Button")

--- a/Sources/TokamakCore/Views/Buttons/Button.swift
+++ b/Sources/TokamakCore/Views/Buttons/Button.swift
@@ -47,6 +47,7 @@ public struct Button<Label>: View where Label: View {
   }
 }
 
+@_spi(TokamakCore)
 public struct _Button<Label>: View where Label: View {
   public let label: Label
   public let action: () -> ()
@@ -57,7 +58,8 @@ public struct _Button<Label>: View where Label: View {
     self.label = label
     self.action = action
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("_Button")
   }
@@ -72,6 +74,7 @@ public extension Button where Label == Text {
 }
 
 extension Button: ParentView {
+  @_spi(TokamakCore)
   public var children: [AnyView] {
     (implementation.label as? GroupView)?.children ?? [AnyView(implementation.label)]
   }

--- a/Sources/TokamakCore/Views/Buttons/Button.swift
+++ b/Sources/TokamakCore/Views/Buttons/Button.swift
@@ -47,7 +47,6 @@ public struct Button<Label>: View where Label: View {
   }
 }
 
-@_spi(TokamakCore)
 public struct _Button<Label>: View where Label: View {
   public let label: Label
   public let action: () -> ()

--- a/Sources/TokamakCore/Views/Buttons/Button.swift
+++ b/Sources/TokamakCore/Views/Buttons/Button.swift
@@ -42,12 +42,13 @@ public struct Button<Label>: View where Label: View {
     implementation = _Button(action: action, label: label())
   }
 
+  @_spi(TomkamakCore)
   public var body: some View {
     implementation
   }
 }
 
-public struct _Button<Label>: View where Label: View {
+public struct _Button<Label>: PrimitiveView where Label: View {
   public let label: Label
   public let action: () -> ()
   @State public var isPressed = false
@@ -56,11 +57,6 @@ public struct _Button<Label>: View where Label: View {
   public init(action: @escaping () -> (), label: Label) {
     self.label = label
     self.action = action
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("_Button")
   }
 }
 

--- a/Sources/TokamakCore/Views/Buttons/Link.swift
+++ b/Sources/TokamakCore/Views/Buttons/Link.swift
@@ -24,7 +24,7 @@ public struct Link<Label>: View where Label: View {
   public init(destination: URL, @ViewBuilder label: () -> Label) {
     (self.destination, self.label) = (destination, label())
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("Link")

--- a/Sources/TokamakCore/Views/Buttons/Link.swift
+++ b/Sources/TokamakCore/Views/Buttons/Link.swift
@@ -17,17 +17,12 @@
 
 import struct Foundation.URL
 
-public struct Link<Label>: View where Label: View {
+public struct Link<Label>: PrimitiveView where Label: View {
   let destination: URL
   let label: Label
 
   public init(destination: URL, @ViewBuilder label: () -> Label) {
     (self.destination, self.label) = (destination, label())
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("Link")
   }
 }
 

--- a/Sources/TokamakCore/Views/Buttons/Link.swift
+++ b/Sources/TokamakCore/Views/Buttons/Link.swift
@@ -24,7 +24,8 @@ public struct Link<Label>: View where Label: View {
   public init(destination: URL, @ViewBuilder label: () -> Label) {
     (self.destination, self.label) = (destination, label())
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("Link")
   }
@@ -36,6 +37,7 @@ public extension Link where Label == Text {
   }
 }
 
+@_spi(TokamakCore)
 public struct _LinkProxy<Label> where Label: View {
   public let subject: Link<Label>
 

--- a/Sources/TokamakCore/Views/Buttons/Link.swift
+++ b/Sources/TokamakCore/Views/Buttons/Link.swift
@@ -37,7 +37,6 @@ public extension Link where Label == Text {
   }
 }
 
-@_spi(TokamakCore)
 public struct _LinkProxy<Label> where Label: View {
   public let subject: Link<Label>
 

--- a/Sources/TokamakCore/Views/Containers/DisclosureGroup.swift
+++ b/Sources/TokamakCore/Views/Containers/DisclosureGroup.swift
@@ -39,7 +39,7 @@ public struct DisclosureGroup<Label, Content>: View where Label: View, Content: 
     self.label = label()
     self.content = content
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("DisclosureGroup")

--- a/Sources/TokamakCore/Views/Containers/DisclosureGroup.swift
+++ b/Sources/TokamakCore/Views/Containers/DisclosureGroup.swift
@@ -39,7 +39,8 @@ public struct DisclosureGroup<Label, Content>: View where Label: View, Content: 
     self.label = label()
     self.content = content
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("DisclosureGroup")
   }
@@ -70,6 +71,7 @@ public extension DisclosureGroup where Label == Text {
   }
 }
 
+@_spi(TokamakCore)
 public struct _DisclosureGroupProxy<Label, Content>
   where Label: View, Content: View
 {

--- a/Sources/TokamakCore/Views/Containers/DisclosureGroup.swift
+++ b/Sources/TokamakCore/Views/Containers/DisclosureGroup.swift
@@ -71,7 +71,6 @@ public extension DisclosureGroup where Label == Text {
   }
 }
 
-@_spi(TokamakCore)
 public struct _DisclosureGroupProxy<Label, Content>
   where Label: View, Content: View
 {

--- a/Sources/TokamakCore/Views/Containers/DisclosureGroup.swift
+++ b/Sources/TokamakCore/Views/Containers/DisclosureGroup.swift
@@ -15,7 +15,7 @@
 //  Created by Carson Katri on 7/3/20.
 //
 
-public struct DisclosureGroup<Label, Content>: View where Label: View, Content: View {
+public struct DisclosureGroup<Label, Content>: PrimitiveView where Label: View, Content: View {
   @State var isExpanded: Bool = false
   let isExpandedBinding: Binding<Bool>?
 
@@ -38,11 +38,6 @@ public struct DisclosureGroup<Label, Content>: View where Label: View, Content: 
     isExpandedBinding = isExpanded
     self.label = label()
     self.content = content
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("DisclosureGroup")
   }
 }
 

--- a/Sources/TokamakCore/Views/Containers/ForEach.swift
+++ b/Sources/TokamakCore/Views/Containers/ForEach.swift
@@ -47,7 +47,7 @@ public struct ForEach<Data, ID, Content>: View where Data: RandomAccessCollectio
     self.id = id
     self.content = content
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("ForEach")

--- a/Sources/TokamakCore/Views/Containers/ForEach.swift
+++ b/Sources/TokamakCore/Views/Containers/ForEach.swift
@@ -31,7 +31,8 @@ protocol ForEachProtocol: GroupView {
 ///         Text("\($0)")
 ///       }
 ///     }
-public struct ForEach<Data, ID, Content>: View where Data: RandomAccessCollection, ID: Hashable,
+public struct ForEach<Data, ID, Content>: PrimitiveView where Data: RandomAccessCollection,
+  ID: Hashable,
   Content: View
 {
   let data: Data
@@ -46,11 +47,6 @@ public struct ForEach<Data, ID, Content>: View where Data: RandomAccessCollectio
     self.data = data
     self.id = id
     self.content = content
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("ForEach")
   }
 }
 

--- a/Sources/TokamakCore/Views/Containers/ForEach.swift
+++ b/Sources/TokamakCore/Views/Containers/ForEach.swift
@@ -47,7 +47,8 @@ public struct ForEach<Data, ID, Content>: View where Data: RandomAccessCollectio
     self.id = id
     self.content = content
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("ForEach")
   }
@@ -79,6 +80,7 @@ public extension ForEach where Data == Range<Int>, ID == Int {
 }
 
 extension ForEach: ParentView {
+  @_spi(TokamakCore)
   public var children: [AnyView] {
     data.map { AnyView(IDView(content($0), id: $0[keyPath: id])) }
   }
@@ -101,6 +103,7 @@ public extension EnvironmentValues {
   }
 }
 
+@_spi(TokamakCore)
 public protocol _AnyIDView {
   var anyId: AnyHashable { get }
   var anyContent: AnyView { get }

--- a/Sources/TokamakCore/Views/Containers/ForEach.swift
+++ b/Sources/TokamakCore/Views/Containers/ForEach.swift
@@ -103,7 +103,6 @@ public extension EnvironmentValues {
   }
 }
 
-@_spi(TokamakCore)
 public protocol _AnyIDView {
   var anyId: AnyHashable { get }
   var anyContent: AnyView { get }

--- a/Sources/TokamakCore/Views/Containers/Group.swift
+++ b/Sources/TokamakCore/Views/Containers/Group.swift
@@ -20,12 +20,14 @@ public struct Group<Content> {
 }
 
 extension Group: View where Content: View {
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("Group")
   }
 }
 
 extension Group: ParentView where Content: View {
+  @_spi(TokamakCore)
   public var children: [AnyView] { (content as? ParentView)?.children ?? [AnyView(content)] }
 }
 

--- a/Sources/TokamakCore/Views/Containers/Group.swift
+++ b/Sources/TokamakCore/Views/Containers/Group.swift
@@ -19,12 +19,7 @@ public struct Group<Content> {
   }
 }
 
-extension Group: View where Content: View {
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("Group")
-  }
-}
+extension Group: PrimitiveView & View where Content: View {}
 
 extension Group: ParentView where Content: View {
   @_spi(TokamakCore)

--- a/Sources/TokamakCore/Views/Containers/List.swift
+++ b/Sources/TokamakCore/Views/Containers/List.swift
@@ -18,7 +18,6 @@
 public struct List<SelectionValue, Content>: View
   where SelectionValue: Hashable, Content: View
 {
-  @_spi(TokamakCore)
   public enum _Selection {
     case one(Binding<SelectionValue?>?)
     case many(Binding<Set<SelectionValue>>?)
@@ -121,7 +120,6 @@ public enum _ListRow {
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
-@_spi(TokamakCore)
 public struct _ListProxy<SelectionValue, Content>
   where SelectionValue: Hashable, Content: View
 {

--- a/Sources/TokamakCore/Views/Containers/List.swift
+++ b/Sources/TokamakCore/Views/Containers/List.swift
@@ -18,6 +18,7 @@
 public struct List<SelectionValue, Content>: View
   where SelectionValue: Hashable, Content: View
 {
+  @_spi(TokamakCore)
   public enum _Selection {
     case one(Binding<SelectionValue?>?)
     case many(Binding<Set<SelectionValue>>?)
@@ -120,6 +121,7 @@ public enum _ListRow {
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
+@_spi(TokamakCore)
 public struct _ListProxy<SelectionValue, Content>
   where SelectionValue: Hashable, Content: View
 {

--- a/Sources/TokamakCore/Views/Containers/List.swift
+++ b/Sources/TokamakCore/Views/Containers/List.swift
@@ -78,6 +78,7 @@ public struct List<SelectionValue, Content>: View
     }
   }
 
+  @_spi(TokamakCore)
   public var body: some View {
     if let style = style as? ListStyleDeferredToRenderer {
       style.listBody(ScrollView {

--- a/Sources/TokamakCore/Views/Containers/OutlineGroup.swift
+++ b/Sources/TokamakCore/Views/Containers/OutlineGroup.swift
@@ -86,6 +86,7 @@ public extension OutlineGroup where Parent: View,
 }
 
 extension OutlineGroup: View where Parent: View, Leaf: View, Subgroup: View {
+  @_spi(TokamakCore)
   public var body: some View {
     switch root {
     case let .collection(data):
@@ -124,6 +125,7 @@ extension OutlineGroup: View where Parent: View, Leaf: View, Subgroup: View {
 public struct OutlineSubgroupChildren: View {
   let children: () -> AnyView
 
+  @_spi(TokamakCore)
   public var body: some View {
     children()
   }

--- a/Sources/TokamakCore/Views/Containers/Section.swift
+++ b/Sources/TokamakCore/Views/Containers/Section.swift
@@ -33,6 +33,7 @@ extension Section: View, SectionView where Parent: View, Content: View, Footer: 
   }
 
   @ViewBuilder
+  @_spi(TokamakCore)
   public var body: TupleView<(Parent, Content, Footer)> {
     header
     content

--- a/Sources/TokamakCore/Views/Containers/TupleView.swift
+++ b/Sources/TokamakCore/Views/Containers/TupleView.swift
@@ -19,6 +19,7 @@
 ///
 /// Mainly for use with `@ViewBuilder`.
 public struct TupleView<T>: View {
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("TupleView")
   }

--- a/Sources/TokamakCore/Views/Containers/TupleView.swift
+++ b/Sources/TokamakCore/Views/Containers/TupleView.swift
@@ -18,12 +18,7 @@
 /// A `View` created from a `Tuple` of `View` values.
 ///
 /// Mainly for use with `@ViewBuilder`.
-public struct TupleView<T>: View {
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("TupleView")
-  }
-
+public struct TupleView<T>: PrimitiveView {
   public let value: T
 
   let _children: [AnyView]

--- a/Sources/TokamakCore/Views/Image.swift
+++ b/Sources/TokamakCore/Views/Image.swift
@@ -17,7 +17,7 @@
 
 import Foundation
 
-public struct Image: View {
+public struct Image: PrimitiveView {
   let label: Text?
   let name: String
   let bundle: Bundle?
@@ -38,11 +38,6 @@ public struct Image: View {
     label = nil
     self.name = name
     self.bundle = bundle
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("Image")
   }
 }
 

--- a/Sources/TokamakCore/Views/Image.swift
+++ b/Sources/TokamakCore/Views/Image.swift
@@ -39,7 +39,7 @@ public struct Image: View {
     self.name = name
     self.bundle = bundle
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("Image")

--- a/Sources/TokamakCore/Views/Image.swift
+++ b/Sources/TokamakCore/Views/Image.swift
@@ -47,7 +47,6 @@ public struct Image: View {
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
-@_spi(TokamakCore)
 public struct _ImageProxy {
   public let subject: Image
 

--- a/Sources/TokamakCore/Views/Image.swift
+++ b/Sources/TokamakCore/Views/Image.swift
@@ -39,13 +39,15 @@ public struct Image: View {
     self.name = name
     self.bundle = bundle
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("Image")
   }
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
+@_spi(TokamakCore)
 public struct _ImageProxy {
   public let subject: Image
 

--- a/Sources/TokamakCore/Views/Layout/GeometryReader.swift
+++ b/Sources/TokamakCore/Views/Layout/GeometryReader.swift
@@ -40,14 +40,9 @@ public func makeProxy(from size: CGSize) -> GeometryProxy {
 //   public subscript<T>(anchor: Anchor<T>) -> T {}
 // }
 
-public struct GeometryReader<Content>: View where Content: View {
+public struct GeometryReader<Content>: PrimitiveView where Content: View {
   public let content: (GeometryProxy) -> Content
   public init(@ViewBuilder content: @escaping (GeometryProxy) -> Content) {
     self.content = content
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("GeometryReader")
   }
 }

--- a/Sources/TokamakCore/Views/Layout/GeometryReader.swift
+++ b/Sources/TokamakCore/Views/Layout/GeometryReader.swift
@@ -46,6 +46,7 @@ public struct GeometryReader<Content>: View where Content: View {
     self.content = content
   }
 
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("GeometryReader")
   }

--- a/Sources/TokamakCore/Views/Layout/HStack.swift
+++ b/Sources/TokamakCore/Views/Layout/HStack.swift
@@ -42,7 +42,7 @@ public struct HStack<Content>: View where Content: View {
     self.spacing = spacing
     self.content = content()
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("HStack")

--- a/Sources/TokamakCore/Views/Layout/HStack.swift
+++ b/Sources/TokamakCore/Views/Layout/HStack.swift
@@ -42,13 +42,15 @@ public struct HStack<Content>: View where Content: View {
     self.spacing = spacing
     self.content = content()
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("HStack")
   }
 }
 
 extension HStack: ParentView {
+  @_spi(TokamakCore)
   public var children: [AnyView] {
     (content as? GroupView)?.children ?? [AnyView(content)]
   }

--- a/Sources/TokamakCore/Views/Layout/HStack.swift
+++ b/Sources/TokamakCore/Views/Layout/HStack.swift
@@ -28,7 +28,7 @@ public enum VerticalAlignment: Equatable {
 ///       Text("Hello")
 ///       Text("World")
 ///     }
-public struct HStack<Content>: View where Content: View {
+public struct HStack<Content>: PrimitiveView where Content: View {
   public let alignment: VerticalAlignment
   public let spacing: CGFloat?
   public let content: Content
@@ -41,11 +41,6 @@ public struct HStack<Content>: View where Content: View {
     self.alignment = alignment
     self.spacing = spacing
     self.content = content()
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("HStack")
   }
 }
 

--- a/Sources/TokamakCore/Views/Layout/LazyHGrid.swift
+++ b/Sources/TokamakCore/Views/Layout/LazyHGrid.swift
@@ -35,7 +35,7 @@ public struct LazyHGrid<Content>: View where Content: View {
     self.pinnedViews = pinnedViews
     self.content = content()
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("LazyVGrid")

--- a/Sources/TokamakCore/Views/Layout/LazyHGrid.swift
+++ b/Sources/TokamakCore/Views/Layout/LazyHGrid.swift
@@ -15,7 +15,7 @@
 //  Created by Carson Katri on 7/13/20.
 //
 
-public struct LazyHGrid<Content>: View where Content: View {
+public struct LazyHGrid<Content>: PrimitiveView where Content: View {
   let rows: [GridItem]
   let alignment: VerticalAlignment
   let spacing: CGFloat
@@ -34,11 +34,6 @@ public struct LazyHGrid<Content>: View where Content: View {
     self.spacing = spacing ?? 8
     self.pinnedViews = pinnedViews
     self.content = content()
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("LazyVGrid")
   }
 }
 

--- a/Sources/TokamakCore/Views/Layout/LazyHGrid.swift
+++ b/Sources/TokamakCore/Views/Layout/LazyHGrid.swift
@@ -35,7 +35,8 @@ public struct LazyHGrid<Content>: View where Content: View {
     self.pinnedViews = pinnedViews
     self.content = content()
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("LazyVGrid")
   }

--- a/Sources/TokamakCore/Views/Layout/LazyVGrid.swift
+++ b/Sources/TokamakCore/Views/Layout/LazyVGrid.swift
@@ -35,12 +35,14 @@ public struct LazyVGrid<Content>: View where Content: View {
     self.pinnedViews = pinnedViews
     self.content = content()
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("LazyVGrid")
   }
 }
 
+@_spi(TokamakCore)
 public struct _LazyVGridProxy<Content> where Content: View {
   public let subject: LazyVGrid<Content>
 

--- a/Sources/TokamakCore/Views/Layout/LazyVGrid.swift
+++ b/Sources/TokamakCore/Views/Layout/LazyVGrid.swift
@@ -35,7 +35,7 @@ public struct LazyVGrid<Content>: View where Content: View {
     self.pinnedViews = pinnedViews
     self.content = content()
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("LazyVGrid")

--- a/Sources/TokamakCore/Views/Layout/LazyVGrid.swift
+++ b/Sources/TokamakCore/Views/Layout/LazyVGrid.swift
@@ -42,7 +42,6 @@ public struct LazyVGrid<Content>: View where Content: View {
   }
 }
 
-@_spi(TokamakCore)
 public struct _LazyVGridProxy<Content> where Content: View {
   public let subject: LazyVGrid<Content>
 

--- a/Sources/TokamakCore/Views/Layout/LazyVGrid.swift
+++ b/Sources/TokamakCore/Views/Layout/LazyVGrid.swift
@@ -15,7 +15,7 @@
 //  Created by Carson Katri on 7/13/20.
 //
 
-public struct LazyVGrid<Content>: View where Content: View {
+public struct LazyVGrid<Content>: PrimitiveView where Content: View {
   let columns: [GridItem]
   let alignment: HorizontalAlignment
   let spacing: CGFloat
@@ -34,11 +34,6 @@ public struct LazyVGrid<Content>: View where Content: View {
     self.spacing = spacing ?? 8
     self.pinnedViews = pinnedViews
     self.content = content()
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("LazyVGrid")
   }
 }
 

--- a/Sources/TokamakCore/Views/Layout/ScrollView.swift
+++ b/Sources/TokamakCore/Views/Layout/ScrollView.swift
@@ -49,13 +49,15 @@ public struct ScrollView<Content>: View where Content: View {
     self.showsIndicators = showsIndicators
     self.content = content()
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("ScrollView")
   }
 }
 
 extension ScrollView: ParentView {
+  @_spi(TokamakCore)
   public var children: [AnyView] {
     (content as? GroupView)?.children ?? [AnyView(content)]
   }

--- a/Sources/TokamakCore/Views/Layout/ScrollView.swift
+++ b/Sources/TokamakCore/Views/Layout/ScrollView.swift
@@ -35,7 +35,7 @@
 ///         Text("\($0)")
 ///       }
 ///     }
-public struct ScrollView<Content>: View where Content: View {
+public struct ScrollView<Content>: PrimitiveView where Content: View {
   public let content: Content
   public let axes: Axis.Set
   public let showsIndicators: Bool
@@ -48,11 +48,6 @@ public struct ScrollView<Content>: View where Content: View {
     self.axes = axes
     self.showsIndicators = showsIndicators
     self.content = content()
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("ScrollView")
   }
 }
 

--- a/Sources/TokamakCore/Views/Layout/ScrollView.swift
+++ b/Sources/TokamakCore/Views/Layout/ScrollView.swift
@@ -49,7 +49,7 @@ public struct ScrollView<Content>: View where Content: View {
     self.showsIndicators = showsIndicators
     self.content = content()
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("ScrollView")

--- a/Sources/TokamakCore/Views/Layout/VStack.swift
+++ b/Sources/TokamakCore/Views/Layout/VStack.swift
@@ -39,13 +39,15 @@ public struct VStack<Content>: View where Content: View {
     self.spacing = spacing
     self.content = content()
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("VStack")
   }
 }
 
 extension VStack: ParentView {
+  @_spi(TokamakCore)
   public var children: [AnyView] {
     (content as? GroupView)?.children ?? [AnyView(content)]
   }

--- a/Sources/TokamakCore/Views/Layout/VStack.swift
+++ b/Sources/TokamakCore/Views/Layout/VStack.swift
@@ -25,7 +25,7 @@ public enum HorizontalAlignment: Equatable {
 ///       Text("Hello")
 ///       Text("World")
 ///     }
-public struct VStack<Content>: View where Content: View {
+public struct VStack<Content>: PrimitiveView where Content: View {
   public let alignment: HorizontalAlignment
   public let spacing: CGFloat?
   public let content: Content
@@ -38,11 +38,6 @@ public struct VStack<Content>: View where Content: View {
     self.alignment = alignment
     self.spacing = spacing
     self.content = content()
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("VStack")
   }
 }
 

--- a/Sources/TokamakCore/Views/Layout/VStack.swift
+++ b/Sources/TokamakCore/Views/Layout/VStack.swift
@@ -39,7 +39,7 @@ public struct VStack<Content>: View where Content: View {
     self.spacing = spacing
     self.content = content()
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("VStack")

--- a/Sources/TokamakCore/Views/Layout/ZStack.swift
+++ b/Sources/TokamakCore/Views/Layout/ZStack.swift
@@ -57,13 +57,15 @@ public struct ZStack<Content>: View where Content: View {
     self.spacing = spacing
     self.content = content()
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("ZStack")
   }
 }
 
 extension ZStack: ParentView {
+  @_spi(TokamakCore)
   public var children: [AnyView] {
     (content as? GroupView)?.children ?? [AnyView(content)]
   }

--- a/Sources/TokamakCore/Views/Layout/ZStack.swift
+++ b/Sources/TokamakCore/Views/Layout/ZStack.swift
@@ -43,7 +43,7 @@ public struct Alignment: Equatable {
 ///       Text("Top")
 ///     }
 ///
-public struct ZStack<Content>: View where Content: View {
+public struct ZStack<Content>: PrimitiveView where Content: View {
   public let alignment: Alignment
   public let spacing: CGFloat?
   public let content: Content
@@ -56,11 +56,6 @@ public struct ZStack<Content>: View where Content: View {
     self.alignment = alignment
     self.spacing = spacing
     self.content = content()
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("ZStack")
   }
 }
 

--- a/Sources/TokamakCore/Views/Layout/ZStack.swift
+++ b/Sources/TokamakCore/Views/Layout/ZStack.swift
@@ -57,7 +57,7 @@ public struct ZStack<Content>: View where Content: View {
     self.spacing = spacing
     self.content = content()
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("ZStack")

--- a/Sources/TokamakCore/Views/Navigation/NavigationLink.swift
+++ b/Sources/TokamakCore/Views/Navigation/NavigationLink.swift
@@ -44,7 +44,8 @@ public struct NavigationLink<Label, Destination>: View where Label: View, Destin
   //    tag: V, selection: Binding<V?>,
   //    @ViewBuilder label: () -> Label
   //   ) where V : Hashable
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("NavigationLink")
   }
@@ -73,6 +74,7 @@ public extension NavigationLink where Label == Text {
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
+@_spi(TokamakCore)
 public struct _NavigationLinkProxy<Label, Destination> where Label: View, Destination: View {
   public let subject: NavigationLink<Label, Destination>
 

--- a/Sources/TokamakCore/Views/Navigation/NavigationLink.swift
+++ b/Sources/TokamakCore/Views/Navigation/NavigationLink.swift
@@ -44,7 +44,7 @@ public struct NavigationLink<Label, Destination>: View where Label: View, Destin
   //    tag: V, selection: Binding<V?>,
   //    @ViewBuilder label: () -> Label
   //   ) where V : Hashable
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("NavigationLink")

--- a/Sources/TokamakCore/Views/Navigation/NavigationLink.swift
+++ b/Sources/TokamakCore/Views/Navigation/NavigationLink.swift
@@ -74,7 +74,6 @@ public extension NavigationLink where Label == Text {
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
-@_spi(TokamakCore)
 public struct _NavigationLinkProxy<Label, Destination> where Label: View, Destination: View {
   public let subject: NavigationLink<Label, Destination>
 

--- a/Sources/TokamakCore/Views/Navigation/NavigationLink.swift
+++ b/Sources/TokamakCore/Views/Navigation/NavigationLink.swift
@@ -22,7 +22,9 @@ final class NavigationLinkDestination {
   }
 }
 
-public struct NavigationLink<Label, Destination>: View where Label: View, Destination: View {
+public struct NavigationLink<Label, Destination>: PrimitiveView where Label: View,
+  Destination: View
+{
   @State var destination: NavigationLinkDestination
   let label: Label
 
@@ -44,11 +46,6 @@ public struct NavigationLink<Label, Destination>: View where Label: View, Destin
   //    tag: V, selection: Binding<V?>,
   //    @ViewBuilder label: () -> Label
   //   ) where V : Hashable
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("NavigationLink")
-  }
 }
 
 public extension NavigationLink where Label == Text {

--- a/Sources/TokamakCore/Views/Navigation/NavigationView.swift
+++ b/Sources/TokamakCore/Views/Navigation/NavigationView.swift
@@ -27,13 +27,15 @@ public struct NavigationView<Content>: View where Content: View {
   public init(@ViewBuilder content: () -> Content) {
     self.content = content()
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("NavigationView")
   }
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
+@_spi(TokamakCore)
 public struct _NavigationViewProxy<Content: View> {
   public let subject: NavigationView<Content>
 

--- a/Sources/TokamakCore/Views/Navigation/NavigationView.swift
+++ b/Sources/TokamakCore/Views/Navigation/NavigationView.swift
@@ -19,18 +19,13 @@ public final class NavigationContext: ObservableObject {
   @Published var destination = NavigationLinkDestination(EmptyView())
 }
 
-public struct NavigationView<Content>: View where Content: View {
+public struct NavigationView<Content>: PrimitiveView where Content: View {
   let content: Content
 
   @StateObject var context = NavigationContext()
 
   public init(@ViewBuilder content: () -> Content) {
     self.content = content()
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("NavigationView")
   }
 }
 

--- a/Sources/TokamakCore/Views/Navigation/NavigationView.swift
+++ b/Sources/TokamakCore/Views/Navigation/NavigationView.swift
@@ -35,7 +35,6 @@ public struct NavigationView<Content>: View where Content: View {
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
-@_spi(TokamakCore)
 public struct _NavigationViewProxy<Content: View> {
   public let subject: NavigationView<Content>
 

--- a/Sources/TokamakCore/Views/Navigation/NavigationView.swift
+++ b/Sources/TokamakCore/Views/Navigation/NavigationView.swift
@@ -27,7 +27,7 @@ public struct NavigationView<Content>: View where Content: View {
   public init(@ViewBuilder content: () -> Content) {
     self.content = content()
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("NavigationView")

--- a/Sources/TokamakCore/Views/Selectors/Picker.swift
+++ b/Sources/TokamakCore/Views/Selectors/Picker.swift
@@ -36,7 +36,7 @@ public struct _PickerContainer<Label: View, SelectionValue: Hashable, Content: V
     self.elements = elements
     self.content = content()
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("_PickerLabel")
@@ -47,7 +47,7 @@ public struct _PickerElement: View {
   public let valueIndex: Int?
   public let content: AnyView
   @Environment(\.pickerStyle) public var style
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("_PickerElement")
@@ -125,4 +125,3 @@ extension Picker: _PickerContainerProtocol {
     // .map(\.children) ?? []
   }
 }
-

--- a/Sources/TokamakCore/Views/Selectors/Picker.swift
+++ b/Sources/TokamakCore/Views/Selectors/Picker.swift
@@ -16,7 +16,7 @@ public protocol _PickerContainerProtocol {
   var elements: [_AnyIDView] { get }
 }
 
-public struct _PickerContainer<Label: View, SelectionValue: Hashable, Content: View>: View,
+public struct _PickerContainer<Label: View, SelectionValue: Hashable, Content: View>: PrimitiveView,
   _PickerContainerProtocol
 {
   @Binding public var selection: SelectionValue
@@ -36,22 +36,12 @@ public struct _PickerContainer<Label: View, SelectionValue: Hashable, Content: V
     self.elements = elements
     self.content = content()
   }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("_PickerLabel")
-  }
 }
 
-public struct _PickerElement: View {
+public struct _PickerElement: PrimitiveView {
   public let valueIndex: Int?
   public let content: AnyView
   @Environment(\.pickerStyle) public var style
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("_PickerElement")
-  }
 }
 
 public struct Picker<Label: View, SelectionValue: Hashable, Content: View>: View {
@@ -69,6 +59,7 @@ public struct Picker<Label: View, SelectionValue: Hashable, Content: View>: View
     self.content = content()
   }
 
+  @_spi(TokamakCore)
   public var body: some View {
     let children = self.children
 

--- a/Sources/TokamakCore/Views/Selectors/Picker.swift
+++ b/Sources/TokamakCore/Views/Selectors/Picker.swift
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@_spi(TokamakCore)
 public protocol _PickerContainerProtocol {
   var elements: [_AnyIDView] { get }
 }
 
+@_spi(TokamakCore)
 public struct _PickerContainer<Label: View, SelectionValue: Hashable, Content: View>: View,
   _PickerContainerProtocol
 {
@@ -36,17 +38,20 @@ public struct _PickerContainer<Label: View, SelectionValue: Hashable, Content: V
     self.elements = elements
     self.content = content()
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("_PickerLabel")
   }
 }
 
+@_spi(TokamakCore)
 public struct _PickerElement: View {
   public let valueIndex: Int?
   public let content: AnyView
   @Environment(\.pickerStyle) public var style
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("_PickerElement")
   }
@@ -105,12 +110,14 @@ public extension Picker where Label == Text {
 }
 
 extension Picker: ParentView {
+  @_spi(TokamakCore)
   public var children: [AnyView] {
     (content as? GroupView)?.children ?? [AnyView(content)]
   }
 }
 
 extension Picker: _PickerContainerProtocol {
+  @_spi(TokamakCore)
   public var elements: [_AnyIDView] {
     (content as? ForEachProtocol)?.children
       .compactMap {

--- a/Sources/TokamakCore/Views/Selectors/Picker.swift
+++ b/Sources/TokamakCore/Views/Selectors/Picker.swift
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@_spi(TokamakCore)
 public protocol _PickerContainerProtocol {
   var elements: [_AnyIDView] { get }
 }
 
-@_spi(TokamakCore)
 public struct _PickerContainer<Label: View, SelectionValue: Hashable, Content: View>: View,
   _PickerContainerProtocol
 {
@@ -45,7 +43,6 @@ public struct _PickerContainer<Label: View, SelectionValue: Hashable, Content: V
   }
 }
 
-@_spi(TokamakCore)
 public struct _PickerElement: View {
   public let valueIndex: Int?
   public let content: AnyView
@@ -116,6 +113,7 @@ extension Picker: ParentView {
   }
 }
 
+@_spi(TokamakCore)
 extension Picker: _PickerContainerProtocol {
   @_spi(TokamakCore)
   public var elements: [_AnyIDView] {
@@ -127,3 +125,4 @@ extension Picker: _PickerContainerProtocol {
     // .map(\.children) ?? []
   }
 }
+

--- a/Sources/TokamakCore/Views/Selectors/Slider.swift
+++ b/Sources/TokamakCore/Views/Selectors/Slider.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@_spi(TokamakCore)
 public enum _SliderStep {
   case any
   case discrete(Double.Stride)
@@ -155,7 +154,6 @@ extension Slider: ParentView {
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
-@_spi(TokamakCore)
 public struct _SliderProxy<Label, ValueLabel> where Label: View, ValueLabel: View {
   public let subject: Slider<Label, ValueLabel>
 

--- a/Sources/TokamakCore/Views/Selectors/Slider.swift
+++ b/Sources/TokamakCore/Views/Selectors/Slider.swift
@@ -28,7 +28,7 @@ private func convert<T: BinaryFloatingPoint>(_ range: ClosedRange<T>) -> ClosedR
 /// A control for selecting a value from a bounded linear range of values.
 ///
 /// Available when `Label` and `ValueLabel` conform to `View`.
-public struct Slider<Label, ValueLabel>: View where Label: View, ValueLabel: View {
+public struct Slider<Label, ValueLabel>: PrimitiveView where Label: View, ValueLabel: View {
   let label: Label
   let minValueLabel: ValueLabel
   let maxValueLabel: ValueLabel
@@ -36,11 +36,6 @@ public struct Slider<Label, ValueLabel>: View where Label: View, ValueLabel: Vie
   let bounds: ClosedRange<Double>
   let step: _SliderStep
   let onEditingChanged: (Bool) -> ()
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("Slider")
-  }
 }
 
 public extension Slider where Label == EmptyView, ValueLabel == EmptyView {

--- a/Sources/TokamakCore/Views/Selectors/Slider.swift
+++ b/Sources/TokamakCore/Views/Selectors/Slider.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@_spi(TokamakCore)
 public enum _SliderStep {
   case any
   case discrete(Double.Stride)
@@ -36,7 +37,8 @@ public struct Slider<Label, ValueLabel>: View where Label: View, ValueLabel: Vie
   let bounds: ClosedRange<Double>
   let step: _SliderStep
   let onEditingChanged: (Bool) -> ()
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("Slider")
   }
@@ -144,6 +146,7 @@ public extension Slider {
 }
 
 extension Slider: ParentView {
+  @_spi(TokamakCore)
   public var children: [AnyView] {
     ((label as? GroupView)?.children ?? [AnyView(label)])
       + ((minValueLabel as? GroupView)?.children ?? [AnyView(minValueLabel)])
@@ -152,6 +155,7 @@ extension Slider: ParentView {
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
+@_spi(TokamakCore)
 public struct _SliderProxy<Label, ValueLabel> where Label: View, ValueLabel: View {
   public let subject: Slider<Label, ValueLabel>
 

--- a/Sources/TokamakCore/Views/Selectors/Slider.swift
+++ b/Sources/TokamakCore/Views/Selectors/Slider.swift
@@ -36,7 +36,7 @@ public struct Slider<Label, ValueLabel>: View where Label: View, ValueLabel: Vie
   let bounds: ClosedRange<Double>
   let step: _SliderStep
   let onEditingChanged: (Bool) -> ()
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("Slider")

--- a/Sources/TokamakCore/Views/Selectors/Toggle.swift
+++ b/Sources/TokamakCore/Views/Selectors/Toggle.swift
@@ -25,6 +25,7 @@ public struct Toggle<Label>: View where Label: View {
     self.label = label()
   }
 
+  @_spi(BubbleCore)
   public var body: AnyView {
     toggleStyle.makeBody(
       configuration: ToggleStyleConfiguration(label: AnyView(label), isOn: $isOn)

--- a/Sources/TokamakCore/Views/Selectors/Toggle.swift
+++ b/Sources/TokamakCore/Views/Selectors/Toggle.swift
@@ -48,6 +48,7 @@ public extension Toggle where Label == AnyView {
 }
 
 extension Toggle: ParentView {
+  @_spi(TokamakCore)
   public var children: [AnyView] {
     (label as? GroupView)?.children ?? [AnyView(label)]
   }

--- a/Sources/TokamakCore/Views/Selectors/Toggle.swift
+++ b/Sources/TokamakCore/Views/Selectors/Toggle.swift
@@ -25,7 +25,7 @@ public struct Toggle<Label>: View where Label: View {
     self.label = label()
   }
 
-  @_spi(BubbleCore)
+  @_spi(TokamakCore)
   public var body: AnyView {
     toggleStyle.makeBody(
       configuration: ToggleStyleConfiguration(label: AnyView(label), isOn: $isOn)

--- a/Sources/TokamakCore/Views/Spacers/Divider.swift
+++ b/Sources/TokamakCore/Views/Spacers/Divider.swift
@@ -18,7 +18,10 @@
 /// A horizontal line for separating content.
 public struct Divider: View {
   @Environment(\.self) public var environment
+    
   public init() {}
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("Divider")
   }

--- a/Sources/TokamakCore/Views/Spacers/Divider.swift
+++ b/Sources/TokamakCore/Views/Spacers/Divider.swift
@@ -18,9 +18,9 @@
 /// A horizontal line for separating content.
 public struct Divider: View {
   @Environment(\.self) public var environment
-    
+
   public init() {}
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("Divider")

--- a/Sources/TokamakCore/Views/Spacers/Divider.swift
+++ b/Sources/TokamakCore/Views/Spacers/Divider.swift
@@ -16,13 +16,8 @@
 //
 
 /// A horizontal line for separating content.
-public struct Divider: View {
+public struct Divider: PrimitiveView {
   @Environment(\.self) public var environment
 
   public init() {}
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("Divider")
-  }
 }

--- a/Sources/TokamakCore/Views/Spacers/Spacer.swift
+++ b/Sources/TokamakCore/Views/Spacers/Spacer.swift
@@ -28,7 +28,8 @@ public struct Spacer: View {
   public init(minLength: CGFloat? = nil) {
     self.minLength = minLength
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("Spacer")
   }

--- a/Sources/TokamakCore/Views/Spacers/Spacer.swift
+++ b/Sources/TokamakCore/Views/Spacers/Spacer.swift
@@ -22,15 +22,10 @@
 ///       Spacer()
 ///       Text("World")
 ///     }
-public struct Spacer: View {
+public struct Spacer: PrimitiveView {
   public var minLength: CGFloat?
 
   public init(minLength: CGFloat? = nil) {
     self.minLength = minLength
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("Spacer")
   }
 }

--- a/Sources/TokamakCore/Views/Spacers/Spacer.swift
+++ b/Sources/TokamakCore/Views/Spacers/Spacer.swift
@@ -28,7 +28,7 @@ public struct Spacer: View {
   public init(minLength: CGFloat? = nil) {
     self.minLength = minLength
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("Spacer")

--- a/Sources/TokamakCore/Views/Text/SecureField.swift
+++ b/Sources/TokamakCore/Views/Text/SecureField.swift
@@ -39,7 +39,7 @@ public struct SecureField<Label>: View where Label: View {
   let label: Label
   let textBinding: Binding<String>
   let onCommit: () -> ()
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("SecureField")

--- a/Sources/TokamakCore/Views/Text/SecureField.swift
+++ b/Sources/TokamakCore/Views/Text/SecureField.swift
@@ -65,7 +65,6 @@ extension SecureField: ParentView {
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
-@_spi(TokamakCore)
 public struct _SecureFieldProxy {
   public let subject: SecureField<Text>
 

--- a/Sources/TokamakCore/Views/Text/SecureField.swift
+++ b/Sources/TokamakCore/Views/Text/SecureField.swift
@@ -35,15 +35,10 @@
 ///         print("Set password")
 ///       })
 ///     }
-public struct SecureField<Label>: View where Label: View {
+public struct SecureField<Label>: PrimitiveView where Label: View {
   let label: Label
   let textBinding: Binding<String>
   let onCommit: () -> ()
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("SecureField")
-  }
 }
 
 public extension SecureField where Label == Text {

--- a/Sources/TokamakCore/Views/Text/SecureField.swift
+++ b/Sources/TokamakCore/Views/Text/SecureField.swift
@@ -39,7 +39,8 @@ public struct SecureField<Label>: View where Label: View {
   let label: Label
   let textBinding: Binding<String>
   let onCommit: () -> ()
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("SecureField")
   }
@@ -57,12 +58,14 @@ public extension SecureField where Label == Text {
 }
 
 extension SecureField: ParentView {
+  @_spi(TokamakCore)
   public var children: [AnyView] {
     (label as? GroupView)?.children ?? [AnyView(label)]
   }
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
+@_spi(TokamakCore)
 public struct _SecureFieldProxy {
   public let subject: SecureField<Text>
 

--- a/Sources/TokamakCore/Views/Text/Text.swift
+++ b/Sources/TokamakCore/Views/Text/Text.swift
@@ -71,7 +71,7 @@ public struct Text: View {
   public init<S>(_ content: S) where S: StringProtocol {
     self.init(storage: .verbatim(String(content)))
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("Text")

--- a/Sources/TokamakCore/Views/Text/Text.swift
+++ b/Sources/TokamakCore/Views/Text/Text.swift
@@ -29,7 +29,7 @@
 ///       .bold()
 ///       .italic()
 ///       .underline(true, color: .red)
-public struct Text: View {
+public struct Text: PrimitiveView {
   let storage: _Storage
   let modifiers: [_Modifier]
 
@@ -70,11 +70,6 @@ public struct Text: View {
 
   public init<S>(_ content: S) where S: StringProtocol {
     self.init(storage: .verbatim(String(content)))
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("Text")
   }
 }
 

--- a/Sources/TokamakCore/Views/Text/Text.swift
+++ b/Sources/TokamakCore/Views/Text/Text.swift
@@ -92,7 +92,6 @@ public extension Text._Storage {
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
-@_spi(TokamakCore)
 public struct _TextProxy {
   public let subject: Text
 

--- a/Sources/TokamakCore/Views/Text/Text.swift
+++ b/Sources/TokamakCore/Views/Text/Text.swift
@@ -71,7 +71,8 @@ public struct Text: View {
   public init<S>(_ content: S) where S: StringProtocol {
     self.init(storage: .verbatim(String(content)))
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("Text")
   }
@@ -91,6 +92,7 @@ public extension Text._Storage {
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
+@_spi(TokamakCore)
 public struct _TextProxy {
   public let subject: Text
 

--- a/Sources/TokamakCore/Views/Text/TextEditor.swift
+++ b/Sources/TokamakCore/Views/Text/TextEditor.swift
@@ -12,16 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public struct TextEditor: View {
+public struct TextEditor: PrimitiveView {
   let textBinding: Binding<String>
 
   public init(text: Binding<String>) {
     textBinding = text
-  }
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("TextEditor")
   }
 }
 

--- a/Sources/TokamakCore/Views/Text/TextEditor.swift
+++ b/Sources/TokamakCore/Views/Text/TextEditor.swift
@@ -18,7 +18,8 @@ public struct TextEditor: View {
   public init(text: Binding<String>) {
     textBinding = text
   }
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("TextEditor")
   }

--- a/Sources/TokamakCore/Views/Text/TextEditor.swift
+++ b/Sources/TokamakCore/Views/Text/TextEditor.swift
@@ -18,7 +18,7 @@ public struct TextEditor: View {
   public init(text: Binding<String>) {
     textBinding = text
   }
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("TextEditor")

--- a/Sources/TokamakCore/Views/Text/TextField.swift
+++ b/Sources/TokamakCore/Views/Text/TextField.swift
@@ -40,7 +40,7 @@ public struct TextField<Label>: View where Label: View {
   let onEditingChanged: (Bool) -> ()
   let onCommit: () -> ()
   @Environment(\.textFieldStyle) var style
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("TextField")

--- a/Sources/TokamakCore/Views/Text/TextField.swift
+++ b/Sources/TokamakCore/Views/Text/TextField.swift
@@ -40,7 +40,8 @@ public struct TextField<Label>: View where Label: View {
   let onEditingChanged: (Bool) -> ()
   let onCommit: () -> ()
   @Environment(\.textFieldStyle) var style
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("TextField")
   }
@@ -68,12 +69,14 @@ public extension TextField where Label == Text {
 }
 
 extension TextField: ParentView {
+  @_spi(TokamakCore)
   public var children: [AnyView] {
     (label as? GroupView)?.children ?? [AnyView(label)]
   }
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
+@_spi(TokamakCore)
 public struct _TextFieldProxy {
   public let subject: TextField<Text>
 

--- a/Sources/TokamakCore/Views/Text/TextField.swift
+++ b/Sources/TokamakCore/Views/Text/TextField.swift
@@ -34,17 +34,12 @@
 ///         print("Set username")
 ///       })
 ///     }
-public struct TextField<Label>: View where Label: View {
+public struct TextField<Label>: PrimitiveView where Label: View {
   let label: Label
   let textBinding: Binding<String>
   let onEditingChanged: (Bool) -> ()
   let onCommit: () -> ()
   @Environment(\.textFieldStyle) var style
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("TextField")
-  }
 }
 
 public extension TextField where Label == Text {

--- a/Sources/TokamakCore/Views/Text/TextField.swift
+++ b/Sources/TokamakCore/Views/Text/TextField.swift
@@ -76,7 +76,6 @@ extension TextField: ParentView {
 }
 
 /// This is a helper type that works around absence of "package private" access control in Swift
-@_spi(TokamakCore)
 public struct _TextFieldProxy {
   public let subject: TextField<Text>
 

--- a/Sources/TokamakCore/Views/View.swift
+++ b/Sources/TokamakCore/Views/View.swift
@@ -34,7 +34,7 @@ extension Never: PrimitiveView {}
 public protocol PrimitiveView: View where Body == Never {}
 
 public extension PrimitiveView {
-  @_spi(BubbleCore)
+  @_spi(TokamakCore)
   var body: Never {
     neverBody(String(describing: Self.self))
   }

--- a/Sources/TokamakCore/Views/View.swift
+++ b/Sources/TokamakCore/Views/View.swift
@@ -24,7 +24,7 @@ public protocol View {
 public extension Never {
   @_spi(TokamakCore)
   var body: Never {
-    neverBody("Never")
+    fatalError()
   }
 }
 
@@ -36,7 +36,7 @@ public protocol PrimitiveView: View where Body == Never {}
 public extension PrimitiveView {
   @_spi(BubbleCore)
   var body: Never {
-    fatalError()
+    neverBody(String(describing: Self.self))
   }
 }
 

--- a/Sources/TokamakCore/Views/View.swift
+++ b/Sources/TokamakCore/Views/View.swift
@@ -36,7 +36,7 @@ public protocol PrimitiveView: View where Body == Never {}
 public extension PrimitiveView {
   @_spi(BubbleCore)
   var body: Never {
-    neverBody(String(describing: Self.self))
+    fatalError()
   }
 }
 

--- a/Sources/TokamakCore/Views/View.swift
+++ b/Sources/TokamakCore/Views/View.swift
@@ -22,12 +22,23 @@ public protocol View {
 }
 
 public extension Never {
+  @_spi(TokamakCore)
   var body: Never {
     neverBody("Never")
   }
 }
 
-extension Never: View {}
+extension Never: PrimitiveView {}
+
+/// A `View` that offers primitive functionality, which renders its `body` inaccessible.
+public protocol PrimitiveView: View where Body == Never {}
+
+public extension PrimitiveView {
+  @_spi(BubbleCore)
+  var body: Never {
+    neverBody(String(describing: Self.self))
+  }
+}
 
 /// A `View` type that renders with subviews, usually specified in the `Content` type argument
 public protocol ParentView {

--- a/Sources/TokamakCore/Views/ViewBuilder.swift
+++ b/Sources/TokamakCore/Views/ViewBuilder.swift
@@ -19,7 +19,7 @@
 public struct EmptyView: View {
   @inlinable
   public init() {}
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("EmptyView")
@@ -36,7 +36,7 @@ public struct _ConditionalContent<TrueContent, FalseContent>: View
   }
 
   let storage: Storage
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("_ConditionContent")

--- a/Sources/TokamakCore/Views/ViewBuilder.swift
+++ b/Sources/TokamakCore/Views/ViewBuilder.swift
@@ -16,18 +16,13 @@
 //
 
 /// A `View` with no effect on rendering.
-public struct EmptyView: View {
+public struct EmptyView: PrimitiveView {
   @inlinable
   public init() {}
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("EmptyView")
-  }
 }
 
 // swiftlint:disable:next type_name
-public struct _ConditionalContent<TrueContent, FalseContent>: View
+public struct _ConditionalContent<TrueContent, FalseContent>: PrimitiveView
   where TrueContent: View, FalseContent: View
 {
   enum Storage {
@@ -36,11 +31,6 @@ public struct _ConditionalContent<TrueContent, FalseContent>: View
   }
 
   let storage: Storage
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("_ConditionContent")
-  }
 }
 
 extension _ConditionalContent: GroupView {

--- a/Sources/TokamakCore/Views/ViewBuilder.swift
+++ b/Sources/TokamakCore/Views/ViewBuilder.swift
@@ -27,7 +27,6 @@ public struct EmptyView: View {
 }
 
 // swiftlint:disable:next type_name
-@_spi(TokamakCore)
 public struct _ConditionalContent<TrueContent, FalseContent>: View
   where TrueContent: View, FalseContent: View
 {

--- a/Sources/TokamakCore/Views/ViewBuilder.swift
+++ b/Sources/TokamakCore/Views/ViewBuilder.swift
@@ -19,13 +19,15 @@
 public struct EmptyView: View {
   @inlinable
   public init() {}
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("EmptyView")
   }
 }
 
 // swiftlint:disable:next type_name
+@_spi(TokamakCore)
 public struct _ConditionalContent<TrueContent, FalseContent>: View
   where TrueContent: View, FalseContent: View
 {
@@ -35,7 +37,8 @@ public struct _ConditionalContent<TrueContent, FalseContent>: View
   }
 
   let storage: Storage
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("_ConditionContent")
   }

--- a/Sources/TokamakDOM/DOMRef.swift
+++ b/Sources/TokamakDOM/DOMRef.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import JavaScriptKit
-import TokamakCore
+@_spi(TokamakCore) import TokamakCore
 
 public extension View {
   /** Allows capturing DOM references of host views. The resulting reference is written

--- a/Sources/TokamakDOM/DOMRenderer.swift
+++ b/Sources/TokamakDOM/DOMRenderer.swift
@@ -17,7 +17,7 @@
 
 import JavaScriptKit
 import OpenCombineJS
-import TokamakCore
+@_spi(TokamakCore) import TokamakCore
 import TokamakStaticHTML
 
 extension EnvironmentValues {

--- a/Sources/TokamakDOM/Styles/ButtonStyle.swift
+++ b/Sources/TokamakDOM/Styles/ButtonStyle.swift
@@ -18,6 +18,7 @@
 import TokamakCore
 
 extension ButtonStyleConfiguration.Label: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     _ButtonStyleConfigurationProxy.Label(self).content
   }

--- a/Sources/TokamakDOM/Views/Buttons/Button.swift
+++ b/Sources/TokamakDOM/Views/Buttons/Button.swift
@@ -19,6 +19,7 @@ import TokamakCore
 import TokamakStaticHTML
 
 extension _Button: ViewDeferredToRenderer where Label == Text {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let listeners: [String: Listener] = [
       "pointerdown": { _ in isPressed = true },

--- a/Sources/TokamakDOM/Views/Containers/DisclosureGroup.swift
+++ b/Sources/TokamakDOM/Views/Containers/DisclosureGroup.swift
@@ -70,6 +70,7 @@ extension DisclosureGroup: ViewDeferredToRenderer {
     }
   }
 
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     AnyView(HTML("div", [
       "class": "_tokamak-disclosuregroup",

--- a/Sources/TokamakDOM/Views/DynamicHTML.swift
+++ b/Sources/TokamakDOM/Views/DynamicHTML.swift
@@ -34,7 +34,8 @@ public struct DynamicHTML<Content>: View, AnyDynamicHTML {
   let content: Content
 
   public var innerHTML: String?
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("HTML")
   }
@@ -68,7 +69,8 @@ extension DynamicHTML: ParentView where Content: View {
     self.content = content()
     innerHTML = nil
   }
-
+    
+  @_spi(TokamakCore)
   public var children: [AnyView] {
     [AnyView(content)]
   }

--- a/Sources/TokamakDOM/Views/DynamicHTML.swift
+++ b/Sources/TokamakDOM/Views/DynamicHTML.swift
@@ -34,7 +34,7 @@ public struct DynamicHTML<Content>: View, AnyDynamicHTML {
   let content: Content
 
   public var innerHTML: String?
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("HTML")
@@ -69,7 +69,7 @@ extension DynamicHTML: ParentView where Content: View {
     self.content = content()
     innerHTML = nil
   }
-    
+
   @_spi(TokamakCore)
   public var children: [AnyView] {
     [AnyView(content)]

--- a/Sources/TokamakDOM/Views/DynamicHTML.swift
+++ b/Sources/TokamakDOM/Views/DynamicHTML.swift
@@ -27,13 +27,18 @@ protocol AnyDynamicHTML: AnyHTML {
   var listeners: [String: Listener] { get }
 }
 
-public struct DynamicHTML<Content>: PrimitiveView, AnyDynamicHTML {
+public struct DynamicHTML<Content>: View, AnyDynamicHTML {
   public let tag: String
   public let attributes: [HTMLAttribute: String]
   public let listeners: [String: Listener]
   let content: Content
 
   public var innerHTML: String?
+
+  @_spi(TokamakCore)
+  public var body: Never {
+    neverBody("HTML")
+  }
 }
 
 public extension DynamicHTML where Content: StringProtocol {

--- a/Sources/TokamakDOM/Views/DynamicHTML.swift
+++ b/Sources/TokamakDOM/Views/DynamicHTML.swift
@@ -27,18 +27,13 @@ protocol AnyDynamicHTML: AnyHTML {
   var listeners: [String: Listener] { get }
 }
 
-public struct DynamicHTML<Content>: View, AnyDynamicHTML {
+public struct DynamicHTML<Content>: PrimitiveView, AnyDynamicHTML {
   public let tag: String
   public let attributes: [HTMLAttribute: String]
   public let listeners: [String: Listener]
   let content: Content
 
   public var innerHTML: String?
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("HTML")
-  }
 }
 
 public extension DynamicHTML where Content: StringProtocol {

--- a/Sources/TokamakDOM/Views/Layout/GeometryReader.swift
+++ b/Sources/TokamakDOM/Views/Layout/GeometryReader.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import JavaScriptKit
-import TokamakCore
+@_spi(TokamakCore) import TokamakCore
 import TokamakStaticHTML
 
 private let ResizeObserver = JSObject.global.ResizeObserver.function!

--- a/Sources/TokamakDOM/Views/Layout/GeometryReader.swift
+++ b/Sources/TokamakDOM/Views/Layout/GeometryReader.swift
@@ -19,6 +19,7 @@ import TokamakStaticHTML
 private let ResizeObserver = JSObject.global.ResizeObserver.function!
 
 extension GeometryReader: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     AnyView(_GeometryReader(content: content))
   }

--- a/Sources/TokamakDOM/Views/Navigation/NavigationLink.swift
+++ b/Sources/TokamakDOM/Views/Navigation/NavigationLink.swift
@@ -16,6 +16,7 @@ import TokamakCore
 import TokamakStaticHTML
 
 extension NavigationLink: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let proxy = _NavigationLinkProxy(self)
     return AnyView(

--- a/Sources/TokamakDOM/Views/Selectors/Picker.swift
+++ b/Sources/TokamakDOM/Views/Selectors/Picker.swift
@@ -17,6 +17,7 @@ import TokamakCore
 import TokamakStaticHTML
 
 extension _PickerContainer: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     AnyView(HTML("label") {
       label
@@ -35,6 +36,7 @@ extension _PickerContainer: ViewDeferredToRenderer {
 }
 
 extension _PickerElement: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let attributes: [HTMLAttribute: String]
     if let value = valueIndex {

--- a/Sources/TokamakDOM/Views/Selectors/Slider.swift
+++ b/Sources/TokamakDOM/Views/Selectors/Slider.swift
@@ -17,6 +17,7 @@ import TokamakCore
 import TokamakStaticHTML
 
 extension Slider: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let proxy = _SliderProxy(self)
     let step: String

--- a/Sources/TokamakDOM/Views/Text/SecureField.swift
+++ b/Sources/TokamakDOM/Views/Text/SecureField.swift
@@ -18,6 +18,7 @@
 import TokamakCore
 
 extension SecureField: ViewDeferredToRenderer where Label == Text {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let proxy = _SecureFieldProxy(self)
     return AnyView(DynamicHTML("input", [

--- a/Sources/TokamakDOM/Views/Text/TextEditor.swift
+++ b/Sources/TokamakDOM/Views/Text/TextEditor.swift
@@ -15,6 +15,7 @@
 import TokamakCore
 
 extension TextEditor: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let proxy = _TextEditorProxy(self)
 

--- a/Sources/TokamakDOM/Views/Text/TextField.swift
+++ b/Sources/TokamakDOM/Views/Text/TextField.swift
@@ -38,7 +38,8 @@ extension TextField: ViewDeferredToRenderer where Label == Text {
       return ""
     }
   }
-
+    
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let proxy = _TextFieldProxy(self)
 

--- a/Sources/TokamakDOM/Views/Text/TextField.swift
+++ b/Sources/TokamakDOM/Views/Text/TextField.swift
@@ -38,7 +38,7 @@ extension TextField: ViewDeferredToRenderer where Label == Text {
       return ""
     }
   }
-    
+
   @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let proxy = _TextFieldProxy(self)

--- a/Sources/TokamakGTK/Modifiers/WidgetModifier.swift
+++ b/Sources/TokamakGTK/Modifiers/WidgetModifier.swift
@@ -51,6 +51,7 @@ extension WidgetAttributeModifier {
 }
 
 extension ModifiedContent: ViewDeferredToRenderer where Content: View {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     guard let widgetModifier = modifier as? WidgetModifier else {
       return AnyView(content)

--- a/Sources/TokamakGTK/Scenes/SceneContainerView.swift
+++ b/Sources/TokamakGTK/Scenes/SceneContainerView.swift
@@ -18,12 +18,8 @@
 import CGTK
 import TokamakCore
 
-struct SceneContainerView<Content: View>: View, AnyWidget {
+struct SceneContainerView<Content: View>: PrimitiveView, AnyWidget {
   let content: Content
-
-  var body: Never {
-    neverBody("SceneContainerView")
-  }
 
   func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget> {
     print("Making window")

--- a/Sources/TokamakGTK/Scenes/SceneContainerView.swift
+++ b/Sources/TokamakGTK/Scenes/SceneContainerView.swift
@@ -18,8 +18,12 @@
 import CGTK
 import TokamakCore
 
-struct SceneContainerView<Content: View>: PrimitiveView, AnyWidget {
+struct SceneContainerView<Content: View>: View, AnyWidget {
   let content: Content
+
+  var body: Never {
+    neverBody("SceneContainerView")
+  }
 
   func new(_ application: UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget> {
     print("Making window")

--- a/Sources/TokamakGTK/Shapes/Shape.swift
+++ b/Sources/TokamakGTK/Shapes/Shape.swift
@@ -51,6 +51,7 @@ func createPath(from elements: [Path.Element], in cr: OpaquePointer) {
 }
 
 extension _ShapeView: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     AnyView(WidgetView(build: { _ in
       let w = gtk_drawing_area_new()

--- a/Sources/TokamakGTK/Tokens/BuiltinColors.swift
+++ b/Sources/TokamakGTK/Tokens/BuiltinColors.swift
@@ -15,7 +15,7 @@
 //  Created by Carson Katri on 8/4/20.
 //
 
-import TokamakCore
+@_spi(TokamakCore) import TokamakCore
 
 // MARK: List Colors
 

--- a/Sources/TokamakGTK/Views/List.swift
+++ b/Sources/TokamakGTK/Views/List.swift
@@ -31,6 +31,7 @@ extension List: ViewDeferredToRenderer {
     }
   }
 
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let proxy = _ListProxy(self)
     return AnyView(ScrollView {

--- a/Sources/TokamakGTK/Views/NavigationView.swift
+++ b/Sources/TokamakGTK/Views/NavigationView.swift
@@ -71,7 +71,7 @@ extension NavigationView: ViewDeferredToRenderer {
 }
 
 extension NavigationLink: ViewDeferredToRenderer {
-@_spi(TokamakCore)
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let proxy = _NavigationLinkProxy(self)
     return AnyView(Button(action: { proxy.activate() }) {

--- a/Sources/TokamakGTK/Views/NavigationView.swift
+++ b/Sources/TokamakGTK/Views/NavigationView.swift
@@ -59,6 +59,7 @@ protocol GtkStackProtocol {}
 // }
 
 extension NavigationView: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let proxy = _NavigationViewProxy(self)
     return AnyView(HStack {
@@ -70,6 +71,7 @@ extension NavigationView: ViewDeferredToRenderer {
 }
 
 extension NavigationLink: ViewDeferredToRenderer {
+@_spi(TokamakCore)
   public var deferredBody: AnyView {
     let proxy = _NavigationLinkProxy(self)
     return AnyView(Button(action: { proxy.activate() }) {

--- a/Sources/TokamakGTK/Views/ScrollView.swift
+++ b/Sources/TokamakGTK/Views/ScrollView.swift
@@ -19,6 +19,7 @@ import CGTK
 import TokamakCore
 
 extension ScrollView: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     AnyView(WidgetView(build: { _ in
       gtk_scrolled_window_new(nil, nil)

--- a/Sources/TokamakGTK/Views/Stack.swift
+++ b/Sources/TokamakGTK/Views/Stack.swift
@@ -23,7 +23,7 @@ protocol StackProtocol {
   var alignment: Alignment { get }
 }
 
-struct Box<Content: View>: PrimitiveView, ParentView, AnyWidget, StackProtocol {
+struct Box<Content: View>: View, ParentView, AnyWidget, StackProtocol {
   let content: Content
   let orientation: GtkOrientation
   let spacing: TokamakCore.CGFloat
@@ -42,6 +42,10 @@ struct Box<Content: View>: PrimitiveView, ParentView, AnyWidget, StackProtocol {
   }
 
   func update(widget: Widget) {}
+
+  var body: Never {
+    neverBody("Box")
+  }
 
   public var children: [AnyView] {
     [AnyView(content)]

--- a/Sources/TokamakGTK/Views/Stack.swift
+++ b/Sources/TokamakGTK/Views/Stack.swift
@@ -23,7 +23,7 @@ protocol StackProtocol {
   var alignment: Alignment { get }
 }
 
-struct Box<Content: View>: View, ParentView, AnyWidget, StackProtocol {
+struct Box<Content: View>: PrimitiveView, ParentView, AnyWidget, StackProtocol {
   let content: Content
   let orientation: GtkOrientation
   let spacing: TokamakCore.CGFloat
@@ -42,10 +42,6 @@ struct Box<Content: View>: View, ParentView, AnyWidget, StackProtocol {
   }
 
   func update(widget: Widget) {}
-
-  var body: Never {
-    neverBody("Box")
-  }
 
   public var children: [AnyView] {
     [AnyView(content)]

--- a/Sources/TokamakGTK/Views/Stack.swift
+++ b/Sources/TokamakGTK/Views/Stack.swift
@@ -53,6 +53,7 @@ struct Box<Content: View>: View, ParentView, AnyWidget, StackProtocol {
 }
 
 extension VStack: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     AnyView(
       Box(
@@ -66,6 +67,7 @@ extension VStack: ViewDeferredToRenderer {
 }
 
 extension HStack: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     AnyView(
       Box(

--- a/Sources/TokamakGTK/Views/TextField.swift
+++ b/Sources/TokamakGTK/Views/TextField.swift
@@ -57,6 +57,7 @@ private func bindAction(to entry: UnsafeMutablePointer<GtkWidget>, textBinding: 
 }
 
 extension SecureField: ViewDeferredToRenderer where Label == Text {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let proxy = _SecureFieldProxy(self)
     return AnyView(WidgetView(
@@ -72,6 +73,7 @@ extension SecureField: ViewDeferredToRenderer where Label == Text {
 }
 
 extension TextField: ViewDeferredToRenderer where Label == Text {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let proxy = _TextFieldProxy(self)
     return AnyView(WidgetView(

--- a/Sources/TokamakGTK/Widget.swift
+++ b/Sources/TokamakGTK/Widget.swift
@@ -25,7 +25,7 @@ extension AnyWidget {
   var expand: Bool { false }
 }
 
-struct WidgetView<Content: View>: PrimitiveView, AnyWidget, ParentView {
+struct WidgetView<Content: View>: View, AnyWidget, ParentView {
   let build: (UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget>
   let update: (Widget) -> ()
   let content: Content
@@ -50,6 +50,10 @@ struct WidgetView<Content: View>: PrimitiveView, AnyWidget, ParentView {
     if case .widget = widget.storage {
       update(widget)
     }
+  }
+
+  var body: Never {
+    neverBody("WidgetView")
   }
 
   var children: [AnyView] {

--- a/Sources/TokamakGTK/Widget.swift
+++ b/Sources/TokamakGTK/Widget.swift
@@ -25,7 +25,7 @@ extension AnyWidget {
   var expand: Bool { false }
 }
 
-struct WidgetView<Content: View>: View, AnyWidget, ParentView {
+struct WidgetView<Content: View>: PrimitiveView, AnyWidget, ParentView {
   let build: (UnsafeMutablePointer<GtkApplication>) -> UnsafeMutablePointer<GtkWidget>
   let update: (Widget) -> ()
   let content: Content
@@ -50,10 +50,6 @@ struct WidgetView<Content: View>: View, AnyWidget, ParentView {
     if case .widget = widget.storage {
       update(widget)
     }
-  }
-
-  var body: Never {
-    neverBody("WidgetView")
   }
 
   var children: [AnyView] {

--- a/Sources/TokamakStaticHTML/Modifiers/ModifiedContent.swift
+++ b/Sources/TokamakStaticHTML/Modifiers/ModifiedContent.swift
@@ -30,6 +30,7 @@ extension ModifiedContent: AnyModifiedContent where Modifier: DOMViewModifier, C
 }
 
 extension ModifiedContent: ViewDeferredToRenderer where Content: View, Modifier: ViewModifier {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     if let domModifier = modifier as? DOMViewModifier {
       if let adjacentModifier = content as? AnyModifiedContent,

--- a/Sources/TokamakStaticHTML/Shapes/Path.swift
+++ b/Sources/TokamakStaticHTML/Shapes/Path.swift
@@ -128,6 +128,7 @@ extension Path: ViewDeferredToRenderer {
     svgFrom(storage: storage, strokeStyle: strokeStyle)
   }
 
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let sizeStyle = sizing == .flexible ?
       """

--- a/Sources/TokamakStaticHTML/Shapes/_ShapeView.swift
+++ b/Sources/TokamakStaticHTML/Shapes/_ShapeView.swift
@@ -32,6 +32,7 @@ extension _StrokedShape: ShapeAttributes {
 }
 
 extension _ShapeView: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let path = shape.path(in: .zero).deferredBody
     if let shapeAttributes = shape as? ShapeAttributes {

--- a/Sources/TokamakStaticHTML/Tokens/BuiltinColors.swift
+++ b/Sources/TokamakStaticHTML/Tokens/BuiltinColors.swift
@@ -15,7 +15,7 @@
 //  Created by Carson Katri on 8/4/20.
 //
 
-import TokamakCore
+@_spi(TokamakCore) import TokamakCore
 
 // MARK: List Colors
 

--- a/Sources/TokamakStaticHTML/Views/Buttons/Link.swift
+++ b/Sources/TokamakStaticHTML/Views/Buttons/Link.swift
@@ -18,6 +18,7 @@
 import TokamakCore
 
 extension Link: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let proxy = _LinkProxy(self)
     return AnyView(HTML("a", ["href": proxy.destination.absoluteString, "class": "_tokamak-link"]) {

--- a/Sources/TokamakStaticHTML/Views/Containers/List.swift
+++ b/Sources/TokamakStaticHTML/Views/Containers/List.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import TokamakCore
+@_spi(TokamakCore) import TokamakCore
 
 extension PlainListStyle: ListStyleDeferredToRenderer {
   public func sectionHeader<Header>(_ header: Header) -> AnyView where Header: View {

--- a/Sources/TokamakStaticHTML/Views/HTML.swift
+++ b/Sources/TokamakStaticHTML/Views/HTML.swift
@@ -69,7 +69,8 @@ public struct HTML<Content>: View, AnyHTML {
   let content: Content
 
   public let innerHTML: String?
-
+    
+  @_spi(TokamakCore)
   public var body: Never {
     neverBody("HTML")
   }
@@ -99,7 +100,8 @@ extension HTML: ParentView where Content: View {
     self.content = content()
     innerHTML = nil
   }
-
+    
+  @_spi(TokamakCore)
   public var children: [AnyView] {
     [AnyView(content)]
   }

--- a/Sources/TokamakStaticHTML/Views/HTML.swift
+++ b/Sources/TokamakStaticHTML/Views/HTML.swift
@@ -63,17 +63,12 @@ public extension AnyHTML {
   }
 }
 
-public struct HTML<Content>: View, AnyHTML {
+public struct HTML<Content>: PrimitiveView, AnyHTML {
   public let tag: String
   public let attributes: [HTMLAttribute: String]
   let content: Content
 
   public let innerHTML: String?
-
-  @_spi(TokamakCore)
-  public var body: Never {
-    neverBody("HTML")
-  }
 }
 
 public extension HTML where Content: StringProtocol {

--- a/Sources/TokamakStaticHTML/Views/HTML.swift
+++ b/Sources/TokamakStaticHTML/Views/HTML.swift
@@ -69,7 +69,7 @@ public struct HTML<Content>: View, AnyHTML {
   let content: Content
 
   public let innerHTML: String?
-    
+
   @_spi(TokamakCore)
   public var body: Never {
     neverBody("HTML")
@@ -100,7 +100,7 @@ extension HTML: ParentView where Content: View {
     self.content = content()
     innerHTML = nil
   }
-    
+
   @_spi(TokamakCore)
   public var children: [AnyView] {
     [AnyView(content)]

--- a/Sources/TokamakStaticHTML/Views/HTML.swift
+++ b/Sources/TokamakStaticHTML/Views/HTML.swift
@@ -63,12 +63,17 @@ public extension AnyHTML {
   }
 }
 
-public struct HTML<Content>: PrimitiveView, AnyHTML {
+public struct HTML<Content>: View, AnyHTML {
   public let tag: String
   public let attributes: [HTMLAttribute: String]
   let content: Content
 
   public let innerHTML: String?
+
+  @_spi(TokamakCore)
+  public var body: Never {
+    neverBody("HTML")
+  }
 }
 
 public extension HTML where Content: StringProtocol {

--- a/Sources/TokamakStaticHTML/Views/Images/Image.swift
+++ b/Sources/TokamakStaticHTML/Views/Images/Image.swift
@@ -20,6 +20,7 @@ import TokamakCore
 public typealias Image = TokamakCore.Image
 
 extension Image: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     AnyView(_HTMLImage(proxy: _ImageProxy(self)))
   }

--- a/Sources/TokamakStaticHTML/Views/Layout/HStack.swift
+++ b/Sources/TokamakStaticHTML/Views/Layout/HStack.swift
@@ -30,6 +30,7 @@ extension VerticalAlignment {
 extension HStack: ViewDeferredToRenderer, SpacerContainer {
   public var axis: SpacerContainerAxis { .horizontal }
 
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     AnyView(HTML("div", [
       "style": """

--- a/Sources/TokamakStaticHTML/Views/Layout/LazyHGrid.swift
+++ b/Sources/TokamakStaticHTML/Views/Layout/LazyHGrid.swift
@@ -36,6 +36,7 @@ extension LazyHGrid: ViewDeferredToRenderer {
     _LazyHGridProxy(self).rows.last
   }
 
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     var styles = """
     display: grid;

--- a/Sources/TokamakStaticHTML/Views/Layout/LazyVGrid.swift
+++ b/Sources/TokamakStaticHTML/Views/Layout/LazyVGrid.swift
@@ -36,6 +36,7 @@ extension LazyVGrid: ViewDeferredToRenderer {
     _LazyVGridProxy(self).columns.last
   }
 
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     var styles = """
     display: grid;

--- a/Sources/TokamakStaticHTML/Views/Layout/ScrollView.swift
+++ b/Sources/TokamakStaticHTML/Views/Layout/ScrollView.swift
@@ -26,6 +26,7 @@ extension ScrollView: ViewDeferredToRenderer, SpacerContainer {
     }
   }
 
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let scrollX = axes.contains(.horizontal)
     let scrollY = axes.contains(.vertical)

--- a/Sources/TokamakStaticHTML/Views/Layout/VStack.swift
+++ b/Sources/TokamakStaticHTML/Views/Layout/VStack.swift
@@ -30,6 +30,7 @@ extension HorizontalAlignment {
 extension VStack: ViewDeferredToRenderer, SpacerContainer {
   public var axis: SpacerContainerAxis { .vertical }
 
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     AnyView(HTML("div", [
       "style": """

--- a/Sources/TokamakStaticHTML/Views/Layout/ZStack.swift
+++ b/Sources/TokamakStaticHTML/Views/Layout/ZStack.swift
@@ -23,6 +23,7 @@ struct _ZStack_ContentGridItem: ViewModifier, DOMViewModifier {
 }
 
 extension ZStack: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     AnyView(HTML("div", [
       "style": """

--- a/Sources/TokamakStaticHTML/Views/Navigation/NavigationView.swift
+++ b/Sources/TokamakStaticHTML/Views/Navigation/NavigationView.swift
@@ -15,6 +15,7 @@
 import TokamakCore
 
 extension NavigationView: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     let proxy = _NavigationViewProxy(self)
     return AnyView(HTML("div", [

--- a/Sources/TokamakStaticHTML/Views/Spacers/Divider.swift
+++ b/Sources/TokamakStaticHTML/Views/Spacers/Divider.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import TokamakCore
+@_spi(TokamakCore) import TokamakCore
 
 extension Divider: AnyHTML {
   public var innerHTML: String? { nil }

--- a/Sources/TokamakStaticHTML/Views/Spacers/Spacer.swift
+++ b/Sources/TokamakStaticHTML/Views/Spacers/Spacer.swift
@@ -56,6 +56,7 @@ public extension SpacerContainer where Self: ParentView {
 }
 
 extension Spacer: ViewDeferredToRenderer {
+  @_spi(TokamakCore)
   public var deferredBody: AnyView {
     AnyView(HTML("div", [
       "style": "flex-grow: 1; \(minLength != nil ? "min-width: \(minLength!)" : "")",

--- a/Tests/TokamakTests/ReconcilerTests.swift
+++ b/Tests/TokamakTests/ReconcilerTests.swift
@@ -15,7 +15,7 @@
 //  Created by Max Desiatov on 07/12/2018.
 //
 
-import TokamakTestRenderer
+@_spi(TokamakCore) import TokamakTestRenderer
 import XCTest
 
 @testable import TokamakCore


### PR DESCRIPTION
This PR adds `_spi(TokamakCore)` to the modules:
1. TokamakCore
2. TokamakDOM
3. TokamakGTK
4. TokamakStaticHTML

The attribute is applied to:
1. All `View` bodies in TokamakCore — either primitive or regular like `Color`
2. `ViewDeferredToRenderer` bodies
4. `ParentView` `children` members
5. `View` modifiers (such as  `_onMount(perform:)`)
6. Other members of types (like `Color._withScheme`, and `_AnyApp._launch`) 

The attribute semantics (from my brief testing)
1. It can only be applied to `public` declarations
2. It ensures that every SPI declaration is exposed only by other SPI declarations (i.e. `@_spi(Module) public enum A {}; public var a: A` is illegal)
3. Regularly importing a library prohibits clients from accessing SPI declarations that are not protocol witnesses (with an error).
4. Regularly importing a library "discourages" clients from accessing SPI protocol witnesses by hiding them from the autocompletion suggestions (i.e. users can still access `body` of `Text`, but autocompletion hides it).
5. For a declaration marked with `@_spi(Module)`, a client has to write `@_spi(Module) import Library` in order to normally access such SPI declarations.