### PR TITLE
Use `String(reflecting:)` vs `String(describing:)`

### DIFF
--- a/Sources/TokamakCore/Preferences/PreferenceKey.swift
+++ b/Sources/TokamakCore/Preferences/PreferenceKey.swift
@@ -51,7 +51,7 @@ public struct _PreferenceStore {
   public func value<Key>(forKey key: Key.Type = Key.self) -> _PreferenceValue<Key>
     where Key: PreferenceKey
   {
-    values[String(describing: key)] as? _PreferenceValue<Key>
+    values[String(reflecting: key)] as? _PreferenceValue<Key>
       ?? _PreferenceValue(valueList: [Key.defaultValue])
   }
 
@@ -59,7 +59,7 @@ public struct _PreferenceStore {
     where Key: PreferenceKey
   {
     let previousValues = self.value(forKey: key).valueList
-    values[String(describing: key)] = _PreferenceValue<Key>(valueList: previousValues + [value])
+    values[String(reflecting: key)] = _PreferenceValue<Key>(valueList: previousValues + [value])
   }
 
   public mutating func merge(with other: Self) {

--- a/Sources/TokamakCore/Reflection/typeConstructorName.swift
+++ b/Sources/TokamakCore/Reflection/typeConstructorName.swift
@@ -18,9 +18,5 @@
  is returned.
  */
 public func typeConstructorName(_ type: Any.Type) -> String {
-  // FIXME: no idea if this calculation is reliable, but seems to be the only way to get
-  // a name of a type constructor in runtime. Should definitely check if these are different
-  // across modules, otherwise can cause problems with views with same names in different
-  // modules.
   String(String(reflecting: type).prefix { $0 != "<" })
 }

--- a/Sources/TokamakCore/Reflection/typeConstructorName.swift
+++ b/Sources/TokamakCore/Reflection/typeConstructorName.swift
@@ -22,5 +22,5 @@ public func typeConstructorName(_ type: Any.Type) -> String {
   // a name of a type constructor in runtime. Should definitely check if these are different
   // across modules, otherwise can cause problems with views with same names in different
   // modules.
-  String(String(describing: type).prefix { $0 != "<" })
+  String(String(reflecting: type).prefix { $0 != "<" })
 }

--- a/Sources/TokamakCore/Views/View.swift
+++ b/Sources/TokamakCore/Views/View.swift
@@ -36,7 +36,7 @@ public protocol PrimitiveView: View where Body == Never {}
 public extension PrimitiveView {
   @_spi(TokamakCore)
   var body: Never {
-    neverBody(String(describing: Self.self))
+    neverBody(String(reflecting: Self.self))
   }
 }
 


### PR DESCRIPTION
Resolves #218.

`String(describing:)` initializer applied to metatypes does not include a module name, which can cause problems if two different types with same name come from different modules.

OTOH `String(reflecting:)` does include module name, which makes these reflection strings slightly longer, but should prevent obscure issues with name collisions from happening.