### PR TITLE
Add @dynamicMemberLookup to Binding

### DIFF
--- a/Sources/TokamakCore/State/Binding.swift
+++ b/Sources/TokamakCore/State/Binding.swift
@@ -21,7 +21,9 @@ typealias Updater<T> = (inout T) -> ()
  view's state in-place synchronously, but only schedule an update with
  the renderer at a later time.
  */
-@propertyWrapper public struct Binding<Value>: DynamicProperty {
+@propertyWrapper
+@dynamicMemberLookup
+public struct Binding<Value>: DynamicProperty {
   public var wrappedValue: Value {
     get { get() }
     nonmutating set { set(newValue) }


### PR DESCRIPTION
Allows for `$someObject.someField` to be used as a `Binding`.