### PR TITLE
Fix DOMRenderer crash after DOM has been directly modified. (#326, #369)

### DIFF
--- a/Sources/TokamakDOM/DOMRenderer.swift
+++ b/Sources/TokamakDOM/DOMRenderer.swift
@@ -163,6 +163,6 @@ final class DOMRenderer: Renderer {
     guard mapAnyView(host.view, transform: { (html: AnyHTML) in html }) != nil
     else { return }
 
-    try? _ = parent.ref.throwing.removeChild!(target.ref)
+    _ = try? parent.ref.throwing.removeChild!(target.ref)
   }
 }

--- a/Sources/TokamakDOM/DOMRenderer.swift
+++ b/Sources/TokamakDOM/DOMRenderer.swift
@@ -163,6 +163,6 @@ final class DOMRenderer: Renderer {
     guard mapAnyView(host.view, transform: { (html: AnyHTML) in html }) != nil
     else { return }
 
-    _ = parent.ref.removeChild!(target.ref)
+    try? _ = parent.ref.throwing.removeChild!(target.ref)
   }
 }


### PR DESCRIPTION
When _domRef is used to directly modify the DOM, this causes the state of the DOM to no longer match the View from which it was rendered. When the renderer later tries to unmount the modified element, this can cause a crash.

This PR fixes the crash by catching (and ignoring) this failure in DOMRenderer.unmount. This fixes #326 and #369, which are the same issue.

Note that directly modifying the DOM with `_domRef` can still cause problems, as the state mismatch remains. For example, an update to the `View` can cause the renderer to overwrite those DOM changes.