### PR TITLE
Explicitly import CoreFoundation

### DIFF
--- a/Sources/TokamakCore/PreviewProvider.swift
+++ b/Sources/TokamakCore/PreviewProvider.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import CoreFoundation
 
 /// This protocol has no functionality currently, and is only provided for compatibility purposes.
 public protocol PreviewProvider {

--- a/Sources/TokamakCore/PreviewProvider.swift
+++ b/Sources/TokamakCore/PreviewProvider.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import Foundation
-import CoreFoundation
 
 /// This protocol has no functionality currently, and is only provided for compatibility purposes.
 public protocol PreviewProvider {

--- a/Sources/TokamakCore/Stubs/CGStubs.swift
+++ b/Sources/TokamakCore/Stubs/CGStubs.swift
@@ -16,6 +16,7 @@
 //
 
 import Foundation
+import CoreFoundation
 
 extension CGPoint {
   func rotate(_ angle: Angle, around origin: Self) -> Self {


### PR DESCRIPTION
This allows TokamakDemo to be built with [latest SwiftWasm 5.4 toolchain](https://github.com/swiftwasm/swift/releases/tag/swift-wasm-5.4-SNAPSHOT-2021-06-17-a) in **debug mode** (compiler still crashes when building for release).

BTW this import could be anywhere in the target, couldn't find a file that felt natural to include it in.