### PR TITLE
Fix SwiftLint action

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -12,9 +12,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
+      # Fetch current versions of files
       - name: Fetch base ref
         run: |
           git fetch --prune --no-tags --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/heads/${{ github.base_ref }}
+      # Diff pull request to current files, then SwiftLint changed files
       - name: GitHub Action for SwiftLint
         uses: ezraberch/action-swiftlint@3.2.3
         env:

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -12,7 +12,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
+      - name: Fetch base ref
+        run: |
+          git fetch --prune --no-tags --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/heads/${{ github.base_ref }}
       - name: GitHub Action for SwiftLint
-        uses: norio-nomura/action-swiftlint@3.1.0
+        uses: ezraberch/action-swiftlint@3.2.3
         env:
           DIFF_BASE: ${{ github.base_ref }}
+          DIFF_HEAD: HEAD


### PR DESCRIPTION
The Github Action for SwiftLint is currently not working properly. [Here](https://github.com/TokamakUI/Tokamak/runs/3157815816?check_suite_focus=true) is a recent example. It is not only linting the changed files. In fact, it is linting files multiple times, leading to nearly 5000 files being linted in the example. This leads to warnings being repeated multiple times.

The core issue is  norio-nomura/action-swiftlint#38. Unfortunately, that bug has not been fixed in that repository, so I switched to the [mayk-it/action-swift-lint](https://github.com/mayk-it/action-swiftlint) fork. However, newer versions of action-swiftlint use a swift 5.4 version of SwiftLint, which will crash when linting this project [(details)](https://github.com/ezraberch/Tokamak/runs/3167633497?check_suite_focus=true). so I had to make my own fork which uses 5.3 (we're currently using 5.1).

[Here](https://github.com/ezraberch/Tokamak/runs/3167755083?check_suite_focus=true) is a run with the new version of the action.