### PR TITLE
Initial implementation of `onHover`

### DIFF
--- a/Sources/TokamakCore/Modifiers/HoverActionModifier.swift
+++ b/Sources/TokamakCore/Modifiers/HoverActionModifier.swift
@@ -11,12 +11,21 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+/// Underscore is present in the name for SwiftUI compatibility.
+public struct _HoverActionModifier: ViewModifier {
+  public var hover: ((Bool) -> ())?
 
-#if canImport(SnapshotTesting)
-import SnapshotTesting
-
-public extension Snapshotting where Value == String, Format == String {
-  static let html = Snapshotting(pathExtension: "html", diffing: .lines)
+  public typealias Body = Never
 }
 
-#endif
+extension ModifiedContent
+  where Content: View, Modifier == _HoverActionModifier
+{
+  var hover: ((Bool) -> ())? { modifier.hover }
+}
+
+public extension View {
+  func onHover(perform action: ((Bool) -> ())?) -> some View {
+    modifier(_HoverActionModifier(hover: action))
+  }
+}

--- a/Sources/TokamakDOM/Modifiers/ActionModifier.swift
+++ b/Sources/TokamakDOM/Modifiers/ActionModifier.swift
@@ -12,11 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(SnapshotTesting)
-import SnapshotTesting
+import TokamakCore
 
-public extension Snapshotting where Value == String, Format == String {
-  static let html = Snapshotting(pathExtension: "html", diffing: .lines)
+public protocol DOMActionModifier {
+  var listeners: [String: Listener] { get }
 }
 
-#endif
+extension ModifiedContent
+  where Content: AnyDynamicHTML, Modifier: DOMActionModifier
+{
+  // Merge listeners
+  var listeners: [String: Listener] {
+    var attr = content.listeners
+    for (key, val) in modifier.listeners {
+      if let prev = attr[key] {
+        attr[key] = { input in
+          val(input)
+          prev(input)
+        }
+      }
+    }
+
+    return attr
+  }
+}

--- a/Sources/TokamakDOM/Modifiers/Hover.swift
+++ b/Sources/TokamakDOM/Modifiers/Hover.swift
@@ -12,11 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(SnapshotTesting)
-import SnapshotTesting
+import TokamakCore
 
-public extension Snapshotting where Value == String, Format == String {
-  static let html = Snapshotting(pathExtension: "html", diffing: .lines)
+extension _HoverActionModifier: DOMActionModifier {
+  public var listeners: [String: Listener] {
+    [
+      "mouseover":
+        { _ in hover?(true) },
+      "mouseout":
+        { _ in hover?(false) },
+    ]
+  }
 }
-
-#endif

--- a/Sources/TokamakDOM/Modifiers/ModifiedContent.swift
+++ b/Sources/TokamakDOM/Modifiers/ModifiedContent.swift
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(SnapshotTesting)
-import SnapshotTesting
+import TokamakCore
 
-public extension Snapshotting where Value == String, Format == String {
-  static let html = Snapshotting(pathExtension: "html", diffing: .lines)
+// TOOD: Add _AnyModifiedActionContent similar to TokamakStaticHTML/ModifiedContent.swift?
+extension ModifiedContent: DOMPrimitive where Content: View, Modifier: DOMActionModifier {
+  public var renderedBody: AnyView {
+    // TODO: Combine DOM nodes when possible, rather than generating arbitrary new ones
+    AnyView(DynamicHTML("div", listeners: modifier.listeners) {
+      content
+    })
+  }
 }
-
-#endif


### PR DESCRIPTION
Adds a basic implementation of action modifiers, allowing for dynamic event handling. For testing, adds a trivial `onHover` example.

Very simple content compared to tracing the execution path of Tokamak :P