### PR TITLE
Add Canvas and TimelineView to DOM renderer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash
         run: |
           set -ex
-          sudo xcode-select --switch /Applications/Xcode_12.5.app/Contents/Developer/
+          sudo xcode-select --switch /Applications/Xcode_13.0.app/Contents/Developer/
           # avoid building unrelated products for testing by specifying the test product explicitly
           swift build --product TokamakPackageTests
           `xcrun --find xctest` .build/debug/TokamakPackageTests.xctest ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,11 @@ jobs:
 
           xcodebuild -version
 
-          # make sure Tokamak can be built on macOS so that Xcode autocomplete works
-          xcodebuild -scheme TokamakDemo -destination 'generic/platform=macOS' \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
-            xcpretty --color
+          # Make sure Tokamak can be built on macOS so that Xcode autocomplete works.
+          # Disable macOS builds until Monterey is available on GHA.
+          # xcodebuild -scheme TokamakDemo -destination 'generic/platform=macOS' \
+          #   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
+          #   xcpretty --color
 
           cd "NativeDemo"
           xcodebuild -scheme iOS -destination 'generic/platform=iOS' \

--- a/NativeDemo/TokamakDemo.xcodeproj/project.pbxproj
+++ b/NativeDemo/TokamakDemo.xcodeproj/project.pbxproj
@@ -13,10 +13,12 @@
 		26136824269E8EB5006F372E /* TransitionDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26136822269E8EB5006F372E /* TransitionDemo.swift */; };
 		262DA7B32695D99500CABEAE /* ShapeStyleDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262DA7B22695D99500CABEAE /* ShapeStyleDemo.swift */; };
 		262DA7B42695D99500CABEAE /* ShapeStyleDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262DA7B22695D99500CABEAE /* ShapeStyleDemo.swift */; };
-		26AC04B62698D33A0057784E /* ProgressViewDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AC04B52698D33A0057784E /* ProgressViewDemo.swift */; };
-		26AC04B72698D33A0057784E /* ProgressViewDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AC04B52698D33A0057784E /* ProgressViewDemo.swift */; };
+		2681096D26F7715400078F4E /* CanvasDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2681096C26F7715400078F4E /* CanvasDemo.swift */; };
+		2681096E26F7715400078F4E /* CanvasDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2681096C26F7715400078F4E /* CanvasDemo.swift */; };
 		26A3BFB0269BD18A0004DA16 /* AnimationDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A3BFAF269BD18A0004DA16 /* AnimationDemo.swift */; };
 		26A3BFB1269BD18A0004DA16 /* AnimationDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A3BFAF269BD18A0004DA16 /* AnimationDemo.swift */; };
+		26AC04B62698D33A0057784E /* ProgressViewDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AC04B52698D33A0057784E /* ProgressViewDemo.swift */; };
+		26AC04B72698D33A0057784E /* ProgressViewDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AC04B52698D33A0057784E /* ProgressViewDemo.swift */; };
 		3DCDE44424CA6AD400910F17 /* SidebarDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCDE44324CA6AD400910F17 /* SidebarDemo.swift */; };
 		3DCDE44524CA6AD400910F17 /* SidebarDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCDE44324CA6AD400910F17 /* SidebarDemo.swift */; };
 		4550BD5225B642B80088F4EA /* ShadowDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4550BD5125B642B80088F4EA /* ShadowDemo.swift */; };
@@ -107,8 +109,9 @@
 		207C056F2610E16E00BBBE54 /* DatePickerDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatePickerDemo.swift; sourceTree = "<group>"; };
 		26136822269E8EB5006F372E /* TransitionDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionDemo.swift; sourceTree = "<group>"; };
 		262DA7B22695D99500CABEAE /* ShapeStyleDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShapeStyleDemo.swift; sourceTree = "<group>"; };
-		26AC04B52698D33A0057784E /* ProgressViewDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressViewDemo.swift; sourceTree = "<group>"; };
+		2681096C26F7715400078F4E /* CanvasDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CanvasDemo.swift; sourceTree = "<group>"; };
 		26A3BFAF269BD18A0004DA16 /* AnimationDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationDemo.swift; sourceTree = "<group>"; };
+		26AC04B52698D33A0057784E /* ProgressViewDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressViewDemo.swift; sourceTree = "<group>"; };
 		3DCDE44324CA6AD400910F17 /* SidebarDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidebarDemo.swift; sourceTree = "<group>"; };
 		4550BD5125B642B80088F4EA /* ShadowDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShadowDemo.swift; sourceTree = "<group>"; };
 		8500293E24D2FF3E001A2E84 /* SliderDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SliderDemo.swift; sourceTree = "<group>"; };
@@ -209,6 +212,7 @@
 				D120FDDA257E7145008FFBAD /* TextEditorDemo.swift */,
 				B5C76E4924C73ED4003EABB2 /* AppStorageDemo.swift */,
 				D1C726F224CB63C6003B576D /* ButtonStyleDemo.swift */,
+				2681096C26F7715400078F4E /* CanvasDemo.swift */,
 				B56F22DF24BC89FD001738DF /* ColorDemo.swift */,
 				85ED189E24AD425E0085DFA0 /* Counter.swift */,
 				207C056F2610E16E00BBBE54 /* DatePickerDemo.swift */,
@@ -394,6 +398,7 @@
 				D1316F202500352200224A67 /* StackDemo.swift in Sources */,
 				8500293F24D2FF3E001A2E84 /* SliderDemo.swift in Sources */,
 				4550BD5225B642B80088F4EA /* ShadowDemo.swift in Sources */,
+				2681096D26F7715400078F4E /* CanvasDemo.swift in Sources */,
 				85ED18A924AD425E0085DFA0 /* TokamakDemo.swift in Sources */,
 				B5C76E4A24C73ED5003EABB2 /* AppStorageDemo.swift in Sources */,
 				3DCDE44424CA6AD400910F17 /* SidebarDemo.swift in Sources */,
@@ -431,6 +436,7 @@
 				B5F2BE042571443D00FB3653 /* PreferenceKeyDemo.swift in Sources */,
 				8500294024D2FF3E001A2E84 /* SliderDemo.swift in Sources */,
 				4550BD5325B642B80088F4EA /* ShadowDemo.swift in Sources */,
+				2681096E26F7715400078F4E /* CanvasDemo.swift in Sources */,
 				85ED18B624AD42D70085DFA0 /* NSAppDelegate.swift in Sources */,
 				B5C76E4B24C73ED5003EABB2 /* AppStorageDemo.swift in Sources */,
 				3DCDE44524CA6AD400910F17 /* SidebarDemo.swift in Sources */,

--- a/NativeDemo/TokamakDemo.xcodeproj/project.pbxproj
+++ b/NativeDemo/TokamakDemo.xcodeproj/project.pbxproj
@@ -142,7 +142,7 @@
 		D1316F1F2500352200224A67 /* StackDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StackDemo.swift; sourceTree = "<group>"; };
 		D1B4228E24B3B9BB00682F74 /* ListDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListDemo.swift; sourceTree = "<group>"; };
 		D1B4228F24B3B9BB00682F74 /* OutlineGroupDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutlineGroupDemo.swift; sourceTree = "<group>"; };
-		D1C726F224CB63C6003B576D /* ButtonStyleDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonStyleDemo.swift; sourceTree = "<group>"; };
+		D1C726F224CB63C6003B576D /* ButtonStyleDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = ButtonStyleDemo.swift; sourceTree = "<group>"; tabWidth = 2; };
 		D1D6B62224D817350041E1D9 /* GeometryReaderDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeometryReaderDemo.swift; sourceTree = "<group>"; };
 		D1E5FDA424C1D54B00E7485E /* libTokamakShim.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTokamakShim.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		D1E5FDAC24C1D57000E7485E /* TokamakShim.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokamakShim.swift; sourceTree = "<group>"; };

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ app.
 
 ## Requirements for app developers
 
-- macOS 11 and Xcode 12.5. Xcode 13 is currently not supported.
+- macOS 11 and Xcode 13.
 - [Swift 5.4 or later](https://swift.org/download/) and Ubuntu 18.04 if you'd like to use Linux.
   Other Linux distributions are currently not supported.
 

--- a/Sources/TokamakCore/Modifiers/LifecycleModifier.swift
+++ b/Sources/TokamakCore/Modifiers/LifecycleModifier.swift
@@ -19,6 +19,7 @@ public extension View {
     modifier(_AppearanceActionModifier(appear: action))
   }
 
+  @_spi(TokamakCore)
   func _onUpdate(perform action: (() -> ())? = nil) -> some View {
     modifier(_LifecycleActionModifier(update: action))
   }

--- a/Sources/TokamakCore/Modifiers/LifecycleModifier.swift
+++ b/Sources/TokamakCore/Modifiers/LifecycleModifier.swift
@@ -19,8 +19,28 @@ public extension View {
     modifier(_AppearanceActionModifier(appear: action))
   }
 
+  func _onUpdate(perform action: (() -> ())? = nil) -> some View {
+    modifier(_LifecycleActionModifier(update: action))
+  }
+
   @_spi(TokamakCore)
   func _onUnmount(perform action: (() -> ())? = nil) -> some View {
     modifier(_AppearanceActionModifier(disappear: action))
   }
+}
+
+protocol LifecycleActionType {
+  var update: (() -> ())? { get }
+}
+
+struct _LifecycleActionModifier: ViewModifier {
+  var update: (() -> ())?
+
+  typealias Body = Never
+}
+
+extension ModifiedContent: LifecycleActionType
+  where Content: View, Modifier == _LifecycleActionModifier
+{
+  var update: (() -> ())? { modifier.update }
 }

--- a/Sources/TokamakCore/Modifiers/ModifiedContent.swift
+++ b/Sources/TokamakCore/Modifiers/ModifiedContent.swift
@@ -16,8 +16,10 @@ protocol ModifierContainer {
   var environmentModifier: EnvironmentModifier? { get }
 }
 
+protocol ModifiedContentProtocol {}
+
 /// A value with a modifier applied to it.
-public struct ModifiedContent<Content, Modifier> {
+public struct ModifiedContent<Content, Modifier>: ModifiedContentProtocol {
   @Environment(\.self) public var environment
   public typealias Body = Never
   public private(set) var content: Content

--- a/Sources/TokamakCore/Modifiers/StyleModifiers.swift
+++ b/Sources/TokamakCore/Modifiers/StyleModifiers.swift
@@ -169,6 +169,21 @@ public extension View {
     modifier(_OverlayModifier(overlay: overlay, alignment: alignment))
   }
 
+  @inlinable
+  func overlay<V>(
+    alignment: Alignment = .center,
+    @ViewBuilder content: () -> V
+  ) -> some View where V: View {
+    modifier(_OverlayModifier(overlay: content(), alignment: alignment))
+  }
+
+  @inlinable
+  func overlay<S>(
+    _ style: S
+  ) -> some View where S: ShapeStyle {
+    overlay(Rectangle().fill(style))
+  }
+
   func border<S>(_ content: S, width: CGFloat = 1) -> some View where S: ShapeStyle {
     overlay(Rectangle().strokeBorder(content, lineWidth: width))
   }

--- a/Sources/TokamakCore/MountedViews/MountedCompositeView.swift
+++ b/Sources/TokamakCore/MountedViews/MountedCompositeView.swift
@@ -135,5 +135,9 @@ final class MountedCompositeView<R: Renderer>: MountedCompositeElement<R> {
         )
       }
     )
+
+    if let lifecycleActions = view.view as? LifecycleActionType {
+      lifecycleActions.update?()
+    }
   }
 }

--- a/Sources/TokamakCore/MountedViews/MountedCompositeView.swift
+++ b/Sources/TokamakCore/MountedViews/MountedCompositeView.swift
@@ -33,6 +33,8 @@ final class MountedCompositeView<R: Renderer>: MountedCompositeElement<R> {
     transaction.disablesAnimations = true
     self.transaction = transaction
 
+    updateVariadicView()
+
     let childBody = reconciler.render(compositeView: self)
 
     if let traitModifier = view.view as? _TraitWritingModifierProtocol {
@@ -114,6 +116,7 @@ final class MountedCompositeView<R: Renderer>: MountedCompositeElement<R> {
     var transaction = transaction
     transaction.disablesAnimations = false
     (view.view as? _TransactionModifierProtocol)?.modifyTransaction(&transaction)
+    updateVariadicView()
     let element = reconciler.render(compositeView: self)
     reconciler.reconcile(
       self,
@@ -139,5 +142,43 @@ final class MountedCompositeView<R: Renderer>: MountedCompositeElement<R> {
     if let lifecycleActions = view.view as? LifecycleActionType {
       lifecycleActions.update?()
     }
+  }
+
+  private func updateVariadicView() {
+    if var tree = view.view as? _VariadicView_AnyTree {
+      let elements = ((tree.anyContent.view as? GroupView)?.recursiveChildren ?? [tree.anyContent])
+        .enumerated()
+        .map { (pair: EnumeratedSequence<[AnyView]>.Element) -> _VariadicView_Children.Element in
+          var viewTraits = _ViewTraitStore(values: [:])
+          if let traitModifier = pair.element.view as? _TraitWritingModifierProtocol {
+            traitModifier.modifyViewTraitStore(&viewTraits)
+          }
+          return _VariadicView_Children.Element(
+            view: pair.element,
+            id: AnyHashable(pair.offset),
+            // TODO: Retrieve the ID from the `IDView`. Maybe this should use traits too.
+            viewTraits: viewTraits,
+            onTraitsUpdated: { _ in }
+          )
+        }
+      tree.children = _VariadicView_Children(elements: elements)
+      view.view = tree
+    }
+  }
+}
+
+private extension GroupView {
+  var recursiveChildren: [AnyView] {
+    var allChildren = [AnyView]()
+    for child in children {
+      if !(child.view is ModifiedContentProtocol),
+         let group = child.view as? GroupView
+      {
+        allChildren.append(contentsOf: group.recursiveChildren)
+      } else {
+        allChildren.append(child)
+      }
+    }
+    return allChildren
   }
 }

--- a/Sources/TokamakCore/Shapes/Ellipse.swift
+++ b/Sources/TokamakCore/Shapes/Ellipse.swift
@@ -27,7 +27,19 @@ public struct Ellipse: Shape {
 
 public struct Circle: Shape {
   public func path(in rect: CGRect) -> Path {
-    .init(storage: .ellipse(rect), sizing: .flexible)
+    .init(
+      storage: .ellipse(
+        .init(
+          x: rect.origin
+            .x + (rect.width > rect.height ? (rect.width / 2) - (rect.width - rect.height) : 0),
+          y: rect.origin
+            .y + (rect.height > rect.width ? (rect.height / 2) - (rect.height - rect.width) : 0),
+          width: min(rect.width, rect.height),
+          height: min(rect.width, rect.height)
+        )
+      ),
+      sizing: .flexible
+    )
   }
 
   public init() {}

--- a/Sources/TokamakCore/Shapes/Ellipse.swift
+++ b/Sources/TokamakCore/Shapes/Ellipse.swift
@@ -30,10 +30,9 @@ public struct Circle: Shape {
     .init(
       storage: .ellipse(
         .init(
-          x: rect.origin
-            .x + (rect.width > rect.height ? (rect.width / 2) - (rect.width - rect.height) : 0),
-          y: rect.origin
-            .y + (rect.height > rect.width ? (rect.height / 2) - (rect.height - rect.width) : 0),
+          // Center the circle in the rect.
+          x: rect.origin.x + (rect.width > rect.height ? (rect.width - rect.height) / 2 : 0),
+          y: rect.origin.y + (rect.height > rect.width ? (rect.height - rect.width) / 2 : 0),
           width: min(rect.width, rect.height),
           height: min(rect.width, rect.height)
         )

--- a/Sources/TokamakCore/Shapes/Path/Path.swift
+++ b/Sources/TokamakCore/Shapes/Path/Path.swift
@@ -20,7 +20,7 @@ import Foundation
 /// The outline of a 2D shape.
 public struct Path: Equatable, LosslessStringConvertible {
   public class _PathBox: Equatable {
-    var elements: [Element] = []
+    public var elements: [Element] = []
     public static func == (lhs: Path._PathBox, rhs: Path._PathBox) -> Bool {
       lhs.elements == rhs.elements
     }

--- a/Sources/TokamakCore/Shapes/Rectangle.swift
+++ b/Sources/TokamakCore/Shapes/Rectangle.swift
@@ -39,8 +39,8 @@ extension Rectangle: InsettableShape {
         storage: .rect(CGRect(
           origin: rect.origin,
           size: CGSize(
-            width: rect.size.width - (amount / 2),
-            height: rect.size.height - (amount / 2)
+            width: max(0, rect.size.width - (amount / 2)),
+            height: max(0, rect.size.height - (amount / 2))
           )
         )),
         sizing: .flexible
@@ -105,8 +105,8 @@ extension RoundedRectangle: InsettableShape {
           rect: CGRect(
             origin: rect.origin,
             size: CGSize(
-              width: rect.size.width - (amount / 2),
-              height: rect.size.height - (amount / 2)
+              width: max(0, rect.size.width - (amount / 2)),
+              height: max(0, rect.size.height - (amount / 2))
             )
           ),
           cornerSize: CGSize(

--- a/Sources/TokamakCore/Shapes/Rectangle.swift
+++ b/Sources/TokamakCore/Shapes/Rectangle.swift
@@ -80,3 +80,50 @@ public struct RoundedRectangle: Shape {
     )
   }
 }
+
+extension RoundedRectangle: InsettableShape {
+  @inlinable
+  public func inset(by amount: CGFloat) -> some InsettableShape {
+    _Inset(base: self, amount: amount)
+  }
+
+  @usableFromInline
+  struct _Inset: InsettableShape {
+    @usableFromInline var base: RoundedRectangle
+    @usableFromInline var amount: CGFloat
+
+    @inlinable
+    init(base: RoundedRectangle, amount: CGFloat) {
+      self.base = base
+      self.amount = amount
+    }
+
+    @usableFromInline
+    func path(in rect: CGRect) -> Path {
+      .init(
+        storage: .roundedRect(.init(
+          rect: CGRect(
+            origin: rect.origin,
+            size: CGSize(
+              width: rect.size.width - (amount / 2),
+              height: rect.size.height - (amount / 2)
+            )
+          ),
+          cornerSize: CGSize(
+            width: max(0, base.cornerSize.width - (amount / 2)),
+            height: max(0, base.cornerSize.height - (amount / 2))
+          ),
+          style: base.style
+        )),
+        sizing: .flexible
+      )
+    }
+
+    @usableFromInline
+    func inset(by amount: CGFloat) -> Self {
+      var copy = self
+      copy.amount += amount
+      return copy
+    }
+  }
+}

--- a/Sources/TokamakCore/ViewTraits/TagValueTraitKey.swift
+++ b/Sources/TokamakCore/ViewTraits/TagValueTraitKey.swift
@@ -1,0 +1,47 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/23/21.
+//
+
+import Foundation
+
+public extension View {
+  @inlinable
+  func tag<V>(_ tag: V) -> some View where V: Hashable {
+    _trait(TagValueTraitKey<V>.self, .tagged(tag))
+  }
+
+  @inlinable
+  func _untagged() -> some View {
+    _trait(IsAuxiliaryContentTraitKey.self, true)
+  }
+}
+
+@usableFromInline
+struct TagValueTraitKey<V>: _ViewTraitKey where V: Hashable {
+  @usableFromInline
+  enum Value {
+    case untagged
+    case tagged(V)
+  }
+
+  @inlinable static var defaultValue: Value { .untagged }
+}
+
+@usableFromInline
+struct IsAuxiliaryContentTraitKey: _ViewTraitKey {
+  @inlinable static var defaultValue: Bool { false }
+  @usableFromInline typealias Value = Bool
+}

--- a/Sources/TokamakCore/ViewTraits/TagValueTraitKey.swift
+++ b/Sources/TokamakCore/ViewTraits/TagValueTraitKey.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Tokamak contributors
+// Copyright 2021 Tokamak contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/TokamakCore/Views/Canvas/Canvas.swift
+++ b/Sources/TokamakCore/Views/Canvas/Canvas.swift
@@ -29,7 +29,8 @@ public struct Canvas<Symbols> where Symbols: View {
     onOperation: @escaping (GraphicsContext._Storage, GraphicsContext._Storage._Operation) -> (),
     imageResolver: @escaping (Image, EnvironmentValues) -> GraphicsContext.ResolvedImage,
     textResolver: @escaping (Text, EnvironmentValues) -> GraphicsContext.ResolvedText,
-    symbolResolver: @escaping (AnyView, EnvironmentValues) -> GraphicsContext.ResolvedSymbol
+    symbolResolver: @escaping (AnyHashable, AnyView, EnvironmentValues) -> GraphicsContext
+      .ResolvedSymbol
   ) -> GraphicsContext {
     .init(_storage: .init(
       in: _environment,

--- a/Sources/TokamakCore/Views/Canvas/Canvas.swift
+++ b/Sources/TokamakCore/Views/Canvas/Canvas.swift
@@ -29,13 +29,14 @@ public struct Canvas<Symbols> where Symbols: View {
     onOperation: @escaping (GraphicsContext._Storage, GraphicsContext._Storage._Operation) -> (),
     imageResolver: @escaping (Image, EnvironmentValues) -> GraphicsContext.ResolvedImage,
     textResolver: @escaping (Text, EnvironmentValues) -> GraphicsContext.ResolvedText,
-    symbolResolver: @escaping (AnyHashable) -> GraphicsContext.ResolvedSymbol
+    symbolResolver: @escaping (AnyView, EnvironmentValues) -> GraphicsContext.ResolvedSymbol
   ) -> GraphicsContext {
     .init(_storage: .init(
       in: _environment,
       with: onOperation,
       imageResolver: imageResolver,
       textResolver: textResolver,
+      symbols: AnyView(symbols),
       symbolResolver: symbolResolver
     ))
   }

--- a/Sources/TokamakCore/Views/Canvas/Canvas.swift
+++ b/Sources/TokamakCore/Views/Canvas/Canvas.swift
@@ -1,0 +1,110 @@
+// Copyright 2020-2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/17/21.
+//
+
+import Foundation
+
+public struct Canvas<Symbols> where Symbols: View {
+  public var symbols: Symbols
+  public var renderer: (inout GraphicsContext, CGSize) -> ()
+  public var isOpaque: Bool
+  public var colorMode: ColorRenderingMode
+  public var rendersAsynchronously: Bool
+
+  @Environment(\.self) public var _environment: EnvironmentValues
+  public func _makeContext(
+    onOperation: @escaping (GraphicsContext._Storage, GraphicsContext._Storage._Operation) -> (),
+    imageResolver: @escaping (Image, EnvironmentValues) -> GraphicsContext.ResolvedImage,
+    textResolver: @escaping (Text, EnvironmentValues) -> GraphicsContext.ResolvedText,
+    symbolResolver: @escaping (AnyHashable) -> GraphicsContext.ResolvedSymbol
+  ) -> GraphicsContext {
+    .init(_storage: .init(
+      in: _environment,
+      with: onOperation,
+      imageResolver: imageResolver,
+      textResolver: textResolver,
+      symbolResolver: symbolResolver
+    ))
+  }
+
+  public init(
+    opaque: Bool = false,
+    colorMode: ColorRenderingMode = .nonLinear,
+    rendersAsynchronously: Bool = false,
+    renderer: @escaping (inout GraphicsContext, CGSize) -> (),
+    @ViewBuilder symbols: () -> Symbols
+  ) {
+    isOpaque = opaque
+    self.colorMode = colorMode
+    self.rendersAsynchronously = rendersAsynchronously
+    self.renderer = renderer
+    self.symbols = symbols()
+  }
+}
+
+extension Canvas: _PrimitiveView {}
+
+public extension Canvas where Symbols == EmptyView {
+  init(
+    opaque: Bool = false,
+    colorMode: ColorRenderingMode = .nonLinear,
+    rendersAsynchronously: Bool = false,
+    renderer: @escaping (inout GraphicsContext, CGSize) -> ()
+  ) {
+    isOpaque = opaque
+    self.colorMode = colorMode
+    self.rendersAsynchronously = rendersAsynchronously
+    self.renderer = renderer
+    symbols = EmptyView()
+  }
+}
+
+public enum ColorRenderingMode: Hashable {
+  case nonLinear
+  case linear
+  case extendedLinear
+}
+
+public struct ColorMatrix: Equatable {
+  public var r1: Float = 1, r2: Float = 0, r3: Float = 0, r4: Float = 0, r5: Float = 0
+  public var g1: Float = 0, g2: Float = 1, g3: Float = 0, g4: Float = 0, g5: Float = 0
+  public var b1: Float = 0, b2: Float = 0, b3: Float = 1, b4: Float = 0, b5: Float = 0
+  public var a1: Float = 0, a2: Float = 0, a3: Float = 0, a4: Float = 1, a5: Float = 0
+
+  @inlinable
+  public init() {}
+}
+
+public struct _ColorMatrix: Equatable, Codable {
+  public var m11: Float = 1, m12: Float = 0, m13: Float = 0, m14: Float = 0, m15: Float = 0
+  public var m21: Float = 0, m22: Float = 1, m23: Float = 0, m24: Float = 0, m25: Float = 0
+  public var m31: Float = 0, m32: Float = 0, m33: Float = 1, m34: Float = 0, m35: Float = 0
+  public var m41: Float = 0, m42: Float = 0, m43: Float = 0, m44: Float = 1, m45: Float = 0
+
+  @inlinable
+  public init() {}
+
+  public init(color: Color, in environment: EnvironmentValues) {
+    m11 = 0
+    m15 = Float(color.provider.resolve(in: environment).red / 255)
+    m22 = 0
+    m25 = Float(color.provider.resolve(in: environment).green / 255)
+    m33 = 0
+    m35 = Float(color.provider.resolve(in: environment).blue / 255)
+    m44 = 0
+    m45 = Float(color.provider.resolve(in: environment).opacity / 255)
+  }
+}

--- a/Sources/TokamakCore/Views/Canvas/GraphicsContext/BlendMode.swift
+++ b/Sources/TokamakCore/Views/Canvas/GraphicsContext/BlendMode.swift
@@ -1,0 +1,51 @@
+// Copyright 2020-2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/18/21.
+//
+
+import Foundation
+
+public extension GraphicsContext {
+  enum BlendMode: Int32, Equatable {
+    case normal
+    case multiply
+    case screen
+    case overlay
+    case darken
+    case lighten
+    case colorDodge
+    case colorBurn
+    case softLight
+    case hardLight
+    case difference
+    case exclusion
+    case hue
+    case saturation
+    case color
+    case luminosity
+    case clear
+    case copy
+    case sourceIn
+    case sourceOut
+    case sourceAtop
+    case destinationOver
+    case destinationIn
+    case destinationOut
+    case destinationAtop
+    case xor
+    case plusDarker
+    case plusLighter
+  }
+}

--- a/Sources/TokamakCore/Views/Canvas/GraphicsContext/Filter.swift
+++ b/Sources/TokamakCore/Views/Canvas/GraphicsContext/Filter.swift
@@ -1,0 +1,163 @@
+// Copyright 2020-2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/18/21.
+//
+
+import Foundation
+
+public extension GraphicsContext {
+  struct Filter {
+    public let _storage: _Storage
+
+    private init(_ storage: _Storage) {
+      _storage = storage
+    }
+
+    public enum _Storage {
+      case projectionTransform(ProjectionTransform)
+      case shadow(
+        color: Color = Color(.sRGBLinear, white: 0, opacity: 0.33),
+        radius: CGFloat,
+        x: CGFloat = 0,
+        y: CGFloat = 0,
+        blendMode: BlendMode = .normal,
+        options: ShadowOptions = ShadowOptions()
+      )
+      case colorMultiply(Color)
+      case colorMatrix(ColorMatrix)
+      case hueRotation(Angle)
+      case saturation(Double)
+      case brightness(Double)
+      case contrast(Double)
+      case colorInvert(Double = 1)
+      case grayscale(Double)
+      case luminanceToAlpha
+      case blur(
+        radius: CGFloat,
+        options: BlurOptions = .opaque
+      )
+      case alphaThreshold(
+        min: Double,
+        max: Double = 1,
+        color: Color = Color.black
+      )
+    }
+
+    public static func projectionTransform(_ matrix: ProjectionTransform) -> Self {
+      .init(.projectionTransform(matrix))
+    }
+
+    public static func shadow(
+      color: Color = Color(.sRGBLinear, white: 0, opacity: 0.33),
+      radius: CGFloat,
+      x: CGFloat = 0,
+      y: CGFloat = 0,
+      blendMode: BlendMode = .normal,
+      options: ShadowOptions = ShadowOptions()
+    ) -> Self {
+      .init(.shadow(
+        color: color,
+        radius: radius,
+        x: x,
+        y: y,
+        blendMode: blendMode,
+        options: options
+      ))
+    }
+
+    public static func colorMultiply(_ color: Color) -> Self {
+      .init(.colorMultiply(color))
+    }
+
+    public static func colorMatrix(_ matrix: ColorMatrix) -> Self {
+      .init(.colorMatrix(matrix))
+    }
+
+    public static func hueRotation(_ angle: Angle) -> Self {
+      .init(.hueRotation(angle))
+    }
+
+    public static func saturation(_ amount: Double) -> Self {
+      .init(.saturation(amount))
+    }
+
+    public static func brightness(_ amount: Double) -> Self {
+      .init(.brightness(amount))
+    }
+
+    public static func contrast(_ amount: Double) -> Self {
+      .init(.contrast(amount))
+    }
+
+    public static func colorInvert(_ amount: Double = 1) -> Self {
+      .init(.colorInvert(amount))
+    }
+
+    public static func grayscale(_ amount: Double) -> Self {
+      .init(.grayscale(amount))
+    }
+
+    public static var luminanceToAlpha: Self {
+      .init(.luminanceToAlpha)
+    }
+
+    public static func blur(
+      radius: CGFloat,
+      options: BlurOptions = BlurOptions()
+    ) -> Filter {
+      .init(.blur(radius: radius, options: options))
+    }
+
+    public static func alphaThreshold(
+      min: Double,
+      max: Double = 1,
+      color: Color = Color.black
+    ) -> Filter {
+      .init(.alphaThreshold(min: min, max: max, color: color))
+    }
+  }
+
+  @frozen struct ShadowOptions: OptionSet {
+    public let rawValue: UInt32
+    @inlinable
+    public init(rawValue: UInt32) { self.rawValue = rawValue }
+    @inlinable public static var shadowAbove: Self { Self(rawValue: 1 << 0) }
+    @inlinable public static var shadowOnly: Self { Self(rawValue: 1 << 1) }
+    @inlinable public static var invertsAlpha: Self { Self(rawValue: 1 << 2) }
+    @inlinable public static var disablesGroup: Self { Self(rawValue: 1 << 3) }
+  }
+
+  @frozen struct BlurOptions: OptionSet {
+    public let rawValue: UInt32
+    @inlinable
+    public init(rawValue: UInt32) { self.rawValue = rawValue }
+    @inlinable public static var opaque: Self { Self(rawValue: 1 << 0) }
+    @inlinable public static var dithersResult: Self { Self(rawValue: 1 << 1) }
+  }
+
+  @frozen struct FilterOptions: OptionSet {
+    public let rawValue: UInt32
+    @inlinable
+    public init(rawValue: UInt32) { self.rawValue = rawValue }
+    @inlinable public static var linearColor: Self { Self(rawValue: 1 << 0) }
+  }
+
+  mutating func addFilter(
+    _ filter: Filter,
+    options: FilterOptions = FilterOptions()
+  ) {
+    _storage.perform(.addFilter(filter, options: options))
+  }
+}

--- a/Sources/TokamakCore/Views/Canvas/GraphicsContext/GraphicsContext.swift
+++ b/Sources/TokamakCore/Views/Canvas/GraphicsContext/GraphicsContext.swift
@@ -1,0 +1,164 @@
+// Copyright 2020-2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/18/21.
+//
+
+import Foundation
+
+public struct GraphicsContext {
+  public struct _Storage {
+    public var opacity: Double
+    public var blendMode: BlendMode
+    public var environment: EnvironmentValues
+    public var transform: CGAffineTransform
+    public var clipBoundingRect: CGRect
+
+    public var operationHandler: (Self, _Operation) -> ()
+    public var imageResolver: (Image, EnvironmentValues) -> ResolvedImage
+    public var textResolver: (Text, EnvironmentValues) -> ResolvedText
+    public var symbolResolver: (AnyHashable) -> ResolvedSymbol
+
+    init(
+      in environment: EnvironmentValues,
+      with operationHandler: @escaping (Self, _Operation) -> (),
+      imageResolver: @escaping (Image, EnvironmentValues) -> ResolvedImage,
+      textResolver: @escaping (Text, EnvironmentValues) -> ResolvedText,
+      symbolResolver: @escaping (AnyHashable) -> ResolvedSymbol
+    ) {
+      opacity = 1
+      blendMode = .normal
+      self.environment = environment
+      transform = .identity
+      clipBoundingRect = .zero
+      self.operationHandler = operationHandler
+      self.imageResolver = imageResolver
+      self.textResolver = textResolver
+      self.symbolResolver = symbolResolver
+    }
+
+    public func perform(_ operation: _Operation) {
+      operationHandler(self, operation)
+    }
+
+    public enum _Operation {
+      case clip(Path, style: FillStyle, options: ClipOptions)
+      case beginClipLayer(GraphicsContext, opacity: Double)
+      case endClipLayer
+      case addFilter(Filter, options: FilterOptions)
+      case beginLayer(GraphicsContext)
+      case endLayer
+      case fill(Path, with: Shading, style: FillStyle)
+      case stroke(Path, with: Shading, style: StrokeStyle)
+      case drawImage(ResolvedImage, _ResolvedPositioning, style: FillStyle? = .init())
+      case drawText(ResolvedText, _ResolvedPositioning)
+      case drawSymbol(ResolvedSymbol, _ResolvedPositioning)
+
+      public enum _ResolvedPositioning {
+        case `in`(CGRect)
+        case at(CGPoint, anchor: UnitPoint = .center)
+      }
+    }
+  }
+
+  public var _storage: _Storage
+
+  public var opacity: Double {
+    get { _storage.opacity }
+    set { _storage.opacity = newValue }
+  }
+
+  public var blendMode: BlendMode {
+    get { _storage.blendMode }
+    set { _storage.blendMode = newValue }
+  }
+
+  public var environment: EnvironmentValues {
+    get { _storage.environment }
+    set { _storage.environment = newValue }
+  }
+
+  public var transform: CGAffineTransform {
+    get { _storage.transform }
+    set { _storage.transform = newValue }
+  }
+
+  public mutating func scaleBy(x: CGFloat, y: CGFloat) {
+    addFilter(.projectionTransform(.init(.init(scaleX: x, y: y))))
+  }
+
+  public mutating func translateBy(x: CGFloat, y: CGFloat) {
+    addFilter(.projectionTransform(.init(.init(translationX: x, y: y))))
+  }
+
+  public mutating func rotate(by angle: Angle) {
+    addFilter(.projectionTransform(.init(.init(rotationAngle: CGFloat(angle.radians)))))
+  }
+
+  public mutating func concatenate(_ matrix: CGAffineTransform) {
+    addFilter(.projectionTransform(.init(matrix)))
+  }
+
+  @frozen public struct ClipOptions: OptionSet {
+    public let rawValue: UInt32
+    @inlinable
+    public init(rawValue: UInt32) { self.rawValue = rawValue }
+    @inlinable public static var inverse: Self { Self(rawValue: 1 << 0) }
+  }
+
+  public var clipBoundingRect: CGRect {
+    get { _storage.clipBoundingRect }
+    set { _storage.clipBoundingRect = newValue }
+  }
+
+  public mutating func clip(
+    to path: Path,
+    style: FillStyle = FillStyle(),
+    options: ClipOptions = ClipOptions()
+  ) {
+    _storage.perform(.clip(path, style: style, options: options))
+  }
+
+  public mutating func clipToLayer(
+    opacity: Double = 1,
+    options: ClipOptions = ClipOptions(),
+    content: (inout GraphicsContext) throws -> ()
+  ) rethrows {
+    var layer = GraphicsContext(_storage: _storage)
+    _storage.perform(.beginClipLayer(layer, opacity: opacity))
+    try content(&layer)
+    _storage.perform(.endClipLayer)
+  }
+
+  public func drawLayer(content: (inout GraphicsContext) throws -> ()) rethrows {
+    var layer = GraphicsContext(_storage: _storage)
+    _storage.perform(.beginLayer(layer))
+    try content(&layer)
+    _storage.perform(.endLayer)
+  }
+
+  public func fill(_ path: Path, with shading: Shading, style: FillStyle = FillStyle()) {
+    _storage.perform(.fill(path, with: shading, style: style))
+  }
+
+  public func stroke(_ path: Path, with shading: Shading, style: StrokeStyle) {
+    _storage.perform(.stroke(path, with: shading, style: style))
+  }
+
+  public func stroke(_ path: Path, with shading: Shading, lineWidth: CGFloat = 1) {
+    stroke(path, with: shading, style: .init(lineWidth: lineWidth))
+  }
+
+//  public func withCGContext(content: (CGContext) throws -> ()) rethrows
+}

--- a/Sources/TokamakCore/Views/Canvas/GraphicsContext/GraphicsContext.swift
+++ b/Sources/TokamakCore/Views/Canvas/GraphicsContext/GraphicsContext.swift
@@ -29,7 +29,7 @@ public struct GraphicsContext {
     public var imageResolver: (Image, EnvironmentValues) -> ResolvedImage
     public var textResolver: (Text, EnvironmentValues) -> ResolvedText
     let symbols: AnyView
-    public var symbolResolver: (AnyView, EnvironmentValues) -> ResolvedSymbol
+    public var symbolResolver: (AnyHashable, AnyView, EnvironmentValues) -> ResolvedSymbol
 
     init(
       in environment: EnvironmentValues,
@@ -37,7 +37,7 @@ public struct GraphicsContext {
       imageResolver: @escaping (Image, EnvironmentValues) -> ResolvedImage,
       textResolver: @escaping (Text, EnvironmentValues) -> ResolvedText,
       symbols: AnyView,
-      symbolResolver: @escaping (AnyView, EnvironmentValues) -> ResolvedSymbol
+      symbolResolver: @escaping (AnyHashable, AnyView, EnvironmentValues) -> ResolvedSymbol
     ) {
       opacity = 1
       blendMode = .normal

--- a/Sources/TokamakCore/Views/Canvas/GraphicsContext/GraphicsContext.swift
+++ b/Sources/TokamakCore/Views/Canvas/GraphicsContext/GraphicsContext.swift
@@ -28,14 +28,16 @@ public struct GraphicsContext {
     public var operationHandler: (Self, _Operation) -> ()
     public var imageResolver: (Image, EnvironmentValues) -> ResolvedImage
     public var textResolver: (Text, EnvironmentValues) -> ResolvedText
-    public var symbolResolver: (AnyHashable) -> ResolvedSymbol
+    let symbols: AnyView
+    public var symbolResolver: (AnyView, EnvironmentValues) -> ResolvedSymbol
 
     init(
       in environment: EnvironmentValues,
       with operationHandler: @escaping (Self, _Operation) -> (),
       imageResolver: @escaping (Image, EnvironmentValues) -> ResolvedImage,
       textResolver: @escaping (Text, EnvironmentValues) -> ResolvedText,
-      symbolResolver: @escaping (AnyHashable) -> ResolvedSymbol
+      symbols: AnyView,
+      symbolResolver: @escaping (AnyView, EnvironmentValues) -> ResolvedSymbol
     ) {
       opacity = 1
       blendMode = .normal
@@ -45,6 +47,7 @@ public struct GraphicsContext {
       self.operationHandler = operationHandler
       self.imageResolver = imageResolver
       self.textResolver = textResolver
+      self.symbols = symbols
       self.symbolResolver = symbolResolver
     }
 

--- a/Sources/TokamakCore/Views/Canvas/GraphicsContext/Resolvables.swift
+++ b/Sources/TokamakCore/Views/Canvas/GraphicsContext/Resolvables.swift
@@ -1,0 +1,137 @@
+// Copyright 2020-2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/18/21.
+//
+
+import Foundation
+
+public extension GraphicsContext {
+  struct ResolvedImage {
+    public let _image: Image
+
+    public let size: CGSize
+    public let baseline: CGFloat
+    public var shading: Shading?
+
+    public static func _resolved(
+      _ image: Image,
+      size: CGSize,
+      baseline: CGFloat,
+      shading: Shading? = nil
+    ) -> Self {
+      self.init(_image: image, size: size, baseline: baseline, shading: shading)
+    }
+  }
+
+  func resolve(_ image: Image) -> ResolvedImage {
+    _storage.imageResolver(image, _storage.environment)
+  }
+
+  func draw(_ image: ResolvedImage, in rect: CGRect, style: FillStyle = FillStyle()) {
+    _storage.perform(.drawImage(image, .in(rect), style: style))
+  }
+
+  func draw(_ image: ResolvedImage, at point: CGPoint, anchor: UnitPoint = .center) {
+    _storage.perform(.drawImage(image, .at(point, anchor: anchor), style: nil))
+  }
+
+  func draw(_ image: Image, in rect: CGRect, style: FillStyle = FillStyle()) {
+    draw(resolve(image), in: rect, style: style)
+  }
+
+  func draw(_ image: Image, at point: CGPoint, anchor: UnitPoint = .center) {
+    draw(resolve(image), at: point, anchor: anchor)
+  }
+
+  struct ResolvedText {
+    public let _text: Text
+    public var shading: Shading
+
+    private let lazyLayoutComputer: (CGSize) -> _Layout
+
+    public struct _Layout {
+      let size: CGSize
+      let firstBaseline: CGFloat
+      let lastBaseline: CGFloat
+
+      public init(size: CGSize, firstBaseline: CGFloat, lastBaseline: CGFloat) {
+        self.size = size
+        self.firstBaseline = firstBaseline
+        self.lastBaseline = lastBaseline
+      }
+    }
+
+    public static func _resolved(
+      _ text: Text,
+      shading: Shading,
+      lazyLayoutComputer: @escaping (CGSize) -> _Layout
+    ) -> Self {
+      .init(_text: text, shading: shading, lazyLayoutComputer: lazyLayoutComputer)
+    }
+
+    public func measure(in size: CGSize) -> CGSize {
+      lazyLayoutComputer(size).size
+    }
+
+    public func firstBaseline(in size: CGSize) -> CGFloat {
+      lazyLayoutComputer(size).firstBaseline
+    }
+
+    public func lastBaseline(in size: CGSize) -> CGFloat {
+      lazyLayoutComputer(size).lastBaseline
+    }
+  }
+
+  func resolve(_ text: Text) -> ResolvedText {
+    _storage.textResolver(text, _storage.environment)
+  }
+
+  func draw(_ text: ResolvedText, in rect: CGRect) {
+    _storage.perform(.drawText(text, .in(rect)))
+  }
+
+  func draw(_ text: ResolvedText, at point: CGPoint, anchor: UnitPoint = .center) {
+    _storage.perform(.drawText(text, .at(point, anchor: anchor)))
+  }
+
+  func draw(_ text: Text, in rect: CGRect) {
+    draw(resolve(text), in: rect)
+  }
+
+  func draw(_ text: Text, at point: CGPoint, anchor: UnitPoint = .center) {
+    draw(resolve(text), at: point, anchor: anchor)
+  }
+
+  struct ResolvedSymbol {
+    public let _id: AnyHashable
+    public let size: CGSize
+
+    public static func _resolve(_ id: AnyHashable, size: CGSize) -> Self {
+      .init(_id: id, size: size)
+    }
+  }
+
+  func resolveSymbol<ID>(id: ID) -> ResolvedSymbol? where ID: Hashable {
+    _storage.symbolResolver(AnyHashable(id))
+  }
+
+  func draw(_ symbol: ResolvedSymbol, in rect: CGRect) {
+    _storage.perform(.drawSymbol(symbol, .in(rect)))
+  }
+
+  func draw(_ symbol: ResolvedSymbol, at point: CGPoint, anchor: UnitPoint = .center) {
+    _storage.perform(.drawSymbol(symbol, .at(point, anchor: anchor)))
+  }
+}

--- a/Sources/TokamakCore/Views/Canvas/GraphicsContext/Resolvables.swift
+++ b/Sources/TokamakCore/Views/Canvas/GraphicsContext/Resolvables.swift
@@ -19,19 +19,19 @@ import Foundation
 
 public extension GraphicsContext {
   struct ResolvedImage {
-    public let _image: Image
+    public let _resolved: _AnyImageProviderBox.ResolvedValue
 
     public let size: CGSize
     public let baseline: CGFloat
     public var shading: Shading?
 
     public static func _resolved(
-      _ image: Image,
+      _ resolved: _AnyImageProviderBox.ResolvedValue,
       size: CGSize,
       baseline: CGFloat,
       shading: Shading? = nil
     ) -> Self {
-      self.init(_image: image, size: size, baseline: baseline, shading: shading)
+      self.init(_resolved: resolved, size: size, baseline: baseline, shading: shading)
     }
   }
 
@@ -117,16 +117,18 @@ public extension GraphicsContext {
   struct ResolvedSymbol {
     /// The renderer-specific resolved `View` data.
     public let _resolved: Any
+    public let _id: AnyHashable
     public let size: CGSize
 
-    public static func _resolve(_ resolved: Any, size: CGSize) -> Self {
-      .init(_resolved: resolved, size: size)
+    public static func _resolve(_ resolved: Any, id: AnyHashable, size: CGSize) -> Self {
+      .init(_resolved: resolved, _id: id, size: size)
     }
   }
 
   /// Resolves a symbol marked with the tag `id`.
   func resolveSymbol<ID>(id: ID) -> ResolvedSymbol? where ID: Hashable {
     _storage.symbolResolver(
+      AnyHashable(id),
       AnyView(
         _VariadicView.Tree(SymbolResolverLayout(id: id)) {
           _storage.symbols

--- a/Sources/TokamakCore/Views/Canvas/GraphicsContext/Shading.swift
+++ b/Sources/TokamakCore/Views/Canvas/GraphicsContext/Shading.swift
@@ -1,0 +1,190 @@
+// Copyright 2020-2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/18/21.
+//
+
+import Foundation
+
+public extension GraphicsContext {
+  enum _GradientGeometry {
+    case axial(CGPoint, CGPoint)
+    case conic(CGPoint, Angle)
+    case radial(CGPoint, CGFloat, CGFloat)
+  }
+
+  enum _ResolvedShading {
+    case levels([Self])
+    case style(_ResolvedStyle)
+    case gradient(Gradient, geometry: _GradientGeometry, options: GradientOptions)
+    case tiledImage(
+      Image,
+      origin: CGPoint = .zero,
+      sourceRect: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1),
+      scale: CGFloat = 1
+    )
+  }
+
+  struct Shading {
+    public enum _Storage {
+      case backdrop
+      case foreground
+      case levels([Shading])
+      case color(Color)
+      case style(ShapeStyle)
+      case gradient(Gradient, geometry: _GradientGeometry, options: GradientOptions)
+      case tiledImage(
+        Image,
+        origin: CGPoint = .zero,
+        sourceRect: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1),
+        scale: CGFloat = 1
+      )
+      case resolved(_ResolvedShading)
+    }
+
+    public let _storage: _Storage
+
+    fileprivate init(_ storage: _Storage) {
+      _storage = storage
+    }
+
+    public func _resolve(in environment: EnvironmentValues) -> Self {
+      switch _storage {
+      case .backdrop:
+        return Self.style(BackgroundStyle())._resolve(in: environment)
+      case .foreground:
+        return Self.style(ForegroundStyle())._resolve(in: environment)
+      case let .levels(colors):
+        return .init(.resolved(.levels(colors.compactMap {
+          guard case let .resolved(resolved) = $0._resolve(in: environment)._storage
+          else { return nil }
+          return resolved
+        })))
+      case let .color(color):
+        return Self.style(color)._resolve(in: environment)
+      case let .style(shapeStyle):
+        var shape = _ShapeStyle_Shape(
+          for: .resolveStyle(levels: 0..<1),
+          in: environment,
+          role: .fill
+        )
+        shapeStyle._apply(to: &shape)
+        guard let style = shape.result.resolvedStyle(on: shape, in: environment)
+        else {
+          return .init(.resolved(.style(.color(.init(
+            red: 0,
+            green: 0,
+            blue: 0,
+            opacity: 1,
+            space: .sRGB
+          )))))
+        }
+        return .init(.resolved(.style(style)))
+      case let .gradient(gradient, geometry, options):
+        return .init(.resolved(.gradient(gradient, geometry: geometry, options: options)))
+      case let .tiledImage(image, origin, sourceRect, scale):
+        return .init(.resolved(.tiledImage(
+          image,
+          origin: origin,
+          sourceRect: sourceRect,
+          scale: scale
+        )))
+      case .resolved:
+        return self
+      }
+    }
+
+    public static var backdrop: Shading { .init(.backdrop) }
+    public static var foreground: Shading { .init(.foreground) }
+
+    public static func palette(_ array: [Shading]) -> Shading { .init(.levels(array)) }
+
+    public static func color(_ color: Color) -> Shading { .init(.color(color)) }
+    public static func color(
+      _ colorSpace: Color.RGBColorSpace = .sRGB,
+      red: Double,
+      green: Double,
+      blue: Double,
+      opacity: Double = 1
+    ) -> Shading {
+      .init(.color(Color(colorSpace, red: red, green: green, blue: blue, opacity: opacity)))
+    }
+
+    public static func color(
+      _ colorSpace: Color.RGBColorSpace = .sRGB,
+      white: Double,
+      opacity: Double = 1
+    ) -> Shading {
+      .init(.color(Color(colorSpace, white: white, opacity: opacity)))
+    }
+
+    public static func style<S>(_ style: S) -> Shading where S: ShapeStyle {
+      .init(.style(style))
+    }
+
+    public static func linearGradient(
+      _ gradient: Gradient,
+      startPoint: CGPoint,
+      endPoint: CGPoint,
+      options: GradientOptions = GradientOptions()
+    ) -> Shading {
+      .init(.gradient(gradient, geometry: .axial(startPoint, endPoint), options: options))
+    }
+
+    public static func radialGradient(
+      _ gradient: Gradient,
+      center: CGPoint,
+      startRadius: CGFloat,
+      endRadius: CGFloat,
+      options: GradientOptions = GradientOptions()
+    ) -> Shading {
+      .init(.gradient(
+        gradient,
+        geometry: .radial(center, startRadius, endRadius),
+        options: options
+      ))
+    }
+
+    public static func conicGradient(
+      _ gradient: Gradient,
+      center: CGPoint,
+      angle: Angle = Angle(),
+      options: GradientOptions = GradientOptions()
+    ) -> Shading {
+      .init(.gradient(gradient, geometry: .conic(center, angle), options: options))
+    }
+
+    public static func tiledImage(
+      _ image: Image,
+      origin: CGPoint = .zero,
+      sourceRect: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1),
+      scale: CGFloat = 1
+    ) -> Shading {
+      .init(.tiledImage(image, origin: origin, sourceRect: sourceRect, scale: scale))
+    }
+  }
+
+  @frozen struct GradientOptions: OptionSet {
+    public let rawValue: UInt32
+    @inlinable
+    public init(rawValue: UInt32) { self.rawValue = rawValue }
+    @inlinable public static var `repeat`: Self { Self(rawValue: 1 << 0) }
+    @inlinable public static var mirror: Self { Self(rawValue: 1 << 1) }
+    @inlinable public static var linearColor: Self { Self(rawValue: 1 << 2) }
+  }
+
+  func resolve(_ shading: Shading) -> Shading {
+    shading._resolve(in: _storage.environment)
+  }
+}

--- a/Sources/TokamakCore/Views/Canvas/TimelineView.swift
+++ b/Sources/TokamakCore/Views/Canvas/TimelineView.swift
@@ -166,7 +166,7 @@ public extension TimelineSchedule where Self == AnimationTimelineSchedule {
 
 public struct AnimationTimelineSchedule: TimelineSchedule {
   private let minimumInterval: Double?
-  private let paused: Bool
+  public let _paused: Bool
 
   public struct Entries: Sequence, IteratorProtocol {
     var date: Date
@@ -185,10 +185,10 @@ public struct AnimationTimelineSchedule: TimelineSchedule {
 
   public init(minimumInterval: Double? = nil, paused: Bool = false) {
     self.minimumInterval = minimumInterval
-    self.paused = paused
+    _paused = paused
   }
 
   public func entries(from startDate: Date, mode: TimelineScheduleMode) -> Entries {
-    Entries(date: startDate, minimumInterval: minimumInterval, paused: paused)
+    Entries(date: startDate, minimumInterval: minimumInterval, paused: _paused)
   }
 }

--- a/Sources/TokamakCore/Views/Canvas/TimelineView.swift
+++ b/Sources/TokamakCore/Views/Canvas/TimelineView.swift
@@ -1,0 +1,196 @@
+// Copyright 2020-2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/17/21.
+//
+
+import Foundation
+
+public struct TimelineView<Schedule, Content> where Schedule: TimelineSchedule {
+  let schedule: Schedule
+  let content: (Context) -> Content
+
+  public struct Context {
+    public enum Cadence: Hashable, Comparable {
+      case live
+      case seconds
+      case minutes
+    }
+
+    let dateProvider: () -> Date
+    public var date: Date { dateProvider() }
+    public let cadence: Cadence
+  }
+}
+
+extension TimelineView: View, _PrimitiveView where Content: View {
+  public init(
+    _ schedule: Schedule,
+    @ViewBuilder content: @escaping (Context) -> Content
+  ) {
+    self.schedule = schedule
+    self.content = content
+  }
+}
+
+public struct _TimelineViewProxy<Schedule, Content> where Schedule: TimelineSchedule {
+  let subject: TimelineView<Schedule, Content>
+
+  public init(_ subject: TimelineView<Schedule, Content>) {
+    self.subject = subject
+  }
+
+  public var schedule: Schedule { subject.schedule }
+  public var content: (TimelineView<Schedule, Content>.Context) -> Content { subject.content }
+
+  public func context(date: @escaping () -> Date) -> TimelineView<Schedule, Content>.Context {
+    .init(dateProvider: date, cadence: .live)
+  }
+}
+
+public protocol TimelineSchedule {
+  typealias Mode = TimelineScheduleMode
+  associatedtype Entries: Sequence where Entries.Element == Date
+  func entries(from startDate: Date, mode: Self.Mode) -> Self.Entries
+}
+
+public enum TimelineScheduleMode: Hashable {
+  case normal
+  case lowFrequency
+}
+
+public extension TimelineSchedule where Self == PeriodicTimelineSchedule {
+  @inlinable
+  static func periodic(
+    from startDate: Date,
+    by interval: TimeInterval
+  ) -> PeriodicTimelineSchedule {
+    .init(from: startDate, by: interval)
+  }
+}
+
+public extension TimelineSchedule where Self == EveryMinuteTimelineSchedule {
+  @inlinable static var everyMinute: EveryMinuteTimelineSchedule { .init() }
+}
+
+public extension TimelineSchedule {
+  static func explicit<S>(_ dates: S) -> ExplicitTimelineSchedule<S>
+    where Self == ExplicitTimelineSchedule<S>, S.Element == Date
+  {
+    .init(dates)
+  }
+}
+
+public struct PeriodicTimelineSchedule: TimelineSchedule {
+  private let entries: Entries
+
+  public struct Entries: Sequence, IteratorProtocol {
+    internal var date: Date
+    internal let interval: TimeInterval
+
+    public mutating func next() -> Date? {
+      defer { date.addTimeInterval(interval) }
+      return date
+    }
+
+    public typealias Element = Date
+    public typealias Iterator = Self
+  }
+
+  public init(from startDate: Date, by interval: TimeInterval) {
+    entries = Entries(date: startDate, interval: interval)
+  }
+
+  public func entries(from startDate: Date, mode: TimelineScheduleMode) -> Entries {
+    entries
+  }
+}
+
+public struct EveryMinuteTimelineSchedule: TimelineSchedule {
+  public struct Entries: Sequence, IteratorProtocol {
+    internal var date: Date
+
+    public mutating func next() -> Date? {
+      defer { date.addTimeInterval(60) }
+      return date
+    }
+
+    public typealias Element = Date
+    public typealias Iterator = Self
+  }
+
+  public init() {}
+
+  public func entries(from startDate: Date,
+                      mode: TimelineScheduleMode) -> EveryMinuteTimelineSchedule.Entries
+  {
+    Entries(date: startDate)
+  }
+}
+
+public struct ExplicitTimelineSchedule<Entries>: TimelineSchedule where Entries: Sequence,
+  Entries.Element == Date
+{
+  private let dates: Entries
+
+  public init(_ dates: Entries) {
+    self.dates = dates
+  }
+
+  public func entries(from startDate: Date, mode: TimelineScheduleMode) -> Entries {
+    dates
+  }
+}
+
+public extension TimelineSchedule where Self == AnimationTimelineSchedule {
+  @inlinable static var animation: AnimationTimelineSchedule { .init() }
+  @inlinable
+  static func animation(
+    minimumInterval: Double? = nil,
+    paused: Bool = false
+  ) -> AnimationTimelineSchedule {
+    .init(minimumInterval: minimumInterval, paused: paused)
+  }
+}
+
+public struct AnimationTimelineSchedule: TimelineSchedule {
+  let minimumInterval: Double?
+  let paused: Bool
+
+  public init(minimumInterval: Double? = nil, paused: Bool = false) {
+    self.minimumInterval = minimumInterval
+    self.paused = paused
+  }
+
+  public func entries(from startDate: Date, mode: TimelineScheduleMode) -> Entries {
+    Entries(startDate: startDate, minimumInterval: minimumInterval, paused: paused)
+  }
+
+  public struct Entries: Sequence, IteratorProtocol {
+    internal let startDate: Date
+    internal let minimumInterval: Double?
+    internal let paused: Bool
+
+    public mutating func next() -> Date? {
+      guard !paused else { return nil }
+      guard let minimumInterval = minimumInterval else {
+        return .init()
+      }
+      return startDate.addingTimeInterval(minimumInterval)
+    }
+
+    public typealias Element = Date
+    public typealias Iterator = Self
+  }
+}

--- a/Sources/TokamakCore/Views/Containers/VariadicView.swift
+++ b/Sources/TokamakCore/Views/Containers/VariadicView.swift
@@ -1,0 +1,111 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/20/21.
+//
+
+public enum _VariadicView {
+  public typealias ViewRoot = _VariadicView_ViewRoot
+  public typealias Children = _VariadicView_Children
+
+  public struct Tree<Root, Content>: View, _VariadicView_AnyTree
+    where Root: _VariadicView_ViewRoot, Content: View
+  {
+    public var root: Root
+    public var content: Content
+
+    public var children: Children?
+    public var anyContent: AnyView { AnyView(content) }
+
+    @inlinable
+    public init(_ root: Root, @ViewBuilder content: () -> Content) {
+      self.root = root
+      self.content = content()
+    }
+
+    public var body: some View {
+      if let children = children {
+        root.body(children: children)
+      }
+    }
+  }
+}
+
+public protocol _VariadicView_ViewRoot {
+  associatedtype Body: View
+  @ViewBuilder
+  func body(children: _VariadicView.Children) -> Self.Body
+}
+
+public extension _VariadicView_ViewRoot where Self.Body == Never {
+  func body(children: _VariadicView.Children) -> Never {
+    fatalError()
+  }
+}
+
+public struct _VariadicView_Children {
+  private var elements: [Element]
+
+  init(elements: [Element]) {
+    self.elements = elements
+  }
+}
+
+extension _VariadicView_Children: RandomAccessCollection {
+  public struct Element: View, Identifiable {
+    let view: AnyView
+    public var id: AnyHashable
+    let viewTraits: _ViewTraitStore
+    let onTraitsUpdated: (_ViewTraitStore) -> ()
+
+    public func id<ID>(as _: ID.Type = ID.self) -> ID? where ID: Hashable {
+      id.base as? ID
+    }
+
+    public subscript<Trait>(key: Trait.Type) -> Trait.Value where Trait: _ViewTraitKey {
+      get {
+        viewTraits.value(forKey: key)
+      }
+      set {
+        var updated = viewTraits
+        updated.insert(newValue, forKey: key)
+        onTraitsUpdated(updated)
+      }
+    }
+
+    public var body: some View {
+      view
+    }
+  }
+
+  public var startIndex: Int { elements.startIndex }
+  public var endIndex: Int { elements.endIndex }
+  public subscript(index: Int) -> Element { elements[index] }
+
+  public typealias Index = Int
+  public typealias Indices = Range<Int>
+  public typealias Iterator = IndexingIterator<_VariadicView_Children>
+  public typealias SubSequence = Slice<_VariadicView_Children>
+}
+
+extension _VariadicView_Children: View {
+  public var body: some View {
+    ForEach(elements) { $0 }
+  }
+}
+
+public protocol _VariadicView_AnyTree {
+  var anyContent: AnyView { get }
+  var children: _VariadicView.Children? { get set }
+}

--- a/Sources/TokamakCore/Views/Image.swift
+++ b/Sources/TokamakCore/Views/Image.swift
@@ -26,6 +26,11 @@ public class _AnyImageProviderBox: AnyTokenBox, Equatable {
 
     public let storage: Storage
     public let label: Text?
+
+    public init(storage: Storage, label: Text?) {
+      self.storage = storage
+      self.label = label
+    }
   }
 
   public static func == (lhs: _AnyImageProviderBox, rhs: _AnyImageProviderBox) -> Bool {

--- a/Sources/TokamakDOM/Core.swift
+++ b/Sources/TokamakDOM/Core.swift
@@ -132,6 +132,9 @@ public typealias EveryMinuteTimelineSchedule = TokamakCore.EveryMinuteTimelineSc
 public typealias ExplicitTimelineSchedule = TokamakCore.ExplicitTimelineSchedule
 public typealias PeriodicTimelineSchedule = TokamakCore.PeriodicTimelineSchedule
 
+public typealias HorizontalAlignment = TokamakCore.HorizontalAlignment
+public typealias VerticalAlignment = TokamakCore.VerticalAlignment
+
 // MARK: Views
 
 public typealias Alignment = TokamakCore.Alignment

--- a/Sources/TokamakDOM/Core.swift
+++ b/Sources/TokamakDOM/Core.swift
@@ -123,10 +123,20 @@ public typealias Edge = TokamakCore.Edge
 
 public typealias Prominence = TokamakCore.Prominence
 
+public typealias GraphicsContext = TokamakCore.GraphicsContext
+
+public typealias TimelineSchedule = TokamakCore.TimelineSchedule
+public typealias TimelineScheduleMode = TokamakCore.TimelineScheduleMode
+public typealias AnimationTimelineSchedule = TokamakCore.AnimationTimelineSchedule
+public typealias EveryMinuteTimelineSchedule = TokamakCore.EveryMinuteTimelineSchedule
+public typealias ExplicitTimelineSchedule = TokamakCore.ExplicitTimelineSchedule
+public typealias PeriodicTimelineSchedule = TokamakCore.PeriodicTimelineSchedule
+
 // MARK: Views
 
 public typealias Alignment = TokamakCore.Alignment
 public typealias Button = TokamakCore.Button
+public typealias Canvas = TokamakCore.Canvas
 public typealias ControlGroup = TokamakCore.ControlGroup
 public typealias ControlSize = TokamakCore.ControlSize
 public typealias DatePicker = TokamakCore.DatePicker
@@ -155,6 +165,7 @@ public typealias Spacer = TokamakCore.Spacer
 public typealias Text = TokamakCore.Text
 public typealias TextEditor = TokamakCore.TextEditor
 public typealias TextField = TokamakCore.TextField
+public typealias TimelineView = TokamakCore.TimelineView
 public typealias Toggle = TokamakCore.Toggle
 public typealias VStack = TokamakCore.VStack
 public typealias ZStack = TokamakCore.ZStack

--- a/Sources/TokamakDOM/Views/Canvas/Canvas.swift
+++ b/Sources/TokamakDOM/Views/Canvas/Canvas.swift
@@ -263,8 +263,36 @@ private struct _Canvas<Symbols: View>: View {
         Double(rect.rect.minX + cornerSize.width),
         Double(rect.rect.minY)
       )
+    case let .path(box):
+      for element in box.elements {
+        switch element {
+        case let .move(point):
+          _ = canvasContext.moveTo!(Double(point.x), Double(point.y))
+        case let .line(point):
+          _ = canvasContext.lineTo!(Double(point.x), Double(point.y))
+        case let .quadCurve(endPoint, controlPoint):
+          _ = canvasContext.quadraticCurveTo!(
+            Double(controlPoint.x),
+            Double(controlPoint.y),
+            Double(endPoint.x),
+            Double(endPoint.y)
+          )
+        case let .curve(endPoint, control1, control2):
+          _ = canvasContext.bezierCurveTo!(
+            Double(control1.x),
+            Double(control1.y),
+            Double(control2.x),
+            Double(control2.y),
+            Double(endPoint.x),
+            Double(endPoint.y)
+          )
+        case .closeSubpath:
+          _ = canvasContext.closePath!()
+          _ = canvasContext.beginPath!()
+        }
+      }
     default:
-      print("TODO: push \(path)")
+      print("TODO: push \(path) (\(path.storage))")
     }
     _ = canvasContext.closePath!()
   }

--- a/Sources/TokamakDOM/Views/Canvas/Canvas.swift
+++ b/Sources/TokamakDOM/Views/Canvas/Canvas.swift
@@ -26,12 +26,19 @@ extension Canvas: DOMPrimitive {
   }
 }
 
+extension Canvas: SpacerContainer {
+  public var hasSpacer: Bool { true }
+  public var axis: SpacerContainerAxis { .vertical }
+  public var fillCrossAxis: Bool { true }
+}
+
 private let devicePixelRatio = JSObject.global.devicePixelRatio.number ?? 1
 
 struct _Canvas<Symbols: View>: View {
   let parent: Canvas<Symbols>
   @StateObject private var coordinator = Coordinator()
   @Environment(\.inAnimatingTimelineView) private var inAnimatingTimelineView
+  @Environment(\.isAnimatingTimelineViewPaused) private var isAnimatingTimelineViewPaused
 
   final class Coordinator: ObservableObject {
     @Published var canvas: JSObject?
@@ -93,7 +100,7 @@ struct _Canvas<Symbols: View>: View {
     )
     // Render into the context.
     parent.renderer(&graphicsContext, size)
-    if inAnimatingTimelineView {
+    if inAnimatingTimelineView && !isAnimatingTimelineViewPaused {
       coordinator.currentDrawLoop = JSObject.global.requestAnimationFrame!(JSOneshotClosure { _ in
         draw(in: size)
         return .undefined

--- a/Sources/TokamakDOM/Views/Canvas/Canvas.swift
+++ b/Sources/TokamakDOM/Views/Canvas/Canvas.swift
@@ -1,0 +1,486 @@
+// Copyright 2020-2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/17/21.
+//
+
+import Foundation
+import JavaScriptKit
+import TokamakCore
+
+private let devicePixelRatio = JSObject.global.devicePixelRatio.number ?? 1
+
+private struct _Canvas<Symbols: View>: View {
+  let parent: Canvas<Symbols>
+  @State private var canvas: JSObject?
+  @Environment(\.inAnimatingTimelineView) private var inAnimatingTimelineView
+
+  var body: some View {
+    GeometryReader { proxy in
+      HTML("canvas", [
+        "style": "width: 100%; height: 100%;",
+        "width": "\(proxy.size.width * CGFloat(devicePixelRatio))",
+        "height": "\(proxy.size.height * CGFloat(devicePixelRatio))",
+      ])
+        ._domRef($canvas)
+        .onAppear(perform: draw)
+        ._onUpdate(perform: draw)
+    }
+  }
+
+  private func draw() {
+    guard let canvas = canvas,
+          let canvasContext = canvas.getContext!("2d").object
+    else { return }
+    let size = CGSize(
+      width: canvas.width.number! / devicePixelRatio,
+      height: canvas.height.number! / devicePixelRatio
+    )
+    _ = canvasContext.restore!()
+    _ = canvasContext.clearRect!(0, 0, canvas.width, canvas.height)
+    _ = canvasContext.save!()
+    _ = canvasContext.scale!(devicePixelRatio, devicePixelRatio)
+    var graphicsContext = parent._makeContext { storage, operation in
+      canvasContext.globalCompositeOperation = .string(storage.blendMode.cssValue)
+      switch operation {
+      case let .clip(path, _, _):
+        pushPath(path, in: canvasContext)
+        _ = canvasContext.clip!()
+      case .beginClipLayer:
+        break
+      case .endClipLayer:
+        _ = canvasContext.clip!()
+      case let .addFilter(filter, _):
+        applyFilter(filter, to: canvasContext)
+      case .beginLayer:
+        _ = canvasContext.save!()
+      case .endLayer:
+        _ = canvasContext.restore!()
+      case let .fill(path, shading, fillStyle):
+        _ = canvasContext.save!()
+        pushPath(path, in: canvasContext)
+        canvasContext.fillStyle = shading.cssValue(
+          in: self.parent._environment,
+          with: canvasContext,
+          bounds: path.boundingRect
+        )
+        _ = canvasContext.fill!(fillStyle.isEOFilled ? "evenodd" : "nonzero")
+        _ = canvasContext.restore!()
+      case let .stroke(path, shading, strokeStyle):
+        _ = canvasContext.save!()
+        pushPath(path, in: canvasContext)
+        canvasContext.strokeStyle = shading.cssValue(
+          in: self.parent._environment,
+          with: canvasContext,
+          bounds: path.boundingRect
+        )
+        canvasContext.lineWidth = .number(Double(strokeStyle.lineWidth))
+        _ = canvasContext.stroke!()
+        _ = canvasContext.restore!()
+      case .drawImage:
+        break
+      case let .drawText(text, positioning):
+        let proxy = _TextProxy(text._text)
+
+        _ = canvasContext.save!()
+        canvasContext.fillStyle = text.shading.cssValue(
+          in: self.parent._environment,
+          with: canvasContext,
+          bounds: .zero
+        )
+        switch positioning {
+        case let .in(rect):
+          _ = canvasContext.fillText!(
+            _TextProxy(text._text).rawText,
+            Double(rect.origin.x),
+            Double(rect.origin.y),
+            Double(rect.size.width)
+          )
+        case let .at(point, anchor):
+          // Horizontal alignment
+          canvasContext.textAlign = .string(
+            anchor.x == 0 ? "start" : (anchor.x == 0.5 ? "center" : "end")
+          )
+          // Vertical alignment
+          canvasContext.textBaseline = .string(
+            anchor
+              .y == 0 ? "top" :
+              (anchor.y == 0.5 ? "middle" : (anchor.y == 1 ? "bottom" : "alphabetic"))
+          )
+          applyModifiers(proxy.modifiers, to: canvasContext, in: self.parent._environment)
+          _ = canvasContext.fillText!(proxy.rawText, Double(point.x), Double(point.y))
+        }
+        _ = canvasContext.restore!()
+      case .drawSymbol:
+        break
+      }
+    } imageResolver: { image, _ in
+      ._resolved(image, size: .zero, baseline: 0)
+    } textResolver: { text, _ in
+      ._resolved(
+        text,
+        shading: .foreground,
+        lazyLayoutComputer: { _ in
+          _ = canvasContext.save!()
+          applyModifiers(
+            _TextProxy(text).modifiers,
+            to: canvasContext,
+            in: self.parent._environment
+          )
+          let metrics = canvasContext.measureText!(_TextProxy(text).rawText)
+          _ = canvasContext.restore!()
+          let baselineToTop = metrics.actualBoundingBoxAscent.number ?? 0
+          let baselineToBottom = metrics.actualBoundingBoxDescent.number ?? 0
+          return .init(
+            size: .init(
+              width: CGFloat(metrics.width.number ?? 0),
+              height: CGFloat(baselineToTop + baselineToBottom)
+            ),
+            firstBaseline: CGFloat(baselineToTop),
+            lastBaseline: CGFloat(baselineToBottom)
+          )
+        }
+      )
+    } symbolResolver: { id in
+      print("RESOLVE \(id)")
+      return ._resolve(id, size: .zero)
+    }
+    parent.renderer(&graphicsContext, size)
+    if inAnimatingTimelineView {
+      _ = JSObject.global.requestAnimationFrame!(JSOneshotClosure { _ in
+        draw()
+        return .undefined
+      })
+    }
+  }
+
+  private func applyFilter(_ filter: GraphicsContext.Filter, to canvasContext: JSObject) {
+    let previousFilter = canvasContext.filter
+      .string == "none" ? "" : (canvasContext.filter.string ?? "")
+    switch filter._storage {
+    case let .projectionTransform(matrix):
+      _ = canvasContext.transform!(
+        Double(matrix.m11), Double(matrix.m12),
+        Double(matrix.m21), Double(matrix.m22),
+        Double(matrix.m31), Double(matrix.m32)
+      )
+    case let .shadow(color, radius, x, y, _, _):
+      canvasContext
+        .shadowColor = .string(
+          _ColorProxy(color).resolve(in: parent._environment)
+            .cssValue
+        )
+      canvasContext.shadowBlur = .number(Double(radius))
+      canvasContext.shadowOffsetX = .number(Double(x))
+      canvasContext.shadowOffsetY = .number(Double(y))
+    case .colorMultiply:
+      break
+    case .colorMatrix:
+      break
+    case let .hueRotation(angle):
+      canvasContext.filter = .string("\(previousFilter) hue-rotate(\(angle.radians)rad)")
+    case let .saturation(amount):
+      canvasContext.filter = .string("\(previousFilter) saturate(\(amount * 100)%)")
+    case let .brightness(amount):
+      canvasContext.filter = .string("\(previousFilter) brightness(\(amount * 100)%)")
+    case let .contrast(amount):
+      canvasContext.filter = .string("\(previousFilter) contrast(\(amount * 100)%)")
+    case let .colorInvert(amount):
+      canvasContext.filter = .string("\(previousFilter) invert(\(amount * 100)%)")
+    case let .grayscale(amount):
+      canvasContext.filter = .string("\(previousFilter) grayscale(\(amount * 100)%)")
+    case .luminanceToAlpha:
+      break
+    case let .blur(radius, _):
+      canvasContext.filter = .string("\(previousFilter) blur(\(radius)px)")
+    case .alphaThreshold:
+      break
+    }
+  }
+
+  private func pushPath(_ path: Path, in canvasContext: JSObject) {
+    _ = canvasContext.beginPath!()
+    switch path.storage {
+    case let .rect(rect):
+      _ = canvasContext.rect!(
+        Double(rect.origin.x),
+        Double(rect.origin.y),
+        Double(rect.size.width),
+        Double(rect.size.height)
+      )
+    case let .ellipse(rect):
+      _ = canvasContext.ellipse!(
+        Double(rect.origin.x + rect.size.width / 2),
+        Double(rect.origin.y + rect.size.height / 2),
+        Double(rect.size.width / 2),
+        Double(rect.size.height / 2),
+        0,
+        0,
+        Double.pi * 2
+      )
+    case let .roundedRect(rect):
+      let cornerSize = rect.cornerSize ?? CGSize(
+        width: min(rect.rect.size.width, rect.rect.size.height) / 2,
+        height: min(rect.rect.size.width, rect.rect.size.height) / 2
+      ) // Capsule rounding
+      _ = canvasContext.moveTo!(Double(rect.rect.minX + cornerSize.width), Double(rect.rect.minY))
+      _ = canvasContext.lineTo!(Double(rect.rect.maxX - cornerSize.width), Double(rect.rect.minY))
+      _ = canvasContext.quadraticCurveTo!(
+        Double(rect.rect.maxX),
+        Double(rect.rect.minY),
+        Double(rect.rect.maxX),
+        Double(rect.rect.minY + cornerSize.height)
+      )
+      _ = canvasContext.lineTo!(Double(rect.rect.maxX), Double(rect.rect.maxY - cornerSize.height))
+      _ = canvasContext.quadraticCurveTo!(
+        Double(rect.rect.maxX),
+        Double(rect.rect.maxY),
+        Double(rect.rect.maxX - cornerSize.width),
+        Double(rect.rect.maxY)
+      )
+      _ = canvasContext.lineTo!(Double(rect.rect.minX + cornerSize.width), Double(rect.rect.maxY))
+      _ = canvasContext.quadraticCurveTo!(
+        Double(rect.rect.minX),
+        Double(rect.rect.maxY),
+        Double(rect.rect.minX),
+        Double(rect.rect.maxY - cornerSize.height)
+      )
+      _ = canvasContext.lineTo!(Double(rect.rect.minX), Double(rect.rect.minY + cornerSize.height))
+      _ = canvasContext.quadraticCurveTo!(
+        Double(rect.rect.minX),
+        Double(rect.rect.minY),
+        Double(rect.rect.minX + cornerSize.width),
+        Double(rect.rect.minY)
+      )
+    default:
+      print("TODO: push \(path)")
+    }
+    _ = canvasContext.closePath!()
+  }
+
+  private func applyModifiers(
+    _ modifiers: [Text._Modifier],
+    to canvas: JSObject,
+    in environment: EnvironmentValues
+  ) {
+    var style = ""
+    var variant = ""
+    var weight = ""
+    var size: String?
+    var lineHeight = ""
+    var family: String?
+    for modifier in modifiers {
+      switch modifier {
+      case let .color(color):
+        if let color = color {
+          canvas.fillStyle = GraphicsContext.Shading.color(color)
+            .cssValue(in: environment, with: canvas, bounds: .zero)
+        }
+      case let .font(font):
+        if let font = font {
+          let styles = font.styles(in: environment)
+          style += styles["font-style"] ?? ""
+          variant += styles["font-variant"] ?? ""
+          weight = styles["font-weight"] ?? ""
+          size = styles["font-size"] ?? ""
+          lineHeight = styles["line-height"] ?? ""
+          family = styles["font-family"] ?? ""
+        }
+      case .italic:
+        style += "italic"
+      case let .weight(w):
+        if let value = w?.value {
+          weight = "\(value)"
+        }
+      case .kerning, .tracking, .rounded, .baseline, .strikethrough,
+           .underline: break // Not supported in <canvas>.
+      }
+    }
+
+    canvas
+      .font =
+      .string(
+        "\(style) \(variant) \(weight) \(size ?? "17")pt \(lineHeight) \(family ?? Font.Design.default.families.joined(separator: " "))"
+      )
+  }
+}
+
+extension Canvas: DOMPrimitive {
+  public var renderedBody: AnyView {
+    AnyView(_Canvas(parent: self))
+  }
+}
+
+private extension GraphicsContext.Shading {
+  func cssValue(in environment: EnvironmentValues, with canvas: JSObject,
+                bounds: CGRect) -> JSValue
+  {
+    if case let .resolved(resolved) = _resolve(in: environment)._storage {
+      return resolved.cssValue(in: environment, with: canvas, bounds: bounds)
+    }
+    return .string("none")
+  }
+}
+
+private extension GraphicsContext._ResolvedShading {
+  func cssValue(in environment: EnvironmentValues, with canvas: JSObject,
+                bounds: CGRect) -> JSValue
+  {
+    switch self {
+    case let .levels(palette):
+      guard let primary = palette.first else { break }
+      return primary.cssValue(in: environment, with: canvas, bounds: bounds)
+    case let .style(style):
+      return style.cssValue(in: environment, with: canvas, bounds: bounds)
+    case let .gradient(gradient, geometry, _):
+      let gradientBounds = CGRect(origin: .zero, size: .init(width: 1, height: 1))
+      switch geometry {
+      case let .axial(startPoint, endPoint):
+        return _ResolvedStyle.gradient(
+          gradient,
+          style: .linear(
+            startPoint: .init(x: startPoint.x, y: startPoint.y),
+            endPoint: .init(x: endPoint.x, y: endPoint.y)
+          )
+        ).cssValue(in: environment, with: canvas, bounds: gradientBounds)
+      case let .conic(center, angle):
+        return _ResolvedStyle.gradient(
+          gradient,
+          style: .angular(
+            center: .init(x: center.x, y: center.y),
+            startAngle: .degrees(0),
+            endAngle: angle
+          )
+        ).cssValue(in: environment, with: canvas, bounds: gradientBounds)
+      case let .radial(center, startRadius, endRadius):
+        return _ResolvedStyle.gradient(
+          gradient,
+          style: .radial(
+            center: .init(x: center.x, y: center.y),
+            startRadius: startRadius,
+            endRadius: endRadius
+          )
+        ).cssValue(in: environment, with: canvas, bounds: gradientBounds)
+      }
+    case .tiledImage:
+      break
+    }
+    return .string("none")
+  }
+}
+
+private extension _ResolvedStyle {
+  func cssValue(
+    in environment: EnvironmentValues,
+    opacity: Float = 1,
+    with canvas: JSObject,
+    bounds: CGRect
+  ) -> JSValue {
+    switch self {
+    case let .color(color):
+      return .string(AnyColorBox.ResolvedValue(
+        red: color.red,
+        green: color.green,
+        blue: color.blue,
+        opacity: color.opacity * Double(opacity),
+        space: color.space
+      ).cssValue)
+    case .foregroundMaterial:
+      break
+    case let .array(palette):
+      guard let primary = palette.first else { break }
+      return primary.cssValue(in: environment, opacity: opacity, with: canvas, bounds: bounds)
+    case let .opacity(opacity, style):
+      return style.cssValue(in: environment, opacity: opacity, with: canvas, bounds: bounds)
+    case let .gradient(gradient, style):
+      let canvasGradient: JSObject
+      switch style {
+      case let .linear(startPoint, endPoint):
+        canvasGradient = canvas.createLinearGradient!(
+          Double(bounds.origin.x + startPoint.x * bounds.width),
+          Double(bounds.origin.y + startPoint.y * bounds.height),
+          Double(bounds.origin.x + endPoint.x * bounds.width),
+          Double(bounds.origin.y + endPoint.y * bounds.height)
+        ).object!
+      case let .radial(center, startRadius, endRadius):
+        canvasGradient = canvas.createRadialGradient!(
+          Double(bounds.origin.x + center.x * bounds.width),
+          Double(bounds.origin.y + center.y * bounds.height),
+          Double(startRadius),
+          Double(bounds.origin.x + center.x * bounds.width),
+          Double(bounds.origin.y + center.y * bounds.height),
+          Double(endRadius)
+        ).object!
+      case let .elliptical(center, startRadiusFraction, endRadiusFraction):
+        canvasGradient = canvas.createRadialGradient!(
+          Double(bounds.origin.x + center.x * bounds.width),
+          Double(bounds.origin.y + center.y * bounds.height),
+          Double(startRadiusFraction * bounds.width),
+          Double(bounds.origin.x + center.x * bounds.width),
+          Double(bounds.origin.y + center.y * bounds.height),
+          Double(endRadiusFraction * bounds.width)
+        ).object!
+      case let .angular(center, _, endAngle):
+        canvasGradient = canvas.createConicGradient!(
+          Double(endAngle.radians),
+          Double(bounds.origin.x + center.x * bounds.width),
+          Double(bounds.origin.y + center.y * bounds.height)
+        ).object!
+      }
+      for stop in gradient.stops {
+        _ = canvasGradient.addColorStop!(
+          Double(stop.location),
+          _ColorProxy(stop.color).resolve(in: environment).cssValue
+        )
+      }
+      return .object(canvasGradient)
+    }
+    return .string("")
+  }
+}
+
+private extension GraphicsContext.BlendMode {
+  var cssValue: String {
+    switch self {
+    case .normal: return "normal"
+    case .multiply: return "multiply"
+    case .screen: return "screen"
+    case .overlay: return "overlay"
+    case .darken: return "darken"
+    case .lighten: return "lighten"
+    case .colorDodge: return "color-dodge"
+    case .colorBurn: return "color-burn"
+    case .softLight: return "soft-light"
+    case .hardLight: return "hard-light"
+    case .difference: return "difference"
+    case .exclusion: return "exclusion"
+    case .hue: return "hue"
+    case .saturation: return "saturation"
+    case .color: return "color"
+    case .luminosity: return "luminosity"
+    case .clear: return "clear"
+    case .copy: return "copy"
+    case .sourceIn: return "source-in"
+    case .sourceOut: return "source-out"
+    case .sourceAtop: return "source-atop"
+    case .destinationOver: return "destination-over"
+    case .destinationIn: return "destination-in"
+    case .destinationOut: return "destination-out"
+    case .destinationAtop: return "destination-atop"
+    case .xor: return "xor"
+    case .plusDarker: return "darken"
+    case .plusLighter: return "lighten"
+    }
+  }
+}

--- a/Sources/TokamakDOM/Views/Canvas/ImageOperations.swift
+++ b/Sources/TokamakDOM/Views/Canvas/ImageOperations.swift
@@ -1,0 +1,28 @@
+// Copyright 2020-2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/23/21.
+//
+
+import Foundation
+import TokamakCore
+
+extension _Canvas {
+  func resolveImage(
+    _ image: Image,
+    _ environment: EnvironmentValues
+  ) -> GraphicsContext.ResolvedImage {
+    ._resolved(image, size: .zero, baseline: 0)
+  }
+}

--- a/Sources/TokamakDOM/Views/Canvas/ImageOperations.swift
+++ b/Sources/TokamakDOM/Views/Canvas/ImageOperations.swift
@@ -16,13 +16,83 @@
 //
 
 import Foundation
+import JavaScriptKit
 import TokamakCore
+
+private enum ImageCache {
+  private static var values = [String: JSObject]()
+
+  static subscript(_ path: String) -> JSObject? {
+    get { values[path] }
+    set { values[path] = newValue }
+  }
+}
 
 extension _Canvas {
   func resolveImage(
     _ image: Image,
     _ environment: EnvironmentValues
   ) -> GraphicsContext.ResolvedImage {
-    ._resolved(image, size: .zero, baseline: 0)
+    // FIXME: We don't have a way of calculating the size, since we need to wait for the image to load.
+    ._resolved(_ImageProxy(image).provider.resolve(in: environment), size: .zero, baseline: 0)
+  }
+
+  func drawImage(
+    _ image: GraphicsContext.ResolvedImage,
+    at positioning: GraphicsContext._Storage._Operation._ResolvedPositioning,
+    with fillStyle: FillStyle?,
+    in canvasContext: JSObject
+  ) {
+    switch image._resolved.storage {
+    case let .named(name, bundle):
+      let src = bundle?.path(forResource: name, ofType: nil) ?? name
+
+      func draw(_ img: JSObject) {
+        // Draw the image on the canvas.
+        switch positioning {
+        case let .in(rect):
+          _ = canvasContext.drawImage!(
+            img,
+            Double(rect.origin.x), Double(rect.origin.y),
+            Double(rect.size.width), Double(rect.size.height)
+          )
+        case let .at(point, anchor):
+          _ = canvasContext.drawImage!(
+            img,
+            Double(point.x - (anchor.x * CGFloat(img.naturalWidth.number!))),
+            Double(point.y - (anchor.y * CGFloat(img.naturalHeight.number!)))
+          )
+        }
+      }
+
+      if let cached = ImageCache[src] {
+        draw(cached)
+      } else {
+        // Create an Image and draw it after it loads.
+        let img = JSObject.global.Image.function!.new()
+
+        img.onload = .object(JSOneshotClosure { _ in
+          draw(img)
+          return .undefined
+        })
+
+        img.src = .string(src)
+
+        ImageCache[src] = img
+      }
+    case let .resizable(nested, _, _):
+      // Defer to nested.
+      drawImage(
+        ._resolved(
+          .init(storage: nested, label: nil),
+          size: image.size,
+          baseline: image.baseline,
+          shading: image.shading
+        ),
+        at: positioning,
+        with: fillStyle,
+        in: canvasContext
+      )
+    }
   }
 }

--- a/Sources/TokamakDOM/Views/Canvas/ImageOperations.swift
+++ b/Sources/TokamakDOM/Views/Canvas/ImageOperations.swift
@@ -33,7 +33,8 @@ extension _Canvas {
     _ image: Image,
     _ environment: EnvironmentValues
   ) -> GraphicsContext.ResolvedImage {
-    // FIXME: We don't have a way of calculating the size, since we need to wait for the image to load.
+    // FIXME: We don't have a way of calculating the size, since we need to wait for the image
+    // to load.
     ._resolved(_ImageProxy(image).provider.resolve(in: environment), size: .zero, baseline: 0)
   }
 

--- a/Sources/TokamakDOM/Views/Canvas/PathOperations.swift
+++ b/Sources/TokamakDOM/Views/Canvas/PathOperations.swift
@@ -1,0 +1,173 @@
+// Copyright 2020-2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/23/21.
+//
+
+import Foundation
+import JavaScriptKit
+import TokamakCore
+
+extension _Canvas {
+  func clip(to path: Path, in canvasContext: JSObject) {
+    _ = canvasContext.beginPath!()
+    pushPath(path, in: canvasContext)
+    _ = canvasContext.closePath!()
+    _ = canvasContext.clip!()
+  }
+
+  func fillPath(
+    _ path: Path,
+    with shading: GraphicsContext.Shading,
+    style fillStyle: FillStyle,
+    in canvasContext: JSObject
+  ) {
+    _ = canvasContext.save!()
+    _ = canvasContext.beginPath!()
+    pushPath(path, in: canvasContext)
+    _ = canvasContext.closePath!()
+    canvasContext.fillStyle = shading.cssValue(
+      in: parent._environment,
+      with: canvasContext,
+      bounds: path.boundingRect
+    )
+    _ = canvasContext.fill!(fillStyle.isEOFilled ? "evenodd" : "nonzero")
+    _ = canvasContext.restore!()
+  }
+
+  func strokePath(
+    _ path: Path,
+    with shading: GraphicsContext.Shading,
+    style strokeStyle: StrokeStyle,
+    in canvasContext: JSObject
+  ) {
+    _ = canvasContext.save!()
+    _ = canvasContext.beginPath!()
+    pushPath(path, in: canvasContext)
+    _ = canvasContext.closePath!()
+    canvasContext.strokeStyle = shading.cssValue(
+      in: parent._environment,
+      with: canvasContext,
+      bounds: path.boundingRect
+    )
+    canvasContext.lineWidth = .number(Double(strokeStyle.lineWidth))
+    _ = canvasContext.stroke!()
+    _ = canvasContext.restore!()
+  }
+
+  private func pushPath(_ path: Path, in canvasContext: JSObject) {
+    switch path.storage {
+    case .empty: break
+    case let .rect(rect):
+      rect.pushRect(to: canvasContext)
+    case let .ellipse(rect):
+      rect.pushEllipse(to: canvasContext)
+    case let .roundedRect(rect):
+      rect.push(to: canvasContext)
+    case let .path(box):
+      for element in box.elements {
+        switch element {
+        case let .move(point):
+          _ = canvasContext.moveTo!(Double(point.x), Double(point.y))
+        case let .line(point):
+          _ = canvasContext.lineTo!(Double(point.x), Double(point.y))
+        case let .quadCurve(endPoint, controlPoint):
+          _ = canvasContext.quadraticCurveTo!(
+            Double(controlPoint.x),
+            Double(controlPoint.y),
+            Double(endPoint.x),
+            Double(endPoint.y)
+          )
+        case let .curve(endPoint, control1, control2):
+          _ = canvasContext.bezierCurveTo!(
+            Double(control1.x),
+            Double(control1.y),
+            Double(control2.x),
+            Double(control2.y),
+            Double(endPoint.x),
+            Double(endPoint.y)
+          )
+        case .closeSubpath:
+          _ = canvasContext.closePath!() // Close the path.
+          _ = canvasContext.beginPath!() // Reopen for the next segments.
+        }
+      }
+    case let .stroked(stroked):
+      pushPath(stroked.path, in: canvasContext)
+    case let .trimmed(trimmed):
+      pushPath(trimmed.path, in: canvasContext) // TODO: Find a way to trim a Path2D
+    }
+  }
+}
+
+private extension CGRect {
+  func pushRect(to canvasContext: JSObject) {
+    _ = canvasContext.rect!(
+      Double(origin.x),
+      Double(origin.y),
+      Double(size.width),
+      Double(size.height)
+    )
+  }
+
+  func pushEllipse(to canvasContext: JSObject) {
+    _ = canvasContext.ellipse!(
+      Double(origin.x + size.width / 2),
+      Double(origin.y + size.height / 2),
+      Double(size.width / 2),
+      Double(size.height / 2),
+      0,
+      0,
+      Double.pi * 2
+    )
+  }
+}
+
+private extension FixedRoundedRect {
+  func push(to canvasContext: JSObject) {
+    let cornerSize = cornerSize ?? CGSize(
+      width: min(rect.size.width, rect.size.height) / 2,
+      height: min(rect.size.width, rect.size.height) / 2
+    ) // Capsule rounding
+    _ = canvasContext.moveTo!(Double(rect.minX + cornerSize.width), Double(rect.minY))
+    _ = canvasContext.lineTo!(Double(rect.maxX - cornerSize.width), Double(rect.minY))
+    _ = canvasContext.quadraticCurveTo!(
+      Double(rect.maxX),
+      Double(rect.minY),
+      Double(rect.maxX),
+      Double(rect.minY + cornerSize.height)
+    )
+    _ = canvasContext.lineTo!(Double(rect.maxX), Double(rect.maxY - cornerSize.height))
+    _ = canvasContext.quadraticCurveTo!(
+      Double(rect.maxX),
+      Double(rect.maxY),
+      Double(rect.maxX - cornerSize.width),
+      Double(rect.maxY)
+    )
+    _ = canvasContext.lineTo!(Double(rect.minX + cornerSize.width), Double(rect.maxY))
+    _ = canvasContext.quadraticCurveTo!(
+      Double(rect.minX),
+      Double(rect.maxY),
+      Double(rect.minX),
+      Double(rect.maxY - cornerSize.height)
+    )
+    _ = canvasContext.lineTo!(Double(rect.minX), Double(rect.minY + cornerSize.height))
+    _ = canvasContext.quadraticCurveTo!(
+      Double(rect.minX),
+      Double(rect.minY),
+      Double(rect.minX + cornerSize.width),
+      Double(rect.minY)
+    )
+  }
+}

--- a/Sources/TokamakDOM/Views/Canvas/SymbolOperations.swift
+++ b/Sources/TokamakDOM/Views/Canvas/SymbolOperations.swift
@@ -1,0 +1,105 @@
+// Copyright 2020-2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/23/21.
+//
+
+import Foundation
+import JavaScriptKit
+import TokamakCore
+import TokamakStaticHTML
+
+extension _Canvas {
+  func resolveSymbol(
+    _ symbol: AnyView,
+    _ environment: EnvironmentValues
+  ) -> GraphicsContext.ResolvedSymbol {
+    let id = "_resolvable_symbol_body_\(UUID().uuidString)"
+    let divWrapped = HTML(
+      "div",
+      ["xmlns": "http://www.w3.org/1999/xhtml", "id": id, "style": "display: inline-block;"]
+    ) {
+      symbol
+        .environmentValues(environment)
+    }
+    let innerHTML = StaticHTMLRenderer(divWrapped, environment).render()
+    // Add the element to the document to read its size.
+    let unhostedElement = document.createElement!("div").object!
+    unhostedElement.innerHTML = JSValue.string(innerHTML)
+    _ = document.body.appendChild(unhostedElement)
+    let bounds = document.getElementById!(id).object!.getBoundingClientRect!().object!
+    let size = CGSize(width: bounds.width.number!, height: bounds.height.number!)
+    // Remove it from the document.
+    _ = unhostedElement.parentNode.removeChild(unhostedElement)
+
+    // Render the element with the StaticHTMLRenderer, wrapping it in an SVG tag.
+    return ._resolve(
+      StaticHTMLRenderer(
+        HTML(
+          "svg",
+          [
+            "xmlns": "http://www.w3.org/2000/svg",
+            "width": "\(size.width)",
+            "height": "\(size.height)",
+          ]
+        ) {
+          HTML("foreignObject", ["width": "100%", "height": "100%"]) {
+            divWrapped
+          }
+        },
+        environment
+      )
+      .renderRoot(),
+      size: size
+    )
+  }
+
+  func drawSymbol(
+    _ symbol: GraphicsContext.ResolvedSymbol,
+    at positioning: GraphicsContext._Storage._Operation._ResolvedPositioning,
+    in canvasContext: JSObject
+  ) {
+    // Create an SVG element containing the View's rendered HTML.
+    // This was resolved to SVG earlier.
+    let img = JSObject.global.Image.function!.new()
+    let svgData = JSObject.global.Blob.function!.new(
+      [symbol._resolved as? String ?? ""],
+      ["type": "image/svg+xml;charset=utf-8"]
+    )
+    // Create a URL to the SVG data.
+    let objectURL = JSObject.global.URL.function!.createObjectURL!(svgData)
+
+    img.onload = .object(JSOneshotClosure { _ in
+      // Draw the SVG on the canvas.
+      switch positioning {
+      case let .in(rect):
+        _ = canvasContext.drawImage!(
+          img,
+          Double(rect.origin.x), Double(rect.origin.y),
+          Double(rect.size.width), Double(rect.size.height)
+        )
+      case let .at(point, anchor):
+        _ = canvasContext.drawImage!(
+          img,
+          Double(point.x - (anchor.x * symbol.size.width)),
+          Double(point.y - (anchor.y * symbol.size.width))
+        )
+      }
+      _ = JSObject.global.URL.function!.revokeObjectURL!(objectURL)
+      return .undefined
+    })
+
+    img.src = objectURL
+  }
+}

--- a/Sources/TokamakDOM/Views/Canvas/SymbolOperations.swift
+++ b/Sources/TokamakDOM/Views/Canvas/SymbolOperations.swift
@@ -87,7 +87,6 @@ extension _Canvas {
           Double(point.y - (anchor.y * symbol.size.height))
         )
       }
-//      _ = JSObject.global.URL.function!.revokeObjectURL!(objectURL)
     }
 
     if let cached = cachedSymbol(id: symbol._id) {

--- a/Sources/TokamakDOM/Views/Canvas/TextOperations.swift
+++ b/Sources/TokamakDOM/Views/Canvas/TextOperations.swift
@@ -131,7 +131,11 @@ extension _Canvas {
     canvas
       .font =
       .string(
-        "\(style) \(variant) \(weight) \(size ?? "17")pt \(lineHeight) \(family ?? Font.Design.default.families.joined(separator: " "))"
+        """
+        \(style) \(variant) \(weight) \(size ?? "17")pt \(lineHeight) \(
+          family ?? Font.Design.default.families.joined(separator: ", ")
+        )
+        """
       )
   }
 }

--- a/Sources/TokamakDOM/Views/Canvas/TextOperations.swift
+++ b/Sources/TokamakDOM/Views/Canvas/TextOperations.swift
@@ -1,0 +1,137 @@
+// Copyright 2020-2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/23/21.
+//
+
+import Foundation
+import JavaScriptKit
+import TokamakCore
+
+extension _Canvas {
+  func resolveText(in canvasContext: JSObject)
+    -> (Text, EnvironmentValues) -> GraphicsContext.ResolvedText
+  {
+    { text, environment in
+      ._resolved(
+        text,
+        shading: .foreground,
+        lazyLayoutComputer: { _ in
+          _ = canvasContext.save!()
+          applyModifiers(
+            _TextProxy(text).modifiers,
+            to: canvasContext,
+            in: environment
+          )
+          let metrics = canvasContext.measureText!(_TextProxy(text).rawText)
+          _ = canvasContext.restore!()
+          let baselineToTop = metrics.actualBoundingBoxAscent.number ?? 0
+          let baselineToBottom = metrics.actualBoundingBoxDescent.number ?? 0
+          return .init(
+            size: .init(
+              width: CGFloat(metrics.width.number ?? 0),
+              height: CGFloat(baselineToTop + baselineToBottom)
+            ),
+            firstBaseline: CGFloat(baselineToTop),
+            lastBaseline: CGFloat(baselineToBottom)
+          )
+        }
+      )
+    }
+  }
+
+  func drawText(
+    _ text: GraphicsContext.ResolvedText,
+    at positioning: GraphicsContext._Storage._Operation._ResolvedPositioning,
+    in canvasContext: JSObject
+  ) {
+    let proxy = _TextProxy(text._text)
+
+    _ = canvasContext.save!()
+    canvasContext.fillStyle = text.shading.cssValue(
+      in: parent._environment,
+      with: canvasContext,
+      bounds: .zero
+    )
+    switch positioning {
+    case let .in(rect):
+      _ = canvasContext.fillText!(
+        _TextProxy(text._text).rawText,
+        Double(rect.origin.x),
+        Double(rect.origin.y),
+        Double(rect.size.width)
+      )
+    case let .at(point, anchor):
+      // Horizontal alignment
+      canvasContext.textAlign = .string(
+        anchor.x == 0 ? "start" : (anchor.x == 0.5 ? "center" : "end")
+      )
+      // Vertical alignment
+      canvasContext.textBaseline = .string(
+        anchor
+          .y == 0 ? "top" :
+          (anchor.y == 0.5 ? "middle" : (anchor.y == 1 ? "bottom" : "alphabetic"))
+      )
+      applyModifiers(proxy.modifiers, to: canvasContext, in: parent._environment)
+      _ = canvasContext.fillText!(proxy.rawText, Double(point.x), Double(point.y))
+    }
+    _ = canvasContext.restore!()
+  }
+
+  private func applyModifiers(
+    _ modifiers: [Text._Modifier],
+    to canvas: JSObject,
+    in environment: EnvironmentValues
+  ) {
+    var style = ""
+    var variant = ""
+    var weight = ""
+    var size: String?
+    var lineHeight = ""
+    var family: String?
+    for modifier in modifiers {
+      switch modifier {
+      case let .color(color):
+        if let color = color {
+          canvas.fillStyle = GraphicsContext.Shading.color(color)
+            .cssValue(in: environment, with: canvas, bounds: .zero)
+        }
+      case let .font(font):
+        if let font = font {
+          let styles = font.styles(in: environment)
+          style += styles["font-style"] ?? ""
+          variant += styles["font-variant"] ?? ""
+          weight = styles["font-weight"] ?? ""
+          size = styles["font-size"] ?? ""
+          lineHeight = styles["line-height"] ?? ""
+          family = styles["font-family"] ?? ""
+        }
+      case .italic:
+        style += "italic"
+      case let .weight(w):
+        if let value = w?.value {
+          weight = "\(value)"
+        }
+      case .kerning, .tracking, .rounded, .baseline, .strikethrough,
+           .underline: break // Not supported in <canvas>.
+      }
+    }
+
+    canvas
+      .font =
+      .string(
+        "\(style) \(variant) \(weight) \(size ?? "17")pt \(lineHeight) \(family ?? Font.Design.default.families.joined(separator: " "))"
+      )
+  }
+}

--- a/Sources/TokamakDOM/Views/Canvas/TimelineView.swift
+++ b/Sources/TokamakDOM/Views/Canvas/TimelineView.swift
@@ -56,9 +56,10 @@ private struct _TimelineView<Content: View, Schedule: TimelineSchedule>: View {
     }
 
     func queueNext() {
-      // Animated timelines are handled differently on the web, as updating the DOM every frame is costly.
-      // Therefore, animated timelines are only supported by views that read the `inAnimatedTimelineView`
-      // environment value, such as `Canvas`, which updates without DOM manipulation.
+      // Animated timelines are handled differently on the web, as updating the DOM every frame
+      // is costly. Therefore, animated timelines are only supported by views that read the
+      // `inAnimatedTimelineView` environment value, such as `Canvas`, which updates without
+      // DOM manipulation.
       guard !(Schedule.self == AnimationTimelineSchedule.self),
             let next = iterator.next()
       else { return }

--- a/Sources/TokamakDOM/Views/Canvas/TimelineView.swift
+++ b/Sources/TokamakDOM/Views/Canvas/TimelineView.swift
@@ -64,7 +64,6 @@ private struct _TimelineView<Content: View, Schedule: TimelineSchedule>: View {
       else { return }
       timeoutID = JSObject.global.setTimeout!(
         JSOneshotClosure { [weak self] _ in
-          print("Timeline updated")
           self?.date = next
           self?.queueNext()
           return .undefined

--- a/Sources/TokamakDOM/Views/Canvas/TimelineView.swift
+++ b/Sources/TokamakDOM/Views/Canvas/TimelineView.swift
@@ -1,0 +1,105 @@
+// Copyright 2020-2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/18/21.
+//
+
+import Foundation
+import JavaScriptKit
+import TokamakCore
+
+extension EnvironmentValues {
+  enum InAnimatingTimelineViewKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+  }
+
+  var inAnimatingTimelineView: Bool {
+    get { self[InAnimatingTimelineViewKey.self] }
+    set { self[InAnimatingTimelineViewKey.self] = newValue }
+  }
+}
+
+private struct _TimelineView<Content: View, Schedule: TimelineSchedule>: View {
+  let parent: _TimelineViewProxy<Schedule, Content>
+  @StateObject private var coordinator: Coordinator
+  @Environment(\.inAnimatingTimelineView) private var inAnimatingTimelineView
+
+  init(parent: TimelineView<Schedule, Content>) {
+    self.parent = _TimelineViewProxy(parent)
+    _coordinator = .init(
+      wrappedValue: Coordinator(
+        entries: _TimelineViewProxy(parent).schedule
+          .entries(from: Date(), mode: .lowFrequency)
+      )
+    )
+  }
+
+  final class Coordinator: ObservableObject {
+    @Published var date = Date()
+    var iterator: Schedule.Entries.Iterator
+    var timeoutID: JSValue?
+
+    init(entries: Schedule.Entries) {
+      iterator = entries.makeIterator()
+      queueNext()
+    }
+
+    func queueNext() {
+      // Animated timelines are handled differently on the web, as updating the DOM every frame is costly.
+      // Therefore, animated timelines are only supported by views that read the `inAnimatedTimelineView`
+      // environment value, such as `Canvas`, which updates without DOM manipulation.
+      guard !(Schedule.self == AnimationTimelineSchedule.self),
+            let next = iterator.next()
+      else { return }
+      timeoutID = JSObject.global.setTimeout!(
+        JSOneshotClosure { [weak self] _ in
+          print("Timeline updated")
+          self?.date = next
+          self?.queueNext()
+          return .undefined
+        },
+        date.distance(to: next) * 1000
+      )
+    }
+
+    deinit {
+      guard let timeoutID = timeoutID else { return }
+      _ = JSObject.global.clearTimeout!(timeoutID)
+    }
+  }
+
+  var body: some View {
+    parent.content(
+      parent.context(
+        date: {
+          if parent.schedule is AnimationTimelineSchedule {
+            return Date()
+          } else {
+            return coordinator.date
+          }
+        }
+      )
+    )
+    .environment(
+      \.inAnimatingTimelineView,
+      inAnimatingTimelineView || (parent.schedule is AnimationTimelineSchedule)
+    )
+  }
+}
+
+extension TimelineView: DOMPrimitive where Content: View {
+  public var renderedBody: AnyView {
+    AnyView(_TimelineView(parent: self))
+  }
+}

--- a/Sources/TokamakDOM/Views/Text/TextField.swift
+++ b/Sources/TokamakDOM/Views/Text/TextField.swift
@@ -18,7 +18,7 @@
 import TokamakCore
 import TokamakStaticHTML
 
-extension TextField: DOMPrimitive where Label == _TextFieldStyleLabel {
+extension TextField: DOMPrimitive where Label == Text {
   func css(for style: _AnyTextFieldStyle) -> String {
     if style is PlainTextFieldStyle {
       return """
@@ -45,9 +45,7 @@ extension TextField: DOMPrimitive where Label == _TextFieldStyleLabel {
     return AnyView(DynamicHTML("input", [
       "type": proxy.textFieldStyle is RoundedBorderTextFieldStyle ? "search" : "text",
       .value: proxy.textBinding.wrappedValue,
-      "placeholder": mapAnyView(proxy.label.body, transform: { (v: Text) in
-        _TextProxy(v).rawText
-      }) ?? "",
+      "placeholder": _TextProxy(proxy.label).rawText,
       "style": css(for: proxy.textFieldStyle),
       "class": className(for: proxy.textFieldStyle),
     ], listeners: [

--- a/Sources/TokamakDemo/ButtonStyleDemo.swift
+++ b/Sources/TokamakDemo/ButtonStyleDemo.swift
@@ -79,7 +79,6 @@ public struct ButtonStyleDemo: View {
           PressedButtonStyle(pressedColor: Color.red)
         )
       if #available(iOS 15.0, macOS 12.0, *) {
-        #if compiler(>=5.5) || os(WASI) // Xcode 13 required for `controlProminence`.
         Button("Prominent") {}
           .buttonStyle(BorderedProminentButtonStyle())
         Text("borderless")
@@ -90,15 +89,16 @@ public struct ButtonStyleDemo: View {
           .font(.headline)
         allSizes
           .buttonStyle(BorderedButtonStyle())
+        #if !os(iOS)
         Text("link")
           .font(.headline)
         allSizes
           .buttonStyle(LinkButtonStyle())
+        #endif
         Text("plain")
           .font(.headline)
         allSizes
           .buttonStyle(PlainButtonStyle())
-        #endif
       }
     }
   }

--- a/Sources/TokamakDemo/CanvasDemo.swift
+++ b/Sources/TokamakDemo/CanvasDemo.swift
@@ -66,7 +66,7 @@ struct Confetti: View {
         let elapsed = CGFloat(
           timeline.date.timeIntervalSince1970 - startDate
             .timeIntervalSince1970
-        ) * 10
+        ).truncatingRemainder(dividingBy: 4) * 10
         let sqElapsed = elapsed * elapsed
 
         for piece in pieces {

--- a/Sources/TokamakDemo/CanvasDemo.swift
+++ b/Sources/TokamakDemo/CanvasDemo.swift
@@ -1,0 +1,94 @@
+// Copyright 2019-2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 9/19/21.
+//
+
+import Foundation
+import TokamakDOM
+
+public struct CanvasDemo: View {
+  public var body: some View {
+    Confetti()
+  }
+}
+
+struct Confetti: View {
+  static let colors: [Color] = [
+    Color.red,
+    Color.green,
+    Color.blue,
+    Color.pink,
+    Color.purple,
+    Color.orange,
+    Color.yellow,
+  ]
+  @State private var startDate = Date()
+  private let pieces: [Piece] = (0..<50).map { _ in
+    Piece(
+      point: CGPoint(x: CGFloat.random(in: 0...1), y: CGFloat.random(in: 0...1)),
+      size: CGSize(width: CGFloat.random(in: 0...1), height: CGFloat.random(in: 0...1)),
+      initialVelocity: CGSize(
+        width: -CGFloat.random(in: -1...1),
+        height: CGFloat.random(in: 0...2)
+      ),
+      angularVelocity: Double.random(in: -1...1),
+      color: Self.colors.randomElement()!
+    )
+  }
+
+  struct Piece {
+    let point: CGPoint
+    let size: CGSize
+    let initialVelocity: CGSize
+    let angularVelocity: Double
+    let color: Color
+  }
+
+  static let shape = Rectangle()
+
+  var body: some View {
+    TimelineView(AnimationTimelineSchedule.animation) { timeline in
+      Canvas { context, size in
+        let elapsed = CGFloat(
+          timeline.date.timeIntervalSince1970 - startDate
+            .timeIntervalSince1970
+        ) * 10
+        let sqElapsed = elapsed * elapsed
+
+        for piece in pieces {
+          context.drawLayer { context in
+            context.translateBy(
+              x: (piece.point.x * size.width) + (piece.initialVelocity.width * sqElapsed),
+              y: -((1 + piece.point.y) * (size.height / 2)) + (1 + piece.initialVelocity.height) *
+                sqElapsed
+            )
+            context.rotate(by: Angle.degrees(25 * piece.angularVelocity * Double(elapsed)))
+            context.fill(
+              Self.shape
+                .path(in: CGRect(
+                  origin: .zero,
+                  size: CGSize(
+                    width: 5 + (20 * piece.size.width),
+                    height: 5 + (20 * piece.size.height)
+                  )
+                )),
+              with: .color(piece.color)
+            )
+          }
+        }
+      }
+    }
+  }
+}

--- a/Sources/TokamakDemo/CanvasDemo.swift
+++ b/Sources/TokamakDemo/CanvasDemo.swift
@@ -18,12 +18,14 @@
 import Foundation
 import TokamakShim
 
+@available(macOS 12.0, iOS 15.0, *)
 public struct CanvasDemo: View {
   public var body: some View {
     Confetti()
   }
 }
 
+@available(macOS 12.0, iOS 15.0, *)
 struct Confetti: View {
   static let colors: [Color] = [
     Color.red,

--- a/Sources/TokamakDemo/CanvasDemo.swift
+++ b/Sources/TokamakDemo/CanvasDemo.swift
@@ -16,7 +16,7 @@
 //
 
 import Foundation
-import TokamakDOM
+import TokamakShim
 
 public struct CanvasDemo: View {
   public var body: some View {

--- a/Sources/TokamakDemo/CanvasDemo.swift
+++ b/Sources/TokamakDemo/CanvasDemo.swift
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Tokamak contributors
+// Copyright 2021 Tokamak contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/TokamakDemo/TextDemo.swift
+++ b/Sources/TokamakDemo/TextDemo.swift
@@ -53,8 +53,8 @@ struct TextDemo: View {
           .heavy,
           .black,
         ], id: \.self) { weight in
-          Text("a")
-            .fontWeight(weight)
+            Text("a")
+              .fontWeight(weight)
         }
       }
       VStack {

--- a/Sources/TokamakDemo/TokamakDemo.swift
+++ b/Sources/TokamakDemo/TokamakDemo.swift
@@ -105,6 +105,16 @@ struct TokamakDemoView: View {
               NavItem(unavailable: "OutlineGroup")
             }
           }
+          Section(header: Text("Drawing")) {
+            if #available(macOS 12.0, iOS 15.0, *) {
+              NavItem("Canvas", destination: CanvasDemo())
+            }
+            NavItem("Color", destination: ColorDemo())
+            NavItem("Path", destination: PathDemo())
+            if #available(macOS 12.0, iOS 15.0, *) {
+              NavItem("Shape Styles", destination: ShapeStyleDemo())
+            }
+          }
           Section(header: Text("Layout")) {
             NavItem("HStack/VStack", destination: StackDemo())
             if #available(OSX 10.16, iOS 14.0, *) {
@@ -138,15 +148,10 @@ struct TokamakDemoView: View {
           Section(header: Text("Misc")) {
             NavItem("Animation", destination: AnimationDemo())
             NavItem("Transitions", destination: TransitionDemo())
-            NavItem("Path", destination: PathDemo())
             NavItem("ProgressView", destination: ProgressViewDemo())
             NavItem("Environment", destination: EnvironmentDemo().font(.system(size: 8)))
             if #available(macOS 11.0, iOS 14.0, *) {
               NavItem("Preferences", destination: PreferenceKeyDemo())
-            }
-            NavItem("Color", destination: ColorDemo())
-            if #available(macOS 12.0, iOS 15.0, *) {
-              NavItem("Shape Styles", destination: ShapeStyleDemo())
             }
             if #available(OSX 11.0, iOS 14.0, *) {
               NavItem("AppStorage", destination: AppStorageDemo())

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -79,6 +79,11 @@ public final class StaticHTMLRenderer: Renderer {
     """
   }
 
+  /// Renders only the root child of the top level `<body>` tag.
+  public func renderRoot(shouldSortAttributes: Bool = false) -> String {
+    rootTarget.children.first?.outerHTML(shouldSortAttributes: shouldSortAttributes) ?? ""
+  }
+
   public init<V: View>(_ view: V, _ rootEnvironment: EnvironmentValues? = nil) {
     rootTarget = HTMLTarget(view, HTMLBody())
 

--- a/Sources/TokamakStaticHTML/Tokens/Tokens.swift
+++ b/Sources/TokamakStaticHTML/Tokens/Tokens.swift
@@ -20,7 +20,7 @@ extension Color {
   }
 }
 
-extension AnyColorBox.ResolvedValue {
+public extension AnyColorBox.ResolvedValue {
   var cssValue: String {
     "rgba(\(red * 255), \(green * 255), \(blue * 255), \(opacity))"
   }

--- a/Tests/TokamakStaticHTMLTests/HTMLStrategy.swift
+++ b/Tests/TokamakStaticHTMLTests/HTMLStrategy.swift
@@ -15,8 +15,8 @@
 #if canImport(SnapshotTesting)
 import SnapshotTesting
 
-extension Snapshotting where Value == String, Format == String {
-  public static let html = Snapshotting(pathExtension: "html", diffing: .lines)
+public extension Snapshotting where Value == String, Format == String {
+  static let html = Snapshotting(pathExtension: "html", diffing: .lines)
 }
 
 #endif


### PR DESCRIPTION
This is built on the [HTML canvas](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API), and is compatible with the iOS 15 [`Canvas`](https://developer.apple.com/documentation/swiftui/canvas) view. `TimelineView` with an `.animation` schedule only runs with `Canvas` at the moment with a special implementation using `requestAnimationFrame`, but could be adjusted to work with other views as well.

Here's a demo of confetti using `Canvas`:

https://user-images.githubusercontent.com/13581484/133929292-4b98926c-3e0a-468c-ad23-28d8a87e3c77.mov

