### PR TITLE
Build and test with SwiftWasm 5.5 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,17 @@ on:
 
 jobs:
   swiftwasm_bundle:
+    strategy:
+      matrix:
+        swiftwasm:
+          - "5.4"
+          - "5.5"
+
     runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
-      - uses: swiftwasm/swiftwasm-action@v5.4
+      - uses: swiftwasm/swiftwasm-action@v${{ matrix.swiftwasm }}
         with:
           shell-action: carton bundle --product TokamakDemo
 
@@ -20,7 +26,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: swiftwasm/swiftwasm-action@v5.4
+      - uses: swiftwasm/swiftwasm-action@v${{ matrix.swiftwasm }}
         with:
           shell-action: carton test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,27 +6,39 @@ on:
     branches: [main]
 
 jobs:
-  swiftwasm_bundle:
-    strategy:
-      matrix:
-        swiftwasm:
-          - "5.4"
-          - "5.5"
-
+  swiftwasm_bundle_5_4:
     runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
-      - uses: swiftwasm/swiftwasm-action@v${{ matrix.swiftwasm }}
+      - uses: swiftwasm/swiftwasm-action@v5.4
         with:
           shell-action: carton bundle --product TokamakDemo
 
-  swiftwasm_test:
+  swiftwasm_test_5_4:
     runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
-      - uses: swiftwasm/swiftwasm-action@v${{ matrix.swiftwasm }}
+      - uses: swiftwasm/swiftwasm-action@v5.4
+        with:
+          shell-action: carton test
+
+  swiftwasm_bundle_5_5:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: swiftwasm/swiftwasm-action@v5.5
+        with:
+          shell-action: carton bundle --product TokamakDemo
+
+  swiftwasm_test_5_5:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: swiftwasm/swiftwasm-action@v5.5
         with:
           shell-action: carton test
 


### PR DESCRIPTION
Configuration for simultaneous builds with SwiftWasm 5.4 and 5.5 can't be specified more succinctly due to https://github.com/swiftwasm/swiftwasm-action/issues/3. I had to create almost duplicate job descriptions because of that.