### PR TITLE
Fix `rootEnvironment` not merged with `.defaultEnvironment`

### DIFF
--- a/Sources/TokamakCore/Environment/EnvironmentValues.swift
+++ b/Sources/TokamakCore/Environment/EnvironmentValues.swift
@@ -44,6 +44,7 @@ public struct EnvironmentValues: CustomStringConvertible {
     }
   }
 
+  @_spi(TokamakCore)
   public mutating func merge(_ other: Self?) {
     if let other = other {
       values.merge(other.values) { existing, new in
@@ -52,6 +53,7 @@ public struct EnvironmentValues: CustomStringConvertible {
     }
   }
 
+  @_spi(TokamakCore)
   public func merging(_ other: Self?) -> Self {
     var merged = self
     merged.merge(other)

--- a/Sources/TokamakCore/Environment/EnvironmentValues.swift
+++ b/Sources/TokamakCore/Environment/EnvironmentValues.swift
@@ -43,6 +43,20 @@ public struct EnvironmentValues: CustomStringConvertible {
       values[bindable] = newValue
     }
   }
+
+  public mutating func merge(_ other: Self?) {
+    if let other = other {
+      values.merge(other.values) { existing, new in
+        new
+      }
+    }
+  }
+
+  public func merging(_ other: Self?) -> Self {
+    var merged = self
+    merged.merge(other)
+    return merged
+  }
 }
 
 struct IsEnabledKey: EnvironmentKey {

--- a/Sources/TokamakDOM/DOMRenderer.swift
+++ b/Sources/TokamakDOM/DOMRenderer.swift
@@ -100,7 +100,7 @@ final class DOMRenderer: Renderer {
     reconciler = StackReconciler(
       app: app,
       target: DOMNode(ref),
-      environment: rootEnvironment ?? .defaultEnvironment,
+      environment: .defaultEnvironment.merging(rootEnvironment),
       renderer: self
     ) { scheduler.schedule(options: nil, $0) }
   }

--- a/Sources/TokamakDOM/DOMRenderer.swift
+++ b/Sources/TokamakDOM/DOMRenderer.swift
@@ -100,7 +100,7 @@ final class DOMRenderer: Renderer {
     reconciler = StackReconciler(
       app: app,
       target: DOMNode(ref),
-      environment: .defaultEnvironment,
+      environment: rootEnvironment ?? .defaultEnvironment,
       renderer: self
     ) { scheduler.schedule(options: nil, $0) }
   }

--- a/Sources/TokamakGTK/GTKRenderer.swift
+++ b/Sources/TokamakGTK/GTKRenderer.swift
@@ -56,7 +56,7 @@ final class GTKRenderer: Renderer {
         self.reconciler = StackReconciler(
           app: app,
           target: Widget(window),
-          environment: rootEnvironment ?? .defaultEnvironment,
+          environment: .defaultEnvironment.merging(rootEnvironment),
           renderer: self,
           scheduler: { next in
             DispatchQueue.main.async {

--- a/Sources/TokamakGTK/GTKRenderer.swift
+++ b/Sources/TokamakGTK/GTKRenderer.swift
@@ -17,7 +17,7 @@
 
 import CGTK
 import Dispatch
-import TokamakCore
+@_spi(TokamakCore) import TokamakCore
 
 extension EnvironmentValues {
   /// Returns default settings for the GTK environment

--- a/Sources/TokamakGTK/GTKRenderer.swift
+++ b/Sources/TokamakGTK/GTKRenderer.swift
@@ -56,7 +56,7 @@ final class GTKRenderer: Renderer {
         self.reconciler = StackReconciler(
           app: app,
           target: Widget(window),
-          environment: .defaultEnvironment,
+          environment: rootEnvironment ?? .defaultEnvironment,
           renderer: self,
           scheduler: { next in
             DispatchQueue.main.async {

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -90,7 +90,7 @@ public final class StaticHTMLRenderer: Renderer {
     reconciler = StackReconciler(
       view: view,
       target: rootTarget,
-      environment: .defaultEnvironment,
+      environment: rootEnvironment ?? .defaultEnvironment,
       renderer: self,
       scheduler: { _ in
         fatalError("Stateful apps cannot be created with TokamakStaticHTML")
@@ -104,7 +104,7 @@ public final class StaticHTMLRenderer: Renderer {
     reconciler = StackReconciler(
       app: app,
       target: rootTarget,
-      environment: .defaultEnvironment,
+      environment: rootEnvironment ?? .defaultEnvironment,
       renderer: self,
       scheduler: { _ in
         fatalError("Stateful apps cannot be created with TokamakStaticHTML")

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -90,7 +90,7 @@ public final class StaticHTMLRenderer: Renderer {
     reconciler = StackReconciler(
       view: view,
       target: rootTarget,
-      environment: rootEnvironment ?? .defaultEnvironment,
+      environment: .defaultEnvironment.merging(rootEnvironment),
       renderer: self,
       scheduler: { _ in
         fatalError("Stateful apps cannot be created with TokamakStaticHTML")
@@ -104,7 +104,7 @@ public final class StaticHTMLRenderer: Renderer {
     reconciler = StackReconciler(
       app: app,
       target: rootTarget,
-      environment: rootEnvironment ?? .defaultEnvironment,
+      environment: .defaultEnvironment.merging(rootEnvironment),
       renderer: self,
       scheduler: { _ in
         fatalError("Stateful apps cannot be created with TokamakStaticHTML")

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -15,7 +15,7 @@
 //  Created by Carson Katri on 7/20/20.
 //
 
-import TokamakCore
+@_spi(TokamakCore) import TokamakCore
 
 extension EnvironmentValues {
   /// Returns default settings for the static HTML environment


### PR DESCRIPTION
While spelunking through the implementation of `EnvironmentValues` and its uses in Tokamak I noticed that a couple of functions were accepting a `rootEnvironment: EnvironmentValues? = nil` argument but then discarding whatever value you pass to it in favor of `.defaultEnvironment`.

This seems wrong to me? 🤔 