### PR TITLE
Change HStack and VStack to Flex

### DIFF
--- a/Sources/TokamakDemo/Layout/SpacerDemo.swift
+++ b/Sources/TokamakDemo/Layout/SpacerDemo.swift
@@ -23,6 +23,8 @@ struct SpacerDemo: View {
       HStack {
         Text("Left side.")
         Spacer()
+        Text("Center.")
+        Spacer()
         Text("Right side.")
       }
       Spacer()

--- a/Sources/TokamakDemo/Layout/StackDemo.swift
+++ b/Sources/TokamakDemo/Layout/StackDemo.swift
@@ -18,14 +18,17 @@ import TokamakShim
 struct StackDemo: View {
   @State private var horizontalSpacing: CGFloat = 8
   @State private var verticalSpacing: CGFloat = 8
+  @State private var horizontalAlignment: Int = 0
 
   var body: some View {
     VStack(spacing: verticalSpacing) {
+
       Text("Horizontal Spacing")
       Slider(value: $horizontalSpacing, in: 0...100)
 
       Text("Vertical Spacing")
       Slider(value: $verticalSpacing, in: 0...100)
+
       HStack(spacing: horizontalSpacing) {
         Rectangle()
           .fill(Color.red)
@@ -35,6 +38,10 @@ struct StackDemo: View {
           .fill(Color.green)
           .frame(width: 100, height: 100)
       }
+
+      Rectangle()
+          .fill(Color.yellow)
+          .frame(width: 100, height: 100)
     }
   }
 }

--- a/Sources/TokamakDemo/Layout/StackDemo.swift
+++ b/Sources/TokamakDemo/Layout/StackDemo.swift
@@ -18,7 +18,6 @@ import TokamakShim
 struct StackDemo: View {
   @State private var horizontalSpacing: CGFloat = 8
   @State private var verticalSpacing: CGFloat = 8
-  @State private var horizontalAlignment: Int = 0
 
   var body: some View {
     VStack(spacing: verticalSpacing) {

--- a/Sources/TokamakStaticHTML/Resources/TokamakStyles.swift
+++ b/Sources/TokamakStaticHTML/Resources/TokamakStyles.swift
@@ -15,16 +15,22 @@
 import TokamakCore
 
 public let tokamakStyles = """
+html {
+  box-sizing: border-box;
+}
+*, *:before, *:after {
+  box-sizing: inherit;
+}
 ._tokamak-stack {
-  display: grid;
+  display: flex;
 }
 ._tokamak-hstack {
-  grid-auto-flow: column;
-  column-gap: var(--tokamak-stack-gap, \(Int(defaultStackSpacing))px);
+  flex-direction: row;
+  gap: var(--tokamak-stack-gap, \(Int(defaultStackSpacing))px);
 }
 ._tokamak-vstack {
-  grid-auto-flow: row;
-  row-gap: var(--tokamak-stack-gap, \(Int(defaultStackSpacing))px);
+  flex-direction: column;
+  gap: var(--tokamak-stack-gap, \(Int(defaultStackSpacing))px);
 }
 ._tokamak-scrollview-hideindicators {
   scrollbar-color: transparent;

--- a/Sources/TokamakStaticHTML/Shapes/Path.swift
+++ b/Sources/TokamakStaticHTML/Shapes/Path.swift
@@ -136,6 +136,8 @@ extension Path: _HTMLPrimitive {
       """
       width: 100%;
       height: 100%;
+      min-width: 0;
+      min-height: 0;
       """ :
       """
       width: \(max(0, size.width));

--- a/Sources/TokamakStaticHTML/Views/Layout/VStack.swift
+++ b/Sources/TokamakStaticHTML/Views/Layout/VStack.swift
@@ -36,7 +36,7 @@ extension VStack: _HTMLPrimitive, SpacerContainer {
 
     return AnyView(HTML("div", [
       "style": """
-      justify-items: \(alignment.cssValue);
+      align-items: \(alignment.cssValue);
       \(hasSpacer ? "height: 100%;" : "")
       \(fillCrossAxis ? "width: 100%;" : "")
       \(spacing != defaultStackSpacing ? "--tokamak-stack-gap: \(spacing)px;" : "")

--- a/Tests/TokamakStaticHTMLTests/RenderingTests/VisualTests.swift
+++ b/Tests/TokamakStaticHTMLTests/RenderingTests/VisualTests.swift
@@ -147,7 +147,7 @@ final class VisualRenderingTests: XCTestCase {
           Color.clear
             .background(Material.ultraThick)
         }
-      },
+      }.frame(width: 100, height: 100),
       as: .image(size: .init(width: 100, height: 100)),
       timeout: defaultSnapshotTimeout
     )

--- a/Tests/TokamakStaticHTMLTests/RenderingTests/VisualTests.swift
+++ b/Tests/TokamakStaticHTMLTests/RenderingTests/VisualTests.swift
@@ -147,7 +147,7 @@ final class VisualRenderingTests: XCTestCase {
           Color.clear
             .background(Material.ultraThick)
         }
-      }.frame(width: 100, height: 100),
+      },
       as: .image(size: .init(width: 100, height: 100)),
       timeout: defaultSnapshotTimeout
     )


### PR DESCRIPTION
Flex fixes a lot of issues with Spacer (#441) and alignment. I tested alignment with the demo and made a change to the spacer demo to show centering using spacers.

It's worth noting that the minimum requirements for `gap` on `flexbox` is lower than the minimum requirements for Tokamak already, so there shouldn't be any compatibility issues. (https://caniuse.com/flexbox-gap)

I also added `box-sizing: border-box` to the default Tokamak style which fixed some issues in some demos (Namely the Spacer demo, which is why it's included in this PR)

This is my first contribution to Tokamak so I'd appreciate review and feedback!