### PR TITLE
Bump version to 0.10.0, update `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.10.0 (9 April 2022)
+
+This release adds support for SwiftWasm 5.6. It also updates JavaScriptKit and OpenCombineJS dependencies.
+Due to issues with support for older SwiftWasm releases in the `carton`/SwiftPM integration, Tokamak now requires
+SwiftWasm 5.6 or later, while SwiftWasm 5.4 and 5.5 are no longer supported.
+
+**Merged pull requests:**
+
+- Build and test with SwiftWasm 5.6 on CI ([#475](https://github.com/TokamakUI/Tokamak/pull/475)) via [@MaxDesiatov](https://github.com/MaxDesiatov)
+
 # 0.9.1 (16 February 2022)
 
 This release fixes an issue with `EnvironmentValues`, updates CI workflow for SwiftWasm 5.5, and bumps JavaScriptKit dependency to 0.12.0.


### PR DESCRIPTION
I'd be happy to include #471 as well, but I personally prefer rolling out big changes in stages. #471 deserves its own release, while in this release the only meaningful change is the Swift version requirement and JSKit/`carton` dependencies bump.