### PR TITLE
Use stable `v5.6` version of `swiftwasm-action`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,60 +24,60 @@ jobs:
         with:
           shell-action: carton test
 
-  core_macos_build:
-    runs-on: macos-12
+#   core_macos_build:
+#     runs-on: macos-12
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run the test suite on macOS, build the demo project for iOS
-        shell: bash
-        run: |
-          set -ex
-          sudo xcode-select --switch /Applications/Xcode_13.3.1.app/Contents/Developer/
-          # avoid building unrelated products for testing by specifying the test product explicitly
-          swift build --product TokamakPackageTests
-          `xcrun --find xctest` .build/debug/TokamakPackageTests.xctest ||
-            (cp -r /var/folders/*/*/*/*Tests . ; exit 1)
+#     steps:
+#       - uses: actions/checkout@v2
+#       - name: Run the test suite on macOS, build the demo project for iOS
+#         shell: bash
+#         run: |
+#           set -ex
+#           sudo xcode-select --switch /Applications/Xcode_13.3.1.app/Contents/Developer/
+#           # avoid building unrelated products for testing by specifying the test product explicitly
+#           swift build --product TokamakPackageTests
+#           `xcrun --find xctest` .build/debug/TokamakPackageTests.xctest ||
+#             (cp -r /var/folders/*/*/*/*Tests . ; exit 1)
 
-          rm -rf Sources/TokamakGTKCHelpers/*.c
+#           rm -rf Sources/TokamakGTKCHelpers/*.c
 
-          xcodebuild -version
+#           xcodebuild -version
 
-          # Make sure Tokamak can be built on macOS so that Xcode autocomplete works.
-          # Disable macOS builds until Monterey is available on GHA.
-          # xcodebuild -scheme TokamakDemo -destination 'generic/platform=macOS' \
-          #   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
-          #   xcpretty --color
+#           # Make sure Tokamak can be built on macOS so that Xcode autocomplete works.
+#           # Disable macOS builds until Monterey is available on GHA.
+#           # xcodebuild -scheme TokamakDemo -destination 'generic/platform=macOS' \
+#           #   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
+#           #   xcpretty --color
 
-          cd "NativeDemo"
-          xcodebuild -scheme iOS -destination 'generic/platform=iOS' \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
-            xcpretty --color
-          cd ..
+#           cd "NativeDemo"
+#           xcodebuild -scheme iOS -destination 'generic/platform=iOS' \
+#             CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
+#             xcpretty --color
+#           cd ..
 
-          ./benchmark.sh
+#           ./benchmark.sh
 
-      - name: Upload failed snapshots
-        uses: actions/upload-artifact@v2
-        if: ${{ failure() }}
-        with:
-          name: Failed snapshots
-          path: '*Tests'
+#       - name: Upload failed snapshots
+#         uses: actions/upload-artifact@v2
+#         if: ${{ failure() }}
+#         with:
+#           name: Failed snapshots
+#           path: '*Tests'
 
-  gtk_macos_build:
-    runs-on: macos-12
+#   gtk_macos_build:
+#     runs-on: macos-12
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build the GTK renderer on macOS
-        shell: bash
-        run: |
-          set -ex
-          sudo xcode-select --switch /Applications/Xcode_13.3.1.app/Contents/Developer/
+#     steps:
+#       - uses: actions/checkout@v2
+#       - name: Build the GTK renderer on macOS
+#         shell: bash
+#         run: |
+#           set -ex
+#           sudo xcode-select --switch /Applications/Xcode_13.3.1.app/Contents/Developer/
 
-          brew install gtk+3
+#           brew install gtk+3
 
-          make build
+#           make build
 
   gtk_ubuntu_18_04_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,65 +24,66 @@ jobs:
         with:
           shell-action: carton test
 
-#   core_macos_build:
-#     runs-on: macos-12
+  # Disabled until macos-12 is available on GitHub Actions, which is required for Xcode 13.3
+  # core_macos_build:
+  #   runs-on: macos-11
 
-#     steps:
-#       - uses: actions/checkout@v2
-#       - name: Run the test suite on macOS, build the demo project for iOS
-#         shell: bash
-#         run: |
-#           set -ex
-#           sudo xcode-select --switch /Applications/Xcode_13.3.1.app/Contents/Developer/
-#           # avoid building unrelated products for testing by specifying the test product explicitly
-#           swift build --product TokamakPackageTests
-#           `xcrun --find xctest` .build/debug/TokamakPackageTests.xctest ||
-#             (cp -r /var/folders/*/*/*/*Tests . ; exit 1)
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Run the test suite on macOS, build the demo project for iOS
+  #       shell: bash
+  #       run: |
+  #         set -ex
+  #         sudo xcode-select --switch /Applications/Xcode_13.0.app/Contents/Developer/
+  #         # avoid building unrelated products for testing by specifying the test product explicitly
+  #         swift build --product TokamakPackageTests
+  #         `xcrun --find xctest` .build/debug/TokamakPackageTests.xctest ||
+  #           (cp -r /var/folders/*/*/*/*Tests . ; exit 1)
 
-#           rm -rf Sources/TokamakGTKCHelpers/*.c
+  #         rm -rf Sources/TokamakGTKCHelpers/*.c
 
-#           xcodebuild -version
+  #         xcodebuild -version
 
-#           # Make sure Tokamak can be built on macOS so that Xcode autocomplete works.
-#           # Disable macOS builds until Monterey is available on GHA.
-#           # xcodebuild -scheme TokamakDemo -destination 'generic/platform=macOS' \
-#           #   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
-#           #   xcpretty --color
+  #         # Make sure Tokamak can be built on macOS so that Xcode autocomplete works.
+  #         # Disable macOS builds until Monterey is available on GHA.
+  #         # xcodebuild -scheme TokamakDemo -destination 'generic/platform=macOS' \
+  #         #   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
+  #         #   xcpretty --color
 
-#           cd "NativeDemo"
-#           xcodebuild -scheme iOS -destination 'generic/platform=iOS' \
-#             CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
-#             xcpretty --color
-#           cd ..
+  #         cd "NativeDemo"
+  #         xcodebuild -scheme iOS -destination 'generic/platform=iOS' \
+  #           CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
+  #           xcpretty --color
+  #         cd ..
 
-#           ./benchmark.sh
+  #         ./benchmark.sh
 
-#       - name: Upload failed snapshots
-#         uses: actions/upload-artifact@v2
-#         if: ${{ failure() }}
-#         with:
-#           name: Failed snapshots
-#           path: '*Tests'
+  #     - name: Upload failed snapshots
+  #       uses: actions/upload-artifact@v2
+  #       if: ${{ failure() }}
+  #       with:
+  #         name: Failed snapshots
+  #         path: '*Tests'
 
-#   gtk_macos_build:
-#     runs-on: macos-12
+  # gtk_macos_build:
+  #   runs-on: macos-11
 
-#     steps:
-#       - uses: actions/checkout@v2
-#       - name: Build the GTK renderer on macOS
-#         shell: bash
-#         run: |
-#           set -ex
-#           sudo xcode-select --switch /Applications/Xcode_13.3.1.app/Contents/Developer/
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Build the GTK renderer on macOS
+  #       shell: bash
+  #       run: |
+  #         set -ex
+  #         sudo xcode-select --switch /Applications/Xcode_13.0.app/Contents/Developer/
 
-#           brew install gtk+3
+  #         brew install gtk+3
 
-#           make build
+  #         make build
 
   gtk_ubuntu_18_04_build:
     runs-on: ubuntu-latest
     container:
-     image: swiftlang/swift:nightly-bionic
+      image: swiftlang/swift:nightly-bionic
 
     steps:
       - uses: actions/checkout@v2
@@ -97,7 +98,7 @@ jobs:
   gtk_ubuntu_20_04_build:
     runs-on: ubuntu-latest
     container:
-     image: swiftlang/swift:nightly-focal
+      image: swiftlang/swift:nightly-focal
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash
         run: |
           set -ex
-          sudo xcode-select --switch /Applications/Xcode_13.3.app/Contents/Developer/
+          sudo xcode-select --switch /Applications/Xcode_13.3.1.app/Contents/Developer/
           # avoid building unrelated products for testing by specifying the test product explicitly
           swift build --product TokamakPackageTests
           `xcrun --find xctest` .build/debug/TokamakPackageTests.xctest ||
@@ -73,7 +73,7 @@ jobs:
         shell: bash
         run: |
           set -ex
-          sudo xcode-select --switch /Applications/Xcode_13.3.app/Contents/Developer/
+          sudo xcode-select --switch /Applications/Xcode_13.3.1.app/Contents/Developer/
 
           brew install gtk+3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,61 +24,60 @@ jobs:
         with:
           shell-action: carton test
 
-  # Disabled until macos-12 is available on GitHub Actions, which is required for Xcode 13.3
-  # core_macos_build:
-  #   runs-on: macos-11
+  core_macos_build:
+    runs-on: macos-12
 
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Run the test suite on macOS, build the demo project for iOS
-  #       shell: bash
-  #       run: |
-  #         set -ex
-  #         sudo xcode-select --switch /Applications/Xcode_13.0.app/Contents/Developer/
-  #         # avoid building unrelated products for testing by specifying the test product explicitly
-  #         swift build --product TokamakPackageTests
-  #         `xcrun --find xctest` .build/debug/TokamakPackageTests.xctest ||
-  #           (cp -r /var/folders/*/*/*/*Tests . ; exit 1)
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run the test suite on macOS, build the demo project for iOS
+        shell: bash
+        run: |
+          set -ex
+          sudo xcode-select --switch /Applications/Xcode_13.3.app/Contents/Developer/
+          # avoid building unrelated products for testing by specifying the test product explicitly
+          swift build --product TokamakPackageTests
+          `xcrun --find xctest` .build/debug/TokamakPackageTests.xctest ||
+            (cp -r /var/folders/*/*/*/*Tests . ; exit 1)
 
-  #         rm -rf Sources/TokamakGTKCHelpers/*.c
+          rm -rf Sources/TokamakGTKCHelpers/*.c
 
-  #         xcodebuild -version
+          xcodebuild -version
 
-  #         # Make sure Tokamak can be built on macOS so that Xcode autocomplete works.
-  #         # Disable macOS builds until Monterey is available on GHA.
-  #         # xcodebuild -scheme TokamakDemo -destination 'generic/platform=macOS' \
-  #         #   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
-  #         #   xcpretty --color
+          # Make sure Tokamak can be built on macOS so that Xcode autocomplete works.
+          # Disable macOS builds until Monterey is available on GHA.
+          # xcodebuild -scheme TokamakDemo -destination 'generic/platform=macOS' \
+          #   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
+          #   xcpretty --color
 
-  #         cd "NativeDemo"
-  #         xcodebuild -scheme iOS -destination 'generic/platform=iOS' \
-  #           CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
-  #           xcpretty --color
-  #         cd ..
+          cd "NativeDemo"
+          xcodebuild -scheme iOS -destination 'generic/platform=iOS' \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
+            xcpretty --color
+          cd ..
 
-  #         ./benchmark.sh
+          ./benchmark.sh
 
-  #     - name: Upload failed snapshots
-  #       uses: actions/upload-artifact@v2
-  #       if: ${{ failure() }}
-  #       with:
-  #         name: Failed snapshots
-  #         path: '*Tests'
+      - name: Upload failed snapshots
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: Failed snapshots
+          path: '*Tests'
 
-  # gtk_macos_build:
-  #   runs-on: macos-11
+  gtk_macos_build:
+    runs-on: macos-12
 
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Build the GTK renderer on macOS
-  #       shell: bash
-  #       run: |
-  #         set -ex
-  #         sudo xcode-select --switch /Applications/Xcode_13.0.app/Contents/Developer/
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the GTK renderer on macOS
+        shell: bash
+        run: |
+          set -ex
+          sudo xcode-select --switch /Applications/Xcode_13.3.app/Contents/Developer/
 
-  #         brew install gtk+3
+          brew install gtk+3
 
-  #         make build
+          make build
 
   gtk_ubuntu_18_04_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: swiftwasm/swiftwasm-action@main
+      - uses: swiftwasm/swiftwasm-action@v5.6
         with:
           shell-action: carton bundle --product TokamakDemo
 
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: swiftwasm/swiftwasm-action@main
+      - uses: swiftwasm/swiftwasm-action@v5.6
         with:
           shell-action: carton test
 


### PR DESCRIPTION
After `carton` 0.14.0 was tagged, I've updated `swiftwasm-action` to use that latest release. With that, corresponding `v5.6` was tagged, which I propose to use in `ci.yml` instead of the `main` branch.