### PR TITLE
Explicitly mention `carton` version in "Requirements"

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ you'd like to use Xcode for auto-completion, or when developing multi-platform a
 and macOS at the same time.
 - [Swift 5.6 or later](https://swift.org/download/) and Ubuntu 18.04/20.04 if you'd like to use Linux.
   Other Linux distributions are currently not supported.
+- [`carton`](https://carton.dev) build tool of version 0.14.x. See ["Getting started" section](#getting-started) for installation steps.
 
 ### For users of apps depending on Tokamak
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ you'd like to use Xcode for auto-completion, or when developing multi-platform a
 and macOS at the same time.
 - [Swift 5.6 or later](https://swift.org/download/) and Ubuntu 18.04/20.04 if you'd like to use Linux.
   Other Linux distributions are currently not supported.
-- [`carton`](https://carton.dev) build tool of version 0.14.x. See ["Getting started" section](#getting-started) for installation steps.
+- [`carton` 0.14.x](https://carton.dev) (carton is our build tool, see the ["Getting started" section](#getting-started) for installation steps)
 
 ### For users of apps depending on Tokamak
 


### PR DESCRIPTION
This makes the version number of `carton` required for successful builds more explicit.