### PR TITLE
Support meta tags in StaticHTMLRenderer

### DIFF
--- a/Sources/TokamakCore/MountedViews/MountedCompositeView.swift
+++ b/Sources/TokamakCore/MountedViews/MountedCompositeView.swift
@@ -78,9 +78,6 @@ final class MountedCompositeView<R: Renderer>: MountedCompositeElement<R> {
 
       if let preferenceModifier = self.view.view as? _PreferenceWritingViewProtocol {
         self.view = preferenceModifier.modifyPreferenceStore(&self.preferenceStore)
-        if let parent = parent {
-          parent.preferenceStore.merge(with: self.preferenceStore)
-        }
       }
 
       if let preferenceReader = self.view.view as? _PreferenceReadingViewProtocol {

--- a/Sources/TokamakCore/MountedViews/MountedElement.swift
+++ b/Sources/TokamakCore/MountedViews/MountedElement.swift
@@ -94,19 +94,16 @@ public class MountedElement<R: Renderer> {
 
   public internal(set) var environmentValues: EnvironmentValues
 
-  weak var parent: MountedElement<R>?
-  /// `didSet` on this field propagates the preference changes up the view tree.
-  var preferenceStore: _PreferenceStore = .init() {
-    didSet {
-      parent?.preferenceStore.merge(with: preferenceStore)
-    }
-  }
+  weak private(set) var parent: MountedElement<R>?
+
+  var preferenceStore: _PreferenceStore
 
   public internal(set) var viewTraits: _ViewTraitStore
 
   init(_ app: _AnyApp, _ environmentValues: EnvironmentValues, _ parent: MountedElement<R>?) {
     element = .app(app)
     self.parent = parent
+    self.preferenceStore = parent?.preferenceStore ?? .init()
     self.environmentValues = environmentValues
     viewTraits = .init()
     updateEnvironment()
@@ -115,6 +112,7 @@ public class MountedElement<R: Renderer> {
   init(_ scene: _AnyScene, _ environmentValues: EnvironmentValues, _ parent: MountedElement<R>?) {
     element = .scene(scene)
     self.parent = parent
+    self.preferenceStore = parent?.preferenceStore ?? .init()
     self.environmentValues = environmentValues
     viewTraits = .init()
     updateEnvironment()
@@ -128,6 +126,7 @@ public class MountedElement<R: Renderer> {
   ) {
     element = .view(view)
     self.parent = parent
+    self.preferenceStore = parent?.preferenceStore ?? .init()
     self.environmentValues = environmentValues
     self.viewTraits = viewTraits
     updateEnvironment()

--- a/Sources/TokamakCore/MountedViews/MountedElement.swift
+++ b/Sources/TokamakCore/MountedViews/MountedElement.swift
@@ -96,26 +96,26 @@ public class MountedElement<R: Renderer> {
 
   weak private(set) var parent: MountedElement<R>?
 
-  var preferenceStore: _PreferenceStore
+  var preferenceStore: _PreferenceStore = .init()
 
   public internal(set) var viewTraits: _ViewTraitStore
 
   init(_ app: _AnyApp, _ environmentValues: EnvironmentValues, _ parent: MountedElement<R>?) {
     element = .app(app)
     self.parent = parent
-    self.preferenceStore = parent?.preferenceStore ?? .init()
     self.environmentValues = environmentValues
     viewTraits = .init()
     updateEnvironment()
+    connectParentPreferenceStore()
   }
 
   init(_ scene: _AnyScene, _ environmentValues: EnvironmentValues, _ parent: MountedElement<R>?) {
     element = .scene(scene)
     self.parent = parent
-    self.preferenceStore = parent?.preferenceStore ?? .init()
     self.environmentValues = environmentValues
     viewTraits = .init()
     updateEnvironment()
+    connectParentPreferenceStore()
   }
 
   init(
@@ -126,10 +126,10 @@ public class MountedElement<R: Renderer> {
   ) {
     element = .view(view)
     self.parent = parent
-    self.preferenceStore = parent?.preferenceStore ?? .init()
     self.environmentValues = environmentValues
     self.viewTraits = viewTraits
     updateEnvironment()
+    connectParentPreferenceStore()
   }
 
   func updateEnvironment() {
@@ -142,6 +142,10 @@ public class MountedElement<R: Renderer> {
     case .view:
       environmentValues.inject(into: &view.view, type)
     }
+  }
+
+  func connectParentPreferenceStore() {
+    preferenceStore.parent = parent?.preferenceStore
   }
 
   /// You must call `super.prepareForMount` before all other mounting work.

--- a/Sources/TokamakCore/MountedViews/MountedElement.swift
+++ b/Sources/TokamakCore/MountedViews/MountedElement.swift
@@ -94,7 +94,7 @@ public class MountedElement<R: Renderer> {
 
   public internal(set) var environmentValues: EnvironmentValues
 
-  weak private(set) var parent: MountedElement<R>?
+  private(set) weak var parent: MountedElement<R>?
 
   var preferenceStore: _PreferenceStore = .init()
 

--- a/Sources/TokamakCore/Preferences/PreferenceKey.swift
+++ b/Sources/TokamakCore/Preferences/PreferenceKey.swift
@@ -48,7 +48,7 @@ public extension _PreferenceValue {
   }
 }
 
-public struct _PreferenceStore {
+public final class _PreferenceStore {
   /// The backing values of the `_PreferenceStore`.
   private var values: [String: Any]
 
@@ -63,23 +63,11 @@ public struct _PreferenceStore {
       ?? _PreferenceValue(valueList: [Key.defaultValue])
   }
 
-  public mutating func insert<Key>(_ value: Key.Value, forKey key: Key.Type = Key.self)
+  public func insert<Key>(_ value: Key.Value, forKey key: Key.Type = Key.self)
     where Key: PreferenceKey
   {
     let previousValues = self.value(forKey: key).valueList
     values[String(reflecting: key)] = _PreferenceValue<Key>(valueList: previousValues + [value])
-  }
-
-  public mutating func merge(with other: Self) {
-    self = merging(with: other)
-  }
-
-  public func merging(with other: Self) -> Self {
-    var result = values
-    for (key, value) in other.values {
-      result[key] = value
-    }
-    return .init(values: result)
   }
 }
 

--- a/Sources/TokamakCore/Preferences/PreferenceKey.swift
+++ b/Sources/TokamakCore/Preferences/PreferenceKey.swift
@@ -52,6 +52,8 @@ public final class _PreferenceStore {
   /// The backing values of the `_PreferenceStore`.
   private var values: [String: Any]
 
+  weak var parent: _PreferenceStore?
+
   public init(values: [String: Any] = [:]) {
     self.values = values
   }
@@ -68,6 +70,7 @@ public final class _PreferenceStore {
   {
     let previousValues = self.value(forKey: key).valueList
     values[String(reflecting: key)] = _PreferenceValue<Key>(valueList: previousValues + [value])
+    parent?.insert(value, forKey: key)
   }
 }
 

--- a/Sources/TokamakCore/StackReconciler.swift
+++ b/Sources/TokamakCore/StackReconciler.swift
@@ -58,6 +58,12 @@ public final class StackReconciler<R: Renderer> {
    */
   public let rootTarget: R.TargetType
 
+  /** A root renderer's main preference store
+   */
+  public var preferenceStore: _PreferenceStore {
+    rootElement.preferenceStore
+  }
+
   /** A root of the mounted elements tree to which all other mounted elements are attached to.
    */
   private let rootElement: MountedElement<R>

--- a/Sources/TokamakCore/StackReconciler.swift
+++ b/Sources/TokamakCore/StackReconciler.swift
@@ -58,7 +58,7 @@ public final class StackReconciler<R: Renderer> {
    */
   public let rootTarget: R.TargetType
 
-  /** A root renderer's main preference store
+  /** A root renderer's main preference store.
    */
   public var preferenceStore: _PreferenceStore {
     rootElement.preferenceStore

--- a/Sources/TokamakCore/Views/Containers/Group.swift
+++ b/Sources/TokamakCore/Views/Containers/Group.swift
@@ -19,7 +19,7 @@ public struct Group<Content> {
   }
 }
 
-extension Group: _PrimitiveView & View where Content: View {}
+extension Group: _PrimitiveView, View where Content: View {}
 
 extension Group: ParentView where Content: View {
   @_spi(TokamakCore)

--- a/Sources/TokamakStaticHTML/App.swift
+++ b/Sources/TokamakStaticHTML/App.swift
@@ -24,7 +24,7 @@ public extension App {
   }
 
   static func _setTitle(_ title: String) {
-    StaticHTMLRenderer.title = title
+    // no-op: use Title view
   }
 
   var _phasePublisher: AnyPublisher<ScenePhase, Never> {

--- a/Sources/TokamakStaticHTML/Preferences/Preferences.swift
+++ b/Sources/TokamakStaticHTML/Preferences/Preferences.swift
@@ -29,6 +29,6 @@ struct HTMLMetaPreferenceKey: PreferenceKey {
     static var defaultValue: [_HTMLMeta] = []
 
     static func reduce(value: inout [_HTMLMeta], nextValue: () -> [_HTMLMeta]) {
-        value = value + nextValue()
+        value += nextValue()
     }
 }

--- a/Sources/TokamakStaticHTML/Preferences/Preferences.swift
+++ b/Sources/TokamakStaticHTML/Preferences/Preferences.swift
@@ -26,16 +26,9 @@ struct HTMLTitlePreferenceKey: PreferenceKey {
 }
 
 struct HTMLMetaPreferenceKey: PreferenceKey {
-    internal enum HTMLMeta: Equatable, Hashable {
-        case charset(_ charset: String)
-        case name(_ name: String, content: String)
-        case property(_ property: String, content: String)
-        case httpEquiv(_ httpEquiv: String, content: String)
-    }
+    static var defaultValue: [_HTMLMeta] = []
 
-    static var defaultValue: [HTMLMeta] = []
-
-    static func reduce(value: inout [HTMLMeta], nextValue: () -> [HTMLMeta]) {
+    static func reduce(value: inout [_HTMLMeta], nextValue: () -> [_HTMLMeta]) {
         value = value + nextValue()
     }
 }

--- a/Sources/TokamakStaticHTML/Preferences/Preferences.swift
+++ b/Sources/TokamakStaticHTML/Preferences/Preferences.swift
@@ -17,18 +17,21 @@
 
 import TokamakCore
 
-struct HTMLTitlePreferenceKey: PreferenceKey {
-    static var defaultValue: String = ""
+public struct HTMLTitlePreferenceKey: PreferenceKey {
+    public static var defaultValue: String = ""
 
-    static func reduce(value: inout String, nextValue: () -> String) {
+    public static func reduce(value: inout String, nextValue: () -> String) {
         value = nextValue()
     }
 }
 
-struct HTMLMetaPreferenceKey: PreferenceKey {
-    static var defaultValue: [_HTMLMeta] = []
+public struct HTMLMetaPreferenceKey: PreferenceKey {
+    public static var defaultValue: [HTMLMeta.MetaTag] = []
 
-    static func reduce(value: inout [_HTMLMeta], nextValue: () -> [_HTMLMeta]) {
+    public static func reduce(
+        value: inout [HTMLMeta.MetaTag],
+        nextValue: () -> [HTMLMeta.MetaTag]
+    ) {
         value += nextValue()
     }
 }

--- a/Sources/TokamakStaticHTML/Preferences/Preferences.swift
+++ b/Sources/TokamakStaticHTML/Preferences/Preferences.swift
@@ -18,20 +18,20 @@
 import TokamakCore
 
 public struct HTMLTitlePreferenceKey: PreferenceKey {
-    public static var defaultValue: String = ""
+  public static var defaultValue: String = ""
 
-    public static func reduce(value: inout String, nextValue: () -> String) {
-        value = nextValue()
-    }
+  public static func reduce(value: inout String, nextValue: () -> String) {
+    value = nextValue()
+  }
 }
 
 public struct HTMLMetaPreferenceKey: PreferenceKey {
-    public static var defaultValue: [HTMLMeta.MetaTag] = []
+  public static var defaultValue: [HTMLMeta.MetaTag] = []
 
-    public static func reduce(
-        value: inout [HTMLMeta.MetaTag],
-        nextValue: () -> [HTMLMeta.MetaTag]
-    ) {
-        value += nextValue()
-    }
+  public static func reduce(
+    value: inout [HTMLMeta.MetaTag],
+    nextValue: () -> [HTMLMeta.MetaTag]
+  ) {
+    value += nextValue()
+  }
 }

--- a/Sources/TokamakStaticHTML/Preferences/Preferences.swift
+++ b/Sources/TokamakStaticHTML/Preferences/Preferences.swift
@@ -36,6 +36,6 @@ struct HTMLMetaPreferenceKey: PreferenceKey {
     static var defaultValue: [HTMLMeta] = []
 
     static func reduce(value: inout [HTMLMeta], nextValue: () -> [HTMLMeta]) {
-        value.append(contentsOf: nextValue())
+        value = value + nextValue()
     }
 }

--- a/Sources/TokamakStaticHTML/Preferences/Preferences.swift
+++ b/Sources/TokamakStaticHTML/Preferences/Preferences.swift
@@ -1,0 +1,31 @@
+//
+//  Preferences.swift
+//  
+//
+//  Created by Andrew Barba on 5/20/22.
+//
+
+import TokamakCore
+
+internal struct HTMLTitlePreferenceKey: PreferenceKey {
+    static var defaultValue: String = ""
+
+    static func reduce(value: inout String, nextValue: () -> String) {
+        value = nextValue()
+    }
+}
+
+internal struct HTMLMetaPreferenceKey: PreferenceKey {
+    internal enum HTMLMeta: Equatable, Hashable {
+        case charset(_ charset: String)
+        case name(_ name: String, content: String)
+        case property(_ property: String, content: String)
+        case httpEquiv(_ httpEquiv: String, content: String)
+    }
+
+    static var defaultValue: [HTMLMeta] = []
+
+    static func reduce(value: inout [HTMLMeta], nextValue: () -> [HTMLMeta]) {
+        value.append(contentsOf: nextValue())
+    }
+}

--- a/Sources/TokamakStaticHTML/Preferences/Preferences.swift
+++ b/Sources/TokamakStaticHTML/Preferences/Preferences.swift
@@ -17,7 +17,7 @@
 
 import TokamakCore
 
-internal struct HTMLTitlePreferenceKey: PreferenceKey {
+struct HTMLTitlePreferenceKey: PreferenceKey {
     static var defaultValue: String = ""
 
     static func reduce(value: inout String, nextValue: () -> String) {
@@ -25,7 +25,7 @@ internal struct HTMLTitlePreferenceKey: PreferenceKey {
     }
 }
 
-internal struct HTMLMetaPreferenceKey: PreferenceKey {
+struct HTMLMetaPreferenceKey: PreferenceKey {
     internal enum HTMLMeta: Equatable, Hashable {
         case charset(_ charset: String)
         case name(_ name: String, content: String)

--- a/Sources/TokamakStaticHTML/Preferences/Preferences.swift
+++ b/Sources/TokamakStaticHTML/Preferences/Preferences.swift
@@ -1,6 +1,16 @@
+// Copyright 2022 Tokamak contributors
 //
-//  Preferences.swift
-//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Andrew Barba on 5/20/22.
 //

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -78,11 +78,11 @@ public final class StaticHTMLRenderer: Renderer {
 
   var rootTarget: HTMLTarget
 
-  internal var title: String {
+  var title: String {
     reconciler?.preferenceStore.value(forKey: HTMLTitlePreferenceKey.self).value ?? ""
   }
 
-  internal var meta: [HTMLMetaPreferenceKey.HTMLMeta] {
+  var meta: [HTMLMetaPreferenceKey.HTMLMeta] {
     reconciler?.preferenceStore.value(forKey: HTMLMetaPreferenceKey.self).value ?? []
   }
 

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -58,7 +58,7 @@ struct HTMLBody: AnyHTML {
   ]
 }
 
-extension _HTMLMeta {
+extension HTMLMeta.MetaTag {
   func outerHTML() -> String {
     switch self {
     case .charset(let charset):
@@ -82,7 +82,7 @@ public final class StaticHTMLRenderer: Renderer {
     reconciler?.preferenceStore.value(forKey: HTMLTitlePreferenceKey.self).value ?? ""
   }
 
-  var meta: [_HTMLMeta] {
+  var meta: [HTMLMeta.MetaTag] {
     reconciler?.preferenceStore.value(forKey: HTMLMetaPreferenceKey.self).value ?? []
   }
 

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -61,13 +61,13 @@ struct HTMLBody: AnyHTML {
 extension HTMLMeta.MetaTag {
   func outerHTML() -> String {
     switch self {
-    case .charset(let charset):
+    case let .charset(charset):
       return #"<meta charset="\#(charset)">"#
-    case .name(let name, let content):
+    case let .name(name, content):
       return #"<meta name="\#(name)" content="\#(content)">"#
-    case .property(let property, let content):
+    case let .property(property, content):
       return #"<meta property="\#(property)" content="\#(content)">"#
-    case .httpEquiv(let httpEquiv, let content):
+    case let .httpEquiv(httpEquiv, content):
       return #"<meta http-equiv="\#(httpEquiv)" content="\#(content)">"#
     }
   }
@@ -91,7 +91,7 @@ public final class StaticHTMLRenderer: Renderer {
     <html>
     <head>
       <title>\(title)</title>
-      \(meta.map({ $0.outerHTML() }).joined(separator: "\n  "))
+      \(meta.map { $0.outerHTML() }.joined(separator: "\n  "))
       <style>
         \(tokamakStyles)
       </style>
@@ -107,7 +107,6 @@ public final class StaticHTMLRenderer: Renderer {
   }
 
   public init<V: View>(_ view: V, _ rootEnvironment: EnvironmentValues? = nil) {
-
     rootTarget = HTMLTarget(view, HTMLBody())
 
     reconciler = StackReconciler(

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -89,7 +89,7 @@ public final class StaticHTMLRenderer: Renderer {
     <html>
     <head>
       <title>\(title)</title>
-      \(meta.map({ $0.outerHTML() }).joined(separator: "\n      "))
+      \(meta.map({ $0.outerHTML() }).joined(separator: "\n  "))
       <style>
         \(tokamakStyles)
       </style>

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -80,7 +80,9 @@ public final class StaticHTMLRenderer: Renderer {
 
   var rootTarget: HTMLTarget
 
-  public var title: String = ""
+  public static var title: String = ""
+
+  public var title: String = StaticHTMLRenderer.title
 
   public var meta: [HTMLMetaTag] = []
 

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -58,7 +58,7 @@ struct HTMLBody: AnyHTML {
   ]
 }
 
-extension HTMLMetaPreferenceKey.HTMLMeta {
+extension _HTMLMeta {
   func outerHTML() -> String {
     switch self {
     case .charset(let charset):
@@ -82,7 +82,7 @@ public final class StaticHTMLRenderer: Renderer {
     reconciler?.preferenceStore.value(forKey: HTMLTitlePreferenceKey.self).value ?? ""
   }
 
-  var meta: [HTMLMetaPreferenceKey.HTMLMeta] {
+  var meta: [_HTMLMeta] {
     reconciler?.preferenceStore.value(forKey: HTMLMetaPreferenceKey.self).value ?? []
   }
 

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -58,13 +58,8 @@ struct HTMLBody: AnyHTML {
   ]
 }
 
-public enum HTMLMetaTag {
-  case charset(_ charset: String)
-  case name(_ name: String, content: String)
-  case property(_ property: String, content: String)
-  case httpEquiv(_ httpEquiv: String, content: String)
-
-  public func outerHTML() -> String {
+extension HTMLMetaPreferenceKey.HTMLMeta {
+  func outerHTML() -> String {
     switch self {
     case .charset(let charset):
       return #"<meta charset="\#(charset)">"#
@@ -83,11 +78,13 @@ public final class StaticHTMLRenderer: Renderer {
 
   var rootTarget: HTMLTarget
 
-  public static var title: String = ""
+  internal var title: String {
+    reconciler?.preferenceStore.value(forKey: HTMLTitlePreferenceKey.self).value ?? ""
+  }
 
-  public var title: String = StaticHTMLRenderer.title
-
-  public var meta: [HTMLMetaTag] = []
+  internal var meta: [HTMLMetaPreferenceKey.HTMLMeta] {
+    reconciler?.preferenceStore.value(forKey: HTMLMetaPreferenceKey.self).value ?? []
+  }
 
   public func render(shouldSortAttributes: Bool = false) -> String {
     """
@@ -178,23 +175,6 @@ public final class StaticHTMLRenderer: Renderer {
 
   public func primitiveBody(for view: Any) -> AnyView? {
     (view as? _HTMLPrimitive)?.renderedBody
-  }
-}
-
-extension StaticHTMLRenderer {
-  public func title(_ newValue: String) -> Self {
-    title = newValue
-    return self
-  }
-
-  public func meta(_ newValues: HTMLMetaTag...) -> Self {
-    meta.append(contentsOf: newValues)
-    return self
-  }
-
-  public func meta(_ newValues: [HTMLMetaTag]) -> Self {
-    meta.append(contentsOf: newValues)
-    return self
   }
 }
 

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -61,6 +61,7 @@ struct HTMLBody: AnyHTML {
 public enum HTMLMetaTag {
   case charset(_ charset: String)
   case name(_ name: String, content: String)
+  case property(_ property: String, content: String)
   case httpEquiv(_ httpEquiv: String, content: String)
 
   public func outerHTML() -> String {
@@ -69,6 +70,8 @@ public enum HTMLMetaTag {
       return #"<meta charset="\#(charset)">"#
     case .name(let name, let content):
       return #"<meta name="\#(name)" content="\#(content)">"#
+    case .property(let property, let content):
+      return #"<meta property="\#(property)" content="\#(content)">"#
     case .httpEquiv(let httpEquiv, let content):
       return #"<meta http-equiv="\#(httpEquiv)" content="\#(content)">"#
     }
@@ -107,6 +110,7 @@ public final class StaticHTMLRenderer: Renderer {
   }
 
   public init<V: View>(_ view: V, _ rootEnvironment: EnvironmentValues? = nil) {
+
     rootTarget = HTMLTarget(view, HTMLBody())
 
     reconciler = StackReconciler(

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -58,18 +58,38 @@ struct HTMLBody: AnyHTML {
   ]
 }
 
+public enum HTMLMetaTag {
+  case charset(_ charset: String)
+  case name(_ name: String, content: String)
+  case httpEquiv(_ httpEquiv: String, content: String)
+
+  public func outerHTML() -> String {
+    switch self {
+    case .charset(let charset):
+      return #"<meta charset="\#(charset)">"#
+    case .name(let name, let content):
+      return #"<meta name="\#(name)" content="\#(content)">"#
+    case .httpEquiv(let httpEquiv, let content):
+      return #"<meta http-equiv="\#(httpEquiv)" content="\#(content)">"#
+    }
+  }
+}
+
 public final class StaticHTMLRenderer: Renderer {
   private var reconciler: StackReconciler<StaticHTMLRenderer>?
 
   var rootTarget: HTMLTarget
 
-  static var title: String = ""
+  public var title: String = ""
+
+  public var meta: [HTMLMetaTag] = []
 
   public func render(shouldSortAttributes: Bool = false) -> String {
     """
     <html>
     <head>
-      <title>\(Self.title)</title>
+      <title>\(title)</title>
+      \(meta.map({ $0.outerHTML() }).joined(separator: "\n      "))
       <style>
         \(tokamakStyles)
       </style>
@@ -152,6 +172,23 @@ public final class StaticHTMLRenderer: Renderer {
 
   public func primitiveBody(for view: Any) -> AnyView? {
     (view as? _HTMLPrimitive)?.renderedBody
+  }
+}
+
+extension StaticHTMLRenderer {
+  public func title(_ newValue: String) -> Self {
+    title = newValue
+    return self
+  }
+
+  public func meta(_ newValues: HTMLMetaTag...) -> Self {
+    meta.append(contentsOf: newValues)
+    return self
+  }
+
+  public func meta(_ newValues: [HTMLMetaTag]) -> Self {
+    meta.append(contentsOf: newValues)
+    return self
   }
 }
 

--- a/Sources/TokamakStaticHTML/Views/Head/Meta.swift
+++ b/Sources/TokamakStaticHTML/Views/Head/Meta.swift
@@ -18,67 +18,66 @@
 import TokamakCore
 
 public struct HTMLMeta: View {
-    public enum MetaTag: Equatable, Hashable {
-        case charset(_ charset: String)
-        case name(_ name: String, content: String)
-        case property(_ property: String, content: String)
-        case httpEquiv(_ httpEquiv: String, content: String)
-    }
+  public enum MetaTag: Equatable, Hashable {
+    case charset(_ charset: String)
+    case name(_ name: String, content: String)
+    case property(_ property: String, content: String)
+    case httpEquiv(_ httpEquiv: String, content: String)
+  }
 
-    var meta: MetaTag
+  var meta: MetaTag
 
-    public init(_ value: MetaTag) {
-        meta = value
-    }
+  public init(_ value: MetaTag) {
+    meta = value
+  }
 
-    public init(charset: String) {
-        meta = .charset(charset)
-    }
+  public init(charset: String) {
+    meta = .charset(charset)
+  }
 
-    public init(name: String, content: String) {
-        meta = .name(name, content: content)
-    }
+  public init(name: String, content: String) {
+    meta = .name(name, content: content)
+  }
 
-    public init(property: String, content: String) {
-        meta = .property(property, content: content)
-    }
+  public init(property: String, content: String) {
+    meta = .property(property, content: content)
+  }
 
-    public init(httpEquiv: String, content: String) {
-        meta = .httpEquiv(httpEquiv, content: content)
-    }
+  public init(httpEquiv: String, content: String) {
+    meta = .httpEquiv(httpEquiv, content: content)
+  }
 
-    public var body: some View {
-        EmptyView()
-            .preference(key: HTMLMetaPreferenceKey.self, value: [meta])
-    }
+  public var body: some View {
+    EmptyView()
+      .preference(key: HTMLMetaPreferenceKey.self, value: [meta])
+  }
 }
 
-extension View {
+public extension View {
+  func htmlMeta(_ value: HTMLMeta.MetaTag) -> some View {
+    htmlMeta(.init(value))
+  }
 
-    public func htmlMeta(_ value: HTMLMeta.MetaTag) -> some View {
-        htmlMeta(.init(value))
-    }
+  func htmlMeta(charset: String) -> some View {
+    htmlMeta(.init(charset: charset))
+  }
 
-    public func htmlMeta(charset: String) -> some View {
-        htmlMeta(.init(charset: charset))
-    }
+  func htmlMeta(name: String, content: String) -> some View {
+    htmlMeta(.init(name: name, content: content))
+  }
 
-    public func htmlMeta(name: String, content: String) -> some View {
-        htmlMeta(.init(name: name, content: content))
-    }
+  func htmlMeta(property: String, content: String) -> some View {
+    htmlMeta(.init(property: property, content: content))
+  }
 
-    public func htmlMeta(property: String, content: String) -> some View {
-        htmlMeta(.init(property: property, content: content))
-    }
+  func htmlMeta(httpEquiv: String, content: String) -> some View {
+    htmlMeta(.init(httpEquiv: httpEquiv, content: content))
+  }
 
-    public func htmlMeta(httpEquiv: String, content: String) -> some View {
-        htmlMeta(.init(httpEquiv: httpEquiv, content: content))
+  func htmlMeta(_ meta: HTMLMeta) -> some View {
+    Group {
+      self
+      meta
     }
-
-    public func htmlMeta(_ meta: HTMLMeta) -> some View {
-        Group {
-            self
-            meta
-        }
-    }
+  }
 }

--- a/Sources/TokamakStaticHTML/Views/Head/Meta.swift
+++ b/Sources/TokamakStaticHTML/Views/Head/Meta.swift
@@ -17,9 +17,16 @@
 
 import TokamakCore
 
+enum _HTMLMeta: Equatable, Hashable {
+    case charset(_ charset: String)
+    case name(_ name: String, content: String)
+    case property(_ property: String, content: String)
+    case httpEquiv(_ httpEquiv: String, content: String)
+}
+
 public struct HTMLMeta: View {
 
-    internal var meta: HTMLMetaPreferenceKey.HTMLMeta
+    internal var meta: _HTMLMeta
 
     public init(charset: String) {
         meta = .charset(charset)

--- a/Sources/TokamakStaticHTML/Views/Head/Meta.swift
+++ b/Sources/TokamakStaticHTML/Views/Head/Meta.swift
@@ -17,7 +17,7 @@
 
 import TokamakCore
 
-public struct Meta: View {
+public struct HTMLMeta: View {
 
     internal var meta: HTMLMetaPreferenceKey.HTMLMeta
 
@@ -40,5 +40,31 @@ public struct Meta: View {
     public var body: some View {
         EmptyView()
             .preference(key: HTMLMetaPreferenceKey.self, value: [meta])
+    }
+}
+
+extension View {
+
+    public func htmlMeta(charset: String) -> some View {
+        htmlMeta(.init(charset: charset))
+    }
+
+    public func htmlMeta(name: String, content: String) -> some View {
+        htmlMeta(.init(name: name, content: content))
+    }
+
+    public func htmlMeta(property: String, content: String) -> some View {
+        htmlMeta(.init(property: property, content: content))
+    }
+
+    public func htmlMeta(httpEquiv: String, content: String) -> some View {
+        htmlMeta(.init(httpEquiv: httpEquiv, content: content))
+    }
+
+    public func htmlMeta(_ meta: HTMLMeta) -> some View {
+        Group {
+            self
+            meta
+        }
     }
 }

--- a/Sources/TokamakStaticHTML/Views/Head/Meta.swift
+++ b/Sources/TokamakStaticHTML/Views/Head/Meta.swift
@@ -1,0 +1,44 @@
+// Copyright 2022 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Andrew Barba on 5/20/22.
+//
+
+import TokamakCore
+
+public struct Meta: View {
+
+    internal var meta: HTMLMetaPreferenceKey.HTMLMeta
+
+    public init(charset: String) {
+        meta = .charset(charset)
+    }
+
+    public init(name: String, content: String) {
+        meta = .name(name, content: content)
+    }
+
+    public init(property: String, content: String) {
+        meta = .property(property, content: content)
+    }
+
+    public init(httpEquiv: String, content: String) {
+        meta = .httpEquiv(httpEquiv, content: content)
+    }
+
+    public var body: some View {
+        EmptyView()
+            .preference(key: HTMLMetaPreferenceKey.self, value: [meta])
+    }
+}

--- a/Sources/TokamakStaticHTML/Views/Head/Meta.swift
+++ b/Sources/TokamakStaticHTML/Views/Head/Meta.swift
@@ -17,16 +17,19 @@
 
 import TokamakCore
 
-enum _HTMLMeta: Equatable, Hashable {
-    case charset(_ charset: String)
-    case name(_ name: String, content: String)
-    case property(_ property: String, content: String)
-    case httpEquiv(_ httpEquiv: String, content: String)
-}
-
 public struct HTMLMeta: View {
+    public enum MetaTag: Equatable, Hashable {
+        case charset(_ charset: String)
+        case name(_ name: String, content: String)
+        case property(_ property: String, content: String)
+        case httpEquiv(_ httpEquiv: String, content: String)
+    }
 
-    var meta: _HTMLMeta
+    var meta: MetaTag
+
+    public init(_ value: MetaTag) {
+        meta = value
+    }
 
     public init(charset: String) {
         meta = .charset(charset)
@@ -51,6 +54,10 @@ public struct HTMLMeta: View {
 }
 
 extension View {
+
+    public func htmlMeta(_ value: HTMLMeta.MetaTag) -> some View {
+        htmlMeta(.init(value))
+    }
 
     public func htmlMeta(charset: String) -> some View {
         htmlMeta(.init(charset: charset))

--- a/Sources/TokamakStaticHTML/Views/Head/Meta.swift
+++ b/Sources/TokamakStaticHTML/Views/Head/Meta.swift
@@ -26,7 +26,7 @@ enum _HTMLMeta: Equatable, Hashable {
 
 public struct HTMLMeta: View {
 
-    internal var meta: _HTMLMeta
+    var meta: _HTMLMeta
 
     public init(charset: String) {
         meta = .charset(charset)

--- a/Sources/TokamakStaticHTML/Views/Head/Title.swift
+++ b/Sources/TokamakStaticHTML/Views/Head/Title.swift
@@ -1,0 +1,32 @@
+// Copyright 2022 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Andrew Barba on 5/20/22.
+//
+
+import TokamakCore
+
+public struct Title: View {
+
+    internal var title: String
+
+    public init(_ title: String) {
+        self.title = title
+    }
+
+    public var body: some View {
+        EmptyView()
+            .preference(key: HTMLTitlePreferenceKey.self, value: title)
+    }
+}

--- a/Sources/TokamakStaticHTML/Views/Head/Title.swift
+++ b/Sources/TokamakStaticHTML/Views/Head/Title.swift
@@ -18,29 +18,27 @@
 import TokamakCore
 
 public struct HTMLTitle: View {
+  var title: String
 
-    var title: String
+  public init(_ title: String) {
+    self.title = title
+  }
 
-    public init(_ title: String) {
-        self.title = title
-    }
-
-    public var body: some View {
-        EmptyView()
-            .preference(key: HTMLTitlePreferenceKey.self, value: title)
-    }
+  public var body: some View {
+    EmptyView()
+      .preference(key: HTMLTitlePreferenceKey.self, value: title)
+  }
 }
 
-extension View {
+public extension View {
+  func htmlTitle(_ title: String) -> some View {
+    htmlTitle(.init(title))
+  }
 
-    public func htmlTitle(_ title: String) -> some View {
-        htmlTitle(.init(title))
+  func htmlTitle(_ title: HTMLTitle) -> some View {
+    Group {
+      self
+      title
     }
-
-    public func htmlTitle(_ title: HTMLTitle) -> some View {
-        Group {
-            self
-            title
-        }
-    }
+  }
 }

--- a/Sources/TokamakStaticHTML/Views/Head/Title.swift
+++ b/Sources/TokamakStaticHTML/Views/Head/Title.swift
@@ -19,7 +19,7 @@ import TokamakCore
 
 public struct HTMLTitle: View {
 
-    internal var title: String
+    var title: String
 
     public init(_ title: String) {
         self.title = title

--- a/Sources/TokamakStaticHTML/Views/Head/Title.swift
+++ b/Sources/TokamakStaticHTML/Views/Head/Title.swift
@@ -17,7 +17,7 @@
 
 import TokamakCore
 
-public struct Title: View {
+public struct HTMLTitle: View {
 
     internal var title: String
 
@@ -28,5 +28,19 @@ public struct Title: View {
     public var body: some View {
         EmptyView()
             .preference(key: HTMLTitlePreferenceKey.self, value: title)
+    }
+}
+
+extension View {
+
+    public func htmlTitle(_ title: String) -> some View {
+        htmlTitle(.init(title))
+    }
+
+    public func htmlTitle(_ title: HTMLTitle) -> some View {
+        Group {
+            self
+            title
+        }
     }
 }

--- a/Tests/TokamakStaticHTMLTests/HTMLTests.swift
+++ b/Tests/TokamakStaticHTMLTests/HTMLTests.swift
@@ -40,18 +40,6 @@ final class HTMLTests: XCTestCase {
     }
   }
 
-  private struct DoubleTitleBody: View {
-    var body: some View {
-      VStack {
-        HTMLTitle("Title 1")
-        Text("Hello, World")
-        VStack {
-          HTMLTitle("Title 2")
-        }
-      }
-    }
-  }
-
   func testOptional() {
     let resultingHTML = StaticHTMLRenderer(OptionalBody(model: Model(color: Color.red)))
       .render(shouldSortAttributes: true)
@@ -105,12 +93,73 @@ final class HTMLTests: XCTestCase {
     assertSnapshot(matching: insecureHTML, as: .html)
   }
 
-  func testDoubleTitle() {
-    let resultingHTML = StaticHTMLRenderer(DoubleTitleBody())
-      .render(shouldSortAttributes: true)
+  func testTitle() {
+    let resultingHTML = StaticHTMLRenderer(
+      VStack {
+        HTMLTitle("Tokamak")
+        Text("Hello, world!")
+      }
+    ).render(shouldSortAttributes: true)
 
-    assert(resultingHTML.contains("<title>Title 2</title>") == true)
-    assert(resultingHTML.contains("<title>Title 1</title>") == false)
+    assert(resultingHTML.contains("<title>Tokamak</title>"))
+    assertSnapshot(matching: resultingHTML, as: .html)
+  }
+
+  func testDoubleTitle() {
+    let resultingHTML = StaticHTMLRenderer(
+      VStack {
+        HTMLTitle("Tokamak 1")
+        Text("Hello, world!")
+        VStack {
+          HTMLTitle("Tokamak 2")
+        }
+      }
+    ).render(shouldSortAttributes: true)
+
+    assert(resultingHTML.contains("<title>Tokamak 2</title>") == true)
+    assert(resultingHTML.contains("<title>Tokamak 1</title>") == false)
+    assertSnapshot(matching: resultingHTML, as: .html)
+  }
+
+  func testTitleModifier() {
+    let resultingHTML = StaticHTMLRenderer(
+      Text("Hello, world!")
+        .htmlTitle("Tokamak")
+    ).render(shouldSortAttributes: true)
+
+    assert(resultingHTML.contains("<title>Tokamak</title>"))
+    assertSnapshot(matching: resultingHTML, as: .html)
+  }
+
+  func testDoubleTitleModifier() {
+    let resultingHTML = StaticHTMLRenderer(
+      Text("Hello, world!")
+        .htmlTitle("Tokamak 1")
+        .htmlTitle("Tokamak 2")
+    ).render(shouldSortAttributes: true)
+
+    assert(resultingHTML.contains("<title>Tokamak 2</title>") == true)
+    assert(resultingHTML.contains("<title>Tokamak 1</title>") == false)
+    assertSnapshot(matching: resultingHTML, as: .html)
+  }
+
+  func testMetaCharset() {
+    let resultingHTML = StaticHTMLRenderer(
+      VStack {
+        HTMLMeta(charset: "utf-8")
+        Text("Hello, world!")
+      }
+    ).render(shouldSortAttributes: true)
+
+    assertSnapshot(matching: resultingHTML, as: .html)
+  }
+
+  func testMetaCharsetModifier() {
+    let resultingHTML = StaticHTMLRenderer(
+      Text("Hello, world!")
+        .htmlMeta(charset: "utf-8")
+    ).render(shouldSortAttributes: true)
+
     assertSnapshot(matching: resultingHTML, as: .html)
   }
 }

--- a/Tests/TokamakStaticHTMLTests/HTMLTests.swift
+++ b/Tests/TokamakStaticHTMLTests/HTMLTests.swift
@@ -162,6 +162,21 @@ final class HTMLTests: XCTestCase {
 
     assertSnapshot(matching: resultingHTML, as: .html)
   }
+
+  func testMetaAll() {
+    let resultingHTML = StaticHTMLRenderer(
+      VStack {
+        HTMLMeta(charset: "utf-8")
+        HTMLMeta(name: "description", content: "SwiftUI on the web")
+        HTMLMeta(property: "og:image", content: "https://image.png")
+        HTMLMeta(httpEquiv: "refresh", content: "60")
+        Text("Hello, world!")
+      }
+    ).render(shouldSortAttributes: true)
+
+    assert(resultingHTML.components(separatedBy: "<meta ").count == 5)
+    assertSnapshot(matching: resultingHTML, as: .html)
+  }
 }
 
 #endif

--- a/Tests/TokamakStaticHTMLTests/HTMLTests.swift
+++ b/Tests/TokamakStaticHTMLTests/HTMLTests.swift
@@ -179,10 +179,10 @@ final class HTMLTests: XCTestCase {
   }
 
   func testPreferencePropagation() {
-    var title0: String = ""
-    var title1: String = ""
-    var title2: String = ""
-    var title3: String = ""
+    var title0 = ""
+    var title1 = ""
+    var title2 = ""
+    var title3 = ""
 
     let resultingHTML = StaticHTMLRenderer(
       VStack {

--- a/Tests/TokamakStaticHTMLTests/HTMLTests.swift
+++ b/Tests/TokamakStaticHTMLTests/HTMLTests.swift
@@ -40,6 +40,18 @@ final class HTMLTests: XCTestCase {
     }
   }
 
+  private struct DoubleTitleBody: View {
+    var body: some View {
+      VStack {
+        HTMLTitle("Title 1")
+        Text("Hello, World")
+        VStack {
+          HTMLTitle("Title 2")
+        }
+      }
+    }
+  }
+
   func testOptional() {
     let resultingHTML = StaticHTMLRenderer(OptionalBody(model: Model(color: Color.red)))
       .render(shouldSortAttributes: true)
@@ -91,6 +103,15 @@ final class HTMLTests: XCTestCase {
       StaticHTMLRenderer(Text(text)._domTextSanitizer(Sanitizers.HTML.insecure))
         .render(shouldSortAttributes: true)
     assertSnapshot(matching: insecureHTML, as: .html)
+  }
+
+  func testDoubleTitle() {
+    let resultingHTML = StaticHTMLRenderer(DoubleTitleBody())
+      .render(shouldSortAttributes: true)
+
+    assert(resultingHTML.contains("<title>Title 2</title>") == true)
+    assert(resultingHTML.contains("<title>Title 1</title>") == false)
+    assertSnapshot(matching: resultingHTML, as: .html)
   }
 }
 

--- a/Tests/TokamakStaticHTMLTests/HTMLTests.swift
+++ b/Tests/TokamakStaticHTMLTests/HTMLTests.swift
@@ -18,7 +18,7 @@
 #if canImport(SnapshotTesting)
 
 import SnapshotTesting
-@testable import TokamakStaticHTML
+import TokamakStaticHTML
 import XCTest
 
 final class HTMLTests: XCTestCase {

--- a/Tests/TokamakStaticHTMLTests/HTMLTests.swift
+++ b/Tests/TokamakStaticHTMLTests/HTMLTests.swift
@@ -18,7 +18,7 @@
 #if canImport(SnapshotTesting)
 
 import SnapshotTesting
-import TokamakStaticHTML
+@testable import TokamakStaticHTML
 import XCTest
 
 final class HTMLTests: XCTestCase {
@@ -175,6 +175,35 @@ final class HTMLTests: XCTestCase {
     ).render(shouldSortAttributes: true)
 
     assert(resultingHTML.components(separatedBy: "<meta ").count == 5)
+    assertSnapshot(matching: resultingHTML, as: .html)
+  }
+
+  func testPreferencePropagation() {
+    var title0: String = ""
+    var title1: String = ""
+    var title2: String = ""
+    var title3: String = ""
+
+    let resultingHTML = StaticHTMLRenderer(
+      VStack {
+        HTMLTitle("Tokamak 1")
+          .onPreferenceChange(HTMLTitlePreferenceKey.self) { title1 = $0 }
+        VStack {
+          HTMLTitle("Tokamak 2")
+        }
+        .onPreferenceChange(HTMLTitlePreferenceKey.self) { title2 = $0 }
+        VStack {
+          HTMLTitle("Tokamak 3")
+        }
+        .onPreferenceChange(HTMLTitlePreferenceKey.self) { title3 = $0 }
+      }
+      .onPreferenceChange(HTMLTitlePreferenceKey.self) { title0 = $0 }
+    ).render(shouldSortAttributes: true)
+
+    assert(title0 == "Tokamak 3")
+    assert(title1 == "Tokamak 1")
+    assert(title2 == "Tokamak 2")
+    assert(title3 == "Tokamak 3")
     assertSnapshot(matching: resultingHTML, as: .html)
   }
 }

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitle.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitle.1.html
@@ -1,0 +1,267 @@
+<html>
+<head>
+  <title>Title 2</title>
+  
+  <style>
+    ._tokamak-stack {
+  display: grid;
+}
+._tokamak-hstack {
+  grid-auto-flow: column;
+  column-gap: var(--tokamak-stack-gap, 8px);
+}
+._tokamak-vstack {
+  grid-auto-flow: row;
+  row-gap: var(--tokamak-stack-gap, 8px);
+}
+._tokamak-scrollview-hideindicators {
+  scrollbar-color: transparent;
+  scrollbar-width: 0;
+}
+._tokamak-scrollview-hideindicators::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+._tokamak-list {
+  list-style: none;
+  overflow-y: auto;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+}
+._tokamak-disclosuregroup-label {
+  cursor: pointer;
+}
+._tokamak-disclosuregroup-chevron-container {
+  width: .25em;
+  height: .25em;
+  padding: 10px;
+  display: inline-block;
+}
+._tokamak-disclosuregroup-chevron {
+  width: 100%;
+  height: 100%;
+  transform: rotate(45deg);
+  border-right: solid 2px rgba(0, 0, 0, 0.25);
+  border-top: solid 2px rgba(0, 0, 0, 0.25);
+}
+._tokamak-disclosuregroup-content {
+  display: flex;
+  flex-direction: column;
+  margin-left: 1em;
+}
+._tokamak-buttonstyle-reset {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: transparent;
+  border: none;
+  margin: 0;
+  padding: 0;
+  font-size: inherit;
+}
+@supports (-webkit-appearance: default-button) {
+  ._tokamak-button-prominence-increased {
+    -webkit-appearance: default-button;
+  }
+}
+@supports not (-webkit-appearance: default-button) {
+  ._tokamak-button-prominence-increased {
+    background-color: rgb(55, 120, 246);
+    border: 1px solid rgb(88, 156, 248);
+    border-radius: 4px;
+  }
+  ._tokamak-button-prominence-increased:active {
+    background-color: rgb(38, 99, 226);
+  }
+
+  @media (prefers-color-scheme:dark) {
+    ._tokamak-button-prominence-increased {
+      background-color: rgb(56, 116, 225);
+    }
+    ._tokamak-button-prominence-increased:active {
+      background-color: rgb(56, 134, 247);
+    }
+  }
+}
+
+._tokamak-text-redacted {
+  position: relative;
+}
+._tokamak-text-redacted::after {
+  content: " ";
+  background-color: rgb(200, 200, 200);
+  position: absolute;
+  left: 0;
+  width: calc(100% + .1em);
+  height: 1.2em;
+  border-radius: .1em;
+}
+._tokamak-geometryreader {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+._tokamak-navigationview {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  width: 100%;
+  height: 100%;
+}
+._tokamak-navigationview-with-toolbar-content ._tokamak-scrollview {
+  padding-top: 50px;
+}
+._tokamak-navigationview-destination {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  flex-grow: 1;
+  height: 100%;
+}
+
+._tokamak-toolbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  background: rgba(200, 200, 200, 0.2);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  backdrop-filter: saturate(180%) blur(20px);
+}
+
+._tokamak-toolbar-content {
+  flex: 1 1 auto;
+  display: flex;
+  height: 100%;
+}
+._tokamak-toolbar-leading > *, ._tokamak-toolbar-center > * {
+  margin-right: 8px;
+}
+._tokamak-toolbar-trailing > * {
+  margin-left: 8px;
+}
+._tokamak-toolbar-leading {
+  margin-right: auto;
+  align-items: center;
+  justify-content: flex-start;
+  padding-left: 16px;
+}
+._tokamak-toolbar-center {
+  align-items: center;
+  justify-content: center;
+}
+._tokamak-toolbar-trailing {
+  margin-left: auto;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 16px;
+}
+
+._tokamak-toolbar-button {
+  padding: 2px 4px;
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  height: 25px;
+  padding: 0 8px;
+  display: flex;
+  align-items: center;
+}
+._tokamak-toolbar-button:hover {
+  border-color: transparent;
+  background-color: rgba(0, 0, 0, 0.05);
+}
+._tokamak-toolbar-button:active {
+  border-color: transparent;
+  background-color: rgba(0, 0, 0, 0.1);
+}
+._tokamak-toolbar-textfield input {
+  padding: 4px 4px 4px 8px;
+  border-radius: 3px;
+  background-color: rgba(0, 0, 0, 0.05);
+  width: 100%;
+  height: 100%;
+}
+
+._tokamak-formcontrol, ._tokamak-formcontrol-reset {
+  color-scheme: light dark;
+}
+._tokamak-formcontrol-reset {
+  background: none;
+  border: none;
+}
+
+._tokamak-link {
+  text-decoration: none;
+}
+
+._tokamak-texteditor {
+  width: 100%;
+  height: 100%;
+}
+
+._tokamak-aspect-ratio-fill > img {
+  object-fit: fill;
+}
+
+._tokamak-aspect-ratio-fit > img {
+  object-fit: contain;
+}
+
+@media (prefers-color-scheme:dark) {
+  ._tokamak-text-redacted::after {
+    background-color: rgb(100, 100, 100);
+  }
+
+  ._tokamak-disclosuregroup-chevron {
+    border-right-color: rgba(255, 255, 255, 0.25);
+    border-top-color: rgba(255, 255, 255, 0.25);
+  }
+
+  ._tokamak-toolbar {
+    background: rgba(100, 100, 100, 0.2);
+  }
+  ._tokamak-toolbar-button {
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+  ._tokamak-toolbar-button:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+  }
+  ._tokamak-toolbar-button:active {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+  ._tokamak-toolbar-textfield input {
+    background-color: rgba(255, 255, 255, 0.05);
+    color: #FFFFFF;
+  }
+}
+  </style>
+</head>
+<body style="margin: 0;display: flex;
+width: 100%;
+height: 100%;
+justify-content: center;
+align-items: center;
+overflow: hidden;"><div class="_tokamak-stack _tokamak-vstack" style="justify-items: center;
+
+
+"><span style="font-family: system, -apple-system, '.SFNSText-Regular', 'San Francisco', 'Roboto', 'Segoe UI', 'Helvetica Neue', 'Lucida Grande', sans-serif; font-size: 17.0; font-style: normal; font-variant: normal; font-weight: 400; line-height: normal;
+
+color: rgba(0.0, 0.0, 0.0, 1.0);
+font-style: normal;
+font-weight: 400;
+letter-spacing: normal;
+vertical-align: baseline;
+text-decoration: none;
+text-decoration-color: inherit;
+text-align: left;">Hello, World</span>
+<div class="_tokamak-stack _tokamak-vstack" style="justify-items: center;
+
+
+"></div></div></body>
+</html>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitleModifier.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitleModifier.1.html
@@ -1,10 +1,7 @@
 <html>
 <head>
-  <title></title>
-  <meta charset="utf-8">
-  <meta name="description" content="SwiftUI on the web">
-  <meta property="og:image" content="https://image.png">
-  <meta http-equiv="refresh" content="60">
+  <title>Tokamak 2</title>
+  
   <style>
     ._tokamak-stack {
   display: grid;
@@ -250,10 +247,7 @@ width: 100%;
 height: 100%;
 justify-content: center;
 align-items: center;
-overflow: hidden;"><div class="_tokamak-stack _tokamak-vstack" style="justify-items: center;
-
-
-"><span style="font-family: system, -apple-system, '.SFNSText-Regular', 'San Francisco', 'Roboto', 'Segoe UI', 'Helvetica Neue', 'Lucida Grande', sans-serif; font-size: 17.0; font-style: normal; font-variant: normal; font-weight: 400; line-height: normal;
+overflow: hidden;"><span style="font-family: system, -apple-system, '.SFNSText-Regular', 'San Francisco', 'Roboto', 'Segoe UI', 'Helvetica Neue', 'Lucida Grande', sans-serif; font-size: 17.0; font-style: normal; font-variant: normal; font-weight: 400; line-height: normal;
 
 color: rgba(0.0, 0.0, 0.0, 1.0);
 font-style: normal;
@@ -262,5 +256,5 @@ letter-spacing: normal;
 vertical-align: baseline;
 text-decoration: none;
 text-decoration-color: inherit;
-text-align: left;">Hello, world!</span></div></body>
+text-align: left;">Hello, world!</span></body>
 </html>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaAll.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaAll.1.html
@@ -1,0 +1,263 @@
+<html>
+<head>
+  <title></title>
+  <meta http-equiv="refresh" content="60">
+  <style>
+    ._tokamak-stack {
+  display: grid;
+}
+._tokamak-hstack {
+  grid-auto-flow: column;
+  column-gap: var(--tokamak-stack-gap, 8px);
+}
+._tokamak-vstack {
+  grid-auto-flow: row;
+  row-gap: var(--tokamak-stack-gap, 8px);
+}
+._tokamak-scrollview-hideindicators {
+  scrollbar-color: transparent;
+  scrollbar-width: 0;
+}
+._tokamak-scrollview-hideindicators::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+._tokamak-list {
+  list-style: none;
+  overflow-y: auto;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+}
+._tokamak-disclosuregroup-label {
+  cursor: pointer;
+}
+._tokamak-disclosuregroup-chevron-container {
+  width: .25em;
+  height: .25em;
+  padding: 10px;
+  display: inline-block;
+}
+._tokamak-disclosuregroup-chevron {
+  width: 100%;
+  height: 100%;
+  transform: rotate(45deg);
+  border-right: solid 2px rgba(0, 0, 0, 0.25);
+  border-top: solid 2px rgba(0, 0, 0, 0.25);
+}
+._tokamak-disclosuregroup-content {
+  display: flex;
+  flex-direction: column;
+  margin-left: 1em;
+}
+._tokamak-buttonstyle-reset {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: transparent;
+  border: none;
+  margin: 0;
+  padding: 0;
+  font-size: inherit;
+}
+@supports (-webkit-appearance: default-button) {
+  ._tokamak-button-prominence-increased {
+    -webkit-appearance: default-button;
+  }
+}
+@supports not (-webkit-appearance: default-button) {
+  ._tokamak-button-prominence-increased {
+    background-color: rgb(55, 120, 246);
+    border: 1px solid rgb(88, 156, 248);
+    border-radius: 4px;
+  }
+  ._tokamak-button-prominence-increased:active {
+    background-color: rgb(38, 99, 226);
+  }
+
+  @media (prefers-color-scheme:dark) {
+    ._tokamak-button-prominence-increased {
+      background-color: rgb(56, 116, 225);
+    }
+    ._tokamak-button-prominence-increased:active {
+      background-color: rgb(56, 134, 247);
+    }
+  }
+}
+
+._tokamak-text-redacted {
+  position: relative;
+}
+._tokamak-text-redacted::after {
+  content: " ";
+  background-color: rgb(200, 200, 200);
+  position: absolute;
+  left: 0;
+  width: calc(100% + .1em);
+  height: 1.2em;
+  border-radius: .1em;
+}
+._tokamak-geometryreader {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+._tokamak-navigationview {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  width: 100%;
+  height: 100%;
+}
+._tokamak-navigationview-with-toolbar-content ._tokamak-scrollview {
+  padding-top: 50px;
+}
+._tokamak-navigationview-destination {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  flex-grow: 1;
+  height: 100%;
+}
+
+._tokamak-toolbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  background: rgba(200, 200, 200, 0.2);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  backdrop-filter: saturate(180%) blur(20px);
+}
+
+._tokamak-toolbar-content {
+  flex: 1 1 auto;
+  display: flex;
+  height: 100%;
+}
+._tokamak-toolbar-leading > *, ._tokamak-toolbar-center > * {
+  margin-right: 8px;
+}
+._tokamak-toolbar-trailing > * {
+  margin-left: 8px;
+}
+._tokamak-toolbar-leading {
+  margin-right: auto;
+  align-items: center;
+  justify-content: flex-start;
+  padding-left: 16px;
+}
+._tokamak-toolbar-center {
+  align-items: center;
+  justify-content: center;
+}
+._tokamak-toolbar-trailing {
+  margin-left: auto;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 16px;
+}
+
+._tokamak-toolbar-button {
+  padding: 2px 4px;
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  height: 25px;
+  padding: 0 8px;
+  display: flex;
+  align-items: center;
+}
+._tokamak-toolbar-button:hover {
+  border-color: transparent;
+  background-color: rgba(0, 0, 0, 0.05);
+}
+._tokamak-toolbar-button:active {
+  border-color: transparent;
+  background-color: rgba(0, 0, 0, 0.1);
+}
+._tokamak-toolbar-textfield input {
+  padding: 4px 4px 4px 8px;
+  border-radius: 3px;
+  background-color: rgba(0, 0, 0, 0.05);
+  width: 100%;
+  height: 100%;
+}
+
+._tokamak-formcontrol, ._tokamak-formcontrol-reset {
+  color-scheme: light dark;
+}
+._tokamak-formcontrol-reset {
+  background: none;
+  border: none;
+}
+
+._tokamak-link {
+  text-decoration: none;
+}
+
+._tokamak-texteditor {
+  width: 100%;
+  height: 100%;
+}
+
+._tokamak-aspect-ratio-fill > img {
+  object-fit: fill;
+}
+
+._tokamak-aspect-ratio-fit > img {
+  object-fit: contain;
+}
+
+@media (prefers-color-scheme:dark) {
+  ._tokamak-text-redacted::after {
+    background-color: rgb(100, 100, 100);
+  }
+
+  ._tokamak-disclosuregroup-chevron {
+    border-right-color: rgba(255, 255, 255, 0.25);
+    border-top-color: rgba(255, 255, 255, 0.25);
+  }
+
+  ._tokamak-toolbar {
+    background: rgba(100, 100, 100, 0.2);
+  }
+  ._tokamak-toolbar-button {
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+  ._tokamak-toolbar-button:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+  }
+  ._tokamak-toolbar-button:active {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+  ._tokamak-toolbar-textfield input {
+    background-color: rgba(255, 255, 255, 0.05);
+    color: #FFFFFF;
+  }
+}
+  </style>
+</head>
+<body style="margin: 0;display: flex;
+width: 100%;
+height: 100%;
+justify-content: center;
+align-items: center;
+overflow: hidden;"><div class="_tokamak-stack _tokamak-vstack" style="justify-items: center;
+
+
+"><span style="font-family: system, -apple-system, '.SFNSText-Regular', 'San Francisco', 'Roboto', 'Segoe UI', 'Helvetica Neue', 'Lucida Grande', sans-serif; font-size: 17.0; font-style: normal; font-variant: normal; font-weight: 400; line-height: normal;
+
+color: rgba(0.0, 0.0, 0.0, 1.0);
+font-style: normal;
+font-weight: 400;
+letter-spacing: normal;
+vertical-align: baseline;
+text-decoration: none;
+text-decoration-color: inherit;
+text-align: left;">Hello, world!</span></div></body>
+</html>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharset.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharset.1.html
@@ -1,7 +1,7 @@
 <html>
 <head>
-  <title>Tokamak 2</title>
-  
+  <title></title>
+  <meta charset="utf-8">
   <style>
     ._tokamak-stack {
   display: grid;
@@ -259,9 +259,5 @@ letter-spacing: normal;
 vertical-align: baseline;
 text-decoration: none;
 text-decoration-color: inherit;
-text-align: left;">Hello, world!</span>
-<div class="_tokamak-stack _tokamak-vstack" style="justify-items: center;
-
-
-"></div></div></body>
+text-align: left;">Hello, world!</span></div></body>
 </html>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharsetModifier.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharsetModifier.1.html
@@ -1,7 +1,7 @@
 <html>
 <head>
-  <title>Tokamak 2</title>
-  
+  <title></title>
+  <meta charset="utf-8">
   <style>
     ._tokamak-stack {
   display: grid;
@@ -247,10 +247,7 @@ width: 100%;
 height: 100%;
 justify-content: center;
 align-items: center;
-overflow: hidden;"><div class="_tokamak-stack _tokamak-vstack" style="justify-items: center;
-
-
-"><span style="font-family: system, -apple-system, '.SFNSText-Regular', 'San Francisco', 'Roboto', 'Segoe UI', 'Helvetica Neue', 'Lucida Grande', sans-serif; font-size: 17.0; font-style: normal; font-variant: normal; font-weight: 400; line-height: normal;
+overflow: hidden;"><span style="font-family: system, -apple-system, '.SFNSText-Regular', 'San Francisco', 'Roboto', 'Segoe UI', 'Helvetica Neue', 'Lucida Grande', sans-serif; font-size: 17.0; font-style: normal; font-variant: normal; font-weight: 400; line-height: normal;
 
 color: rgba(0.0, 0.0, 0.0, 1.0);
 font-style: normal;
@@ -259,9 +256,5 @@ letter-spacing: normal;
 vertical-align: baseline;
 text-decoration: none;
 text-decoration-color: inherit;
-text-align: left;">Hello, world!</span>
-<div class="_tokamak-stack _tokamak-vstack" style="justify-items: center;
-
-
-"></div></div></body>
+text-align: left;">Hello, world!</span></body>
 </html>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPreferencePropagation.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPreferencePropagation.1.html
@@ -1,0 +1,261 @@
+<html>
+<head>
+  <title>Tokamak 3</title>
+  
+  <style>
+    ._tokamak-stack {
+  display: grid;
+}
+._tokamak-hstack {
+  grid-auto-flow: column;
+  column-gap: var(--tokamak-stack-gap, 8px);
+}
+._tokamak-vstack {
+  grid-auto-flow: row;
+  row-gap: var(--tokamak-stack-gap, 8px);
+}
+._tokamak-scrollview-hideindicators {
+  scrollbar-color: transparent;
+  scrollbar-width: 0;
+}
+._tokamak-scrollview-hideindicators::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+._tokamak-list {
+  list-style: none;
+  overflow-y: auto;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+}
+._tokamak-disclosuregroup-label {
+  cursor: pointer;
+}
+._tokamak-disclosuregroup-chevron-container {
+  width: .25em;
+  height: .25em;
+  padding: 10px;
+  display: inline-block;
+}
+._tokamak-disclosuregroup-chevron {
+  width: 100%;
+  height: 100%;
+  transform: rotate(45deg);
+  border-right: solid 2px rgba(0, 0, 0, 0.25);
+  border-top: solid 2px rgba(0, 0, 0, 0.25);
+}
+._tokamak-disclosuregroup-content {
+  display: flex;
+  flex-direction: column;
+  margin-left: 1em;
+}
+._tokamak-buttonstyle-reset {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: transparent;
+  border: none;
+  margin: 0;
+  padding: 0;
+  font-size: inherit;
+}
+@supports (-webkit-appearance: default-button) {
+  ._tokamak-button-prominence-increased {
+    -webkit-appearance: default-button;
+  }
+}
+@supports not (-webkit-appearance: default-button) {
+  ._tokamak-button-prominence-increased {
+    background-color: rgb(55, 120, 246);
+    border: 1px solid rgb(88, 156, 248);
+    border-radius: 4px;
+  }
+  ._tokamak-button-prominence-increased:active {
+    background-color: rgb(38, 99, 226);
+  }
+
+  @media (prefers-color-scheme:dark) {
+    ._tokamak-button-prominence-increased {
+      background-color: rgb(56, 116, 225);
+    }
+    ._tokamak-button-prominence-increased:active {
+      background-color: rgb(56, 134, 247);
+    }
+  }
+}
+
+._tokamak-text-redacted {
+  position: relative;
+}
+._tokamak-text-redacted::after {
+  content: " ";
+  background-color: rgb(200, 200, 200);
+  position: absolute;
+  left: 0;
+  width: calc(100% + .1em);
+  height: 1.2em;
+  border-radius: .1em;
+}
+._tokamak-geometryreader {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+._tokamak-navigationview {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  width: 100%;
+  height: 100%;
+}
+._tokamak-navigationview-with-toolbar-content ._tokamak-scrollview {
+  padding-top: 50px;
+}
+._tokamak-navigationview-destination {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  flex-grow: 1;
+  height: 100%;
+}
+
+._tokamak-toolbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  background: rgba(200, 200, 200, 0.2);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  backdrop-filter: saturate(180%) blur(20px);
+}
+
+._tokamak-toolbar-content {
+  flex: 1 1 auto;
+  display: flex;
+  height: 100%;
+}
+._tokamak-toolbar-leading > *, ._tokamak-toolbar-center > * {
+  margin-right: 8px;
+}
+._tokamak-toolbar-trailing > * {
+  margin-left: 8px;
+}
+._tokamak-toolbar-leading {
+  margin-right: auto;
+  align-items: center;
+  justify-content: flex-start;
+  padding-left: 16px;
+}
+._tokamak-toolbar-center {
+  align-items: center;
+  justify-content: center;
+}
+._tokamak-toolbar-trailing {
+  margin-left: auto;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 16px;
+}
+
+._tokamak-toolbar-button {
+  padding: 2px 4px;
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  height: 25px;
+  padding: 0 8px;
+  display: flex;
+  align-items: center;
+}
+._tokamak-toolbar-button:hover {
+  border-color: transparent;
+  background-color: rgba(0, 0, 0, 0.05);
+}
+._tokamak-toolbar-button:active {
+  border-color: transparent;
+  background-color: rgba(0, 0, 0, 0.1);
+}
+._tokamak-toolbar-textfield input {
+  padding: 4px 4px 4px 8px;
+  border-radius: 3px;
+  background-color: rgba(0, 0, 0, 0.05);
+  width: 100%;
+  height: 100%;
+}
+
+._tokamak-formcontrol, ._tokamak-formcontrol-reset {
+  color-scheme: light dark;
+}
+._tokamak-formcontrol-reset {
+  background: none;
+  border: none;
+}
+
+._tokamak-link {
+  text-decoration: none;
+}
+
+._tokamak-texteditor {
+  width: 100%;
+  height: 100%;
+}
+
+._tokamak-aspect-ratio-fill > img {
+  object-fit: fill;
+}
+
+._tokamak-aspect-ratio-fit > img {
+  object-fit: contain;
+}
+
+@media (prefers-color-scheme:dark) {
+  ._tokamak-text-redacted::after {
+    background-color: rgb(100, 100, 100);
+  }
+
+  ._tokamak-disclosuregroup-chevron {
+    border-right-color: rgba(255, 255, 255, 0.25);
+    border-top-color: rgba(255, 255, 255, 0.25);
+  }
+
+  ._tokamak-toolbar {
+    background: rgba(100, 100, 100, 0.2);
+  }
+  ._tokamak-toolbar-button {
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+  ._tokamak-toolbar-button:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+  }
+  ._tokamak-toolbar-button:active {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+  ._tokamak-toolbar-textfield input {
+    background-color: rgba(255, 255, 255, 0.05);
+    color: #FFFFFF;
+  }
+}
+  </style>
+</head>
+<body style="margin: 0;display: flex;
+width: 100%;
+height: 100%;
+justify-content: center;
+align-items: center;
+overflow: hidden;"><div class="_tokamak-stack _tokamak-vstack" style="justify-items: center;
+
+
+"><div class="_tokamak-stack _tokamak-vstack" style="justify-items: center;
+
+
+"></div>
+<div class="_tokamak-stack _tokamak-vstack" style="justify-items: center;
+
+
+"></div></div></body>
+</html>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitle.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitle.1.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <title>Tokamak 2</title>
+  <title>Tokamak</title>
   
   <style>
     ._tokamak-stack {
@@ -259,9 +259,5 @@ letter-spacing: normal;
 vertical-align: baseline;
 text-decoration: none;
 text-decoration-color: inherit;
-text-align: left;">Hello, world!</span>
-<div class="_tokamak-stack _tokamak-vstack" style="justify-items: center;
-
-
-"></div></div></body>
+text-align: left;">Hello, world!</span></div></body>
 </html>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitleModifier.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitleModifier.1.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <title>Tokamak 2</title>
+  <title>Tokamak</title>
   
   <style>
     ._tokamak-stack {
@@ -247,10 +247,7 @@ width: 100%;
 height: 100%;
 justify-content: center;
 align-items: center;
-overflow: hidden;"><div class="_tokamak-stack _tokamak-vstack" style="justify-items: center;
-
-
-"><span style="font-family: system, -apple-system, '.SFNSText-Regular', 'San Francisco', 'Roboto', 'Segoe UI', 'Helvetica Neue', 'Lucida Grande', sans-serif; font-size: 17.0; font-style: normal; font-variant: normal; font-weight: 400; line-height: normal;
+overflow: hidden;"><span style="font-family: system, -apple-system, '.SFNSText-Regular', 'San Francisco', 'Roboto', 'Segoe UI', 'Helvetica Neue', 'Lucida Grande', sans-serif; font-size: 17.0; font-style: normal; font-variant: normal; font-weight: 400; line-height: normal;
 
 color: rgba(0.0, 0.0, 0.0, 1.0);
 font-style: normal;
@@ -259,9 +256,5 @@ letter-spacing: normal;
 vertical-align: baseline;
 text-decoration: none;
 text-decoration-color: inherit;
-text-align: left;">Hello, world!</span>
-<div class="_tokamak-stack _tokamak-vstack" style="justify-items: center;
-
-
-"></div></div></body>
+text-align: left;">Hello, world!</span></body>
 </html>


### PR DESCRIPTION
This PR adds the ability to control `<head>` tags using a new `HTMLTitle` view and `HTMLMeta` view. Taking inspiration from Next.js `<NextHead>`, you can use these views anywhere in your view hierarchy and they will be hoisted to the top `<head>` section of the html.

Use as a view:

```swift
var body: some View {
  VStack {
    ...
    HTMLTitle("Hello, Tokamak")
    HTMLMeta(charset: "utf-8")
    ...
  }
}
```

Use as a view modifier:

```swift
var body: some View {
  VStack {
    ...
  }
  .htmlTitle("Hello, Tokamak")
  .htmlMeta(charset: "utf-8")
}
```

And the resulting html (no matter where these are used in your view hierarchy):

```html
<html>
  <head>
    <title>Hello, Tokamak</title>
    <meta charset="utf-8">
  </head>
  <body>
    ...
  </body>
</html>
```