### PR TITLE
Revert "Add html5 doctype to static renderer (#486)"

### DIFF
--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -90,8 +90,9 @@ public final class StaticHTMLRenderer: Renderer {
     """
     <html>
     <head>
-      <title>\(title)</title>
-      \(meta.map { $0.outerHTML() }.joined(separator: "\n  "))
+      <title>\(title)</title>\(
+        !meta.isEmpty ? "\n  " + meta.map { $0.outerHTML() }.joined(separator: "\n  ") : ""
+      )
       <style>
         \(tokamakStyles)
       </style>

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -88,7 +88,6 @@ public final class StaticHTMLRenderer: Renderer {
 
   public func render(shouldSortAttributes: Bool = false) -> String {
     """
-    <!DOCTYPE html>
     <html>
     <head>
       <title>\(title)</title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitle.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitle.1.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <title>Tokamak 2</title>
-  
   <style>
     ._tokamak-stack {
   display: grid;

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitle.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitle.1.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title>Tokamak 2</title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitleModifier.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitleModifier.1.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <title>Tokamak 2</title>
-  
   <style>
     ._tokamak-stack {
   display: grid;

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitleModifier.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitleModifier.1.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title>Tokamak 2</title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testFontStacks.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testFontStacks.1.html
@@ -1,8 +1,6 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title></title>
-  
   <style>
     ._tokamak-stack {
   display: grid;

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testFontStacks.2.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testFontStacks.2.html
@@ -1,8 +1,6 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title></title>
-  
   <style>
     ._tokamak-stack {
   display: grid;

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testHTMLSanitizer.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testHTMLSanitizer.1.html
@@ -1,8 +1,6 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title></title>
-  
   <style>
     ._tokamak-stack {
   display: grid;

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testHTMLSanitizer.2.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testHTMLSanitizer.2.html
@@ -1,8 +1,6 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title></title>
-  
   <style>
     ._tokamak-stack {
   display: grid;

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaAll.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaAll.1.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title></title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharset.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharset.1.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title></title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharsetModifier.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharsetModifier.1.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title></title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testOptional.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testOptional.1.html
@@ -1,8 +1,6 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title></title>
-  
   <style>
     ._tokamak-stack {
   display: grid;

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPaddingFusion.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPaddingFusion.1.html
@@ -1,8 +1,6 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title></title>
-  
   <style>
     ._tokamak-stack {
   display: grid;

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPaddingFusion.2.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPaddingFusion.2.html
@@ -1,8 +1,6 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title></title>
-  
   <style>
     ._tokamak-stack {
   display: grid;

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPreferencePropagation.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPreferencePropagation.1.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <title>Tokamak 3</title>
-  
   <style>
     ._tokamak-stack {
   display: grid;

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPreferencePropagation.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPreferencePropagation.1.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title>Tokamak 3</title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitle.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitle.1.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title>Tokamak</title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitle.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitle.1.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <title>Tokamak</title>
-  
   <style>
     ._tokamak-stack {
   display: grid;

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitleModifier.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitleModifier.1.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
 <head>
   <title>Tokamak</title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitleModifier.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitleModifier.1.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <title>Tokamak</title>
-  
   <style>
     ._tokamak-stack {
   display: grid;


### PR DESCRIPTION
This reverts commit 3081f5521a7bfc10e4b3087f5744887a1c7f4947 which causes failing layout snapshots we've recently turned back on in https://github.com/TokamakUI/Tokamak/pull/484.