### PR TITLE
Add HTML Doctype to Static Renderer

### DIFF
--- a/Sources/TokamakStaticHTML/Resources/TokamakStyles.swift
+++ b/Sources/TokamakStaticHTML/Resources/TokamakStyles.swift
@@ -15,6 +15,9 @@
 import TokamakCore
 
 public let tokamakStyles = """
+html {
+  height: 100%;
+}
 ._tokamak-stack {
   display: grid;
 }

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -88,6 +88,7 @@ public final class StaticHTMLRenderer: Renderer {
 
   public func render(shouldSortAttributes: Bool = false) -> String {
     """
+    <!DOCTYPE html>
     <html>
     <head>
       <title>\(title)</title>\(

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitle.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitle.1.html
@@ -3,7 +3,10 @@
 <head>
   <title>Tokamak 2</title>
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitle.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitle.1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title>Tokamak 2</title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitleModifier.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitleModifier.1.html
@@ -3,7 +3,10 @@
 <head>
   <title>Tokamak 2</title>
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitleModifier.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testDoubleTitleModifier.1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title>Tokamak 2</title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testFontStacks.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testFontStacks.1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title></title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testFontStacks.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testFontStacks.1.html
@@ -3,7 +3,10 @@
 <head>
   <title></title>
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testFontStacks.2.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testFontStacks.2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title></title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testFontStacks.2.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testFontStacks.2.html
@@ -3,7 +3,10 @@
 <head>
   <title></title>
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testHTMLSanitizer.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testHTMLSanitizer.1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title></title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testHTMLSanitizer.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testHTMLSanitizer.1.html
@@ -3,7 +3,10 @@
 <head>
   <title></title>
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testHTMLSanitizer.2.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testHTMLSanitizer.2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title></title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testHTMLSanitizer.2.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testHTMLSanitizer.2.html
@@ -3,7 +3,10 @@
 <head>
   <title></title>
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaAll.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaAll.1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title></title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaAll.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaAll.1.html
@@ -7,7 +7,10 @@
   <meta property="og:image" content="https://image.png">
   <meta http-equiv="refresh" content="60">
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharset.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharset.1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title></title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharset.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharset.1.html
@@ -4,7 +4,10 @@
   <title></title>
   <meta charset="utf-8">
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharsetModifier.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharsetModifier.1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title></title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharsetModifier.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testMetaCharsetModifier.1.html
@@ -4,7 +4,10 @@
   <title></title>
   <meta charset="utf-8">
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testOptional.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testOptional.1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title></title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testOptional.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testOptional.1.html
@@ -3,7 +3,10 @@
 <head>
   <title></title>
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPaddingFusion.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPaddingFusion.1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title></title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPaddingFusion.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPaddingFusion.1.html
@@ -3,7 +3,10 @@
 <head>
   <title></title>
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPaddingFusion.2.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPaddingFusion.2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title></title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPaddingFusion.2.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPaddingFusion.2.html
@@ -3,7 +3,10 @@
 <head>
   <title></title>
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPreferencePropagation.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPreferencePropagation.1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title>Tokamak 3</title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPreferencePropagation.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testPreferencePropagation.1.html
@@ -3,7 +3,10 @@
 <head>
   <title>Tokamak 3</title>
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitle.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitle.1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title>Tokamak</title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitle.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitle.1.html
@@ -3,7 +3,10 @@
 <head>
   <title>Tokamak</title>
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitleModifier.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitleModifier.1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title>Tokamak</title>

--- a/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitleModifier.1.html
+++ b/Tests/TokamakStaticHTMLTests/__Snapshots__/HTMLTests/testTitleModifier.1.html
@@ -3,7 +3,10 @@
 <head>
   <title>Tokamak</title>
   <style>
-    ._tokamak-stack {
+    html {
+  height: 100%;
+}
+._tokamak-stack {
   display: grid;
 }
 ._tokamak-hstack {


### PR DESCRIPTION
1. Adds `<!DOCTYPE html>` to static renderer
2. Attempts to fix layout tests by adding `html { height: 100%; }`.