### PR TITLE
Tweak formatting rules for attributes

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -8,5 +8,7 @@
 --maxwidth 100
 --wraparguments before-first
 --funcattributes prev-line
+--typeattributes prev-line
+--varattributes prev-line
 --disable andOperator
---swiftversion 5.4
+--swiftversion 5.6

--- a/Sources/TokamakCore/Animation/Animatable.swift
+++ b/Sources/TokamakCore/Animation/Animatable.swift
@@ -44,12 +44,16 @@ public extension Animatable where Self.AnimatableData == EmptyAnimatableData {
 public struct EmptyAnimatableData: VectorArithmetic {
   @inlinable
   public init() {}
+
   @inlinable
   public static var zero: Self { .init() }
+
   @inlinable
   public static func += (lhs: inout Self, rhs: Self) {}
+
   @inlinable
   public static func -= (lhs: inout Self, rhs: Self) {}
+
   @inlinable
   public static func + (lhs: Self, rhs: Self) -> Self {
     .zero
@@ -62,8 +66,10 @@ public struct EmptyAnimatableData: VectorArithmetic {
 
   @inlinable
   public mutating func scale(by rhs: Double) {}
+
   @inlinable
   public var magnitudeSquared: Double { .zero }
+
   public static func == (a: Self, b: Self) -> Bool { true }
 }
 

--- a/Sources/TokamakCore/Animation/Animatable.swift
+++ b/Sources/TokamakCore/Animation/Animatable.swift
@@ -40,10 +40,12 @@ public extension Animatable where Self.AnimatableData == EmptyAnimatableData {
   }
 }
 
-@frozen public struct EmptyAnimatableData: VectorArithmetic {
+@frozen
+public struct EmptyAnimatableData: VectorArithmetic {
   @inlinable
   public init() {}
-  @inlinable public static var zero: Self { .init() }
+  @inlinable
+  public static var zero: Self { .init() }
   @inlinable
   public static func += (lhs: inout Self, rhs: Self) {}
   @inlinable
@@ -60,11 +62,13 @@ public extension Animatable where Self.AnimatableData == EmptyAnimatableData {
 
   @inlinable
   public mutating func scale(by rhs: Double) {}
-  @inlinable public var magnitudeSquared: Double { .zero }
+  @inlinable
+  public var magnitudeSquared: Double { .zero }
   public static func == (a: Self, b: Self) -> Bool { true }
 }
 
-@frozen public struct AnimatablePair<First, Second>: VectorArithmetic
+@frozen
+public struct AnimatablePair<First, Second>: VectorArithmetic
   where First: VectorArithmetic, Second: VectorArithmetic
 {
   public var first: First
@@ -81,7 +85,8 @@ public extension Animatable where Self.AnimatableData == EmptyAnimatableData {
     set { (first, second) = newValue }
   }
 
-  @_transparent public static var zero: Self {
+  @_transparent
+  public static var zero: Self {
     @_transparent get {
       .init(First.zero, Second.zero)
     }
@@ -115,7 +120,8 @@ public extension Animatable where Self.AnimatableData == EmptyAnimatableData {
     second.scale(by: rhs)
   }
 
-  @_transparent public var magnitudeSquared: Double {
+  @_transparent
+  public var magnitudeSquared: Double {
     @_transparent get {
       first.magnitudeSquared + second.magnitudeSquared
     }

--- a/Sources/TokamakCore/Animation/Animation.swift
+++ b/Sources/TokamakCore/Animation/Animation.swift
@@ -156,6 +156,7 @@ public struct _AnimationModifier<Value>: ViewModifier, Equatable
     let content: Content
     let animation: Animation?
     let value: Value
+
     @State
     private var lastValue: Value?
 

--- a/Sources/TokamakCore/Animation/Animation.swift
+++ b/Sources/TokamakCore/Animation/Animation.swift
@@ -139,7 +139,8 @@ public struct _AnimationProxy {
   public func resolve() -> _AnimationBoxBase._Resolved { subject.box.resolve() }
 }
 
-@frozen public struct _AnimationModifier<Value>: ViewModifier, Equatable
+@frozen
+public struct _AnimationModifier<Value>: ViewModifier, Equatable
   where Value: Equatable
 {
   public var animation: Animation?
@@ -155,7 +156,8 @@ public struct _AnimationProxy {
     let content: Content
     let animation: Animation?
     let value: Value
-    @State private var lastValue: Value?
+    @State
+    private var lastValue: Value?
 
     var body: some View {
       content.transaction {
@@ -180,7 +182,8 @@ public struct _AnimationProxy {
   }
 }
 
-@frozen public struct _AnimationView<Content>: View
+@frozen
+public struct _AnimationView<Content>: View
   where Content: Equatable, Content: View
 {
   public var content: Content

--- a/Sources/TokamakCore/Animation/Transaction.swift
+++ b/Sources/TokamakCore/Animation/Transaction.swift
@@ -50,7 +50,8 @@ protocol _TransactionModifierProtocol {
   func modifyTransaction(_ transaction: inout Transaction)
 }
 
-@frozen public struct _TransactionModifier: ViewModifier {
+@frozen
+public struct _TransactionModifier: ViewModifier {
   public var transform: (inout Transaction) -> ()
 
   @inlinable
@@ -77,7 +78,8 @@ extension ModifiedContent: _TransactionModifierProtocol
   }
 }
 
-@frozen public struct _PushPopTransactionModifier<V>: ViewModifier where V: ViewModifier {
+@frozen
+public struct _PushPopTransactionModifier<V>: ViewModifier where V: ViewModifier {
   public var content: V
   public var base: _TransactionModifier
 

--- a/Sources/TokamakCore/Animation/VectorArithmetic.swift
+++ b/Sources/TokamakCore/Animation/VectorArithmetic.swift
@@ -25,6 +25,7 @@ public protocol VectorArithmetic: AdditiveArithmetic {
 extension Float: VectorArithmetic {
   @_transparent
   public mutating func scale(by rhs: Double) { self *= Float(rhs) }
+
   @_transparent
   public var magnitudeSquared: Double {
     @_transparent get { Double(self * self) }
@@ -34,6 +35,7 @@ extension Float: VectorArithmetic {
 extension Double: VectorArithmetic {
   @_transparent
   public mutating func scale(by rhs: Double) { self *= rhs }
+
   @_transparent
   public var magnitudeSquared: Double {
     @_transparent get { self * self }
@@ -43,6 +45,7 @@ extension Double: VectorArithmetic {
 extension CGFloat: VectorArithmetic {
   @_transparent
   public mutating func scale(by rhs: Double) { self *= CGFloat(rhs) }
+
   @_transparent
   public var magnitudeSquared: Double {
     @_transparent get { Double(self * self) }

--- a/Sources/TokamakCore/Animation/VectorArithmetic.swift
+++ b/Sources/TokamakCore/Animation/VectorArithmetic.swift
@@ -25,7 +25,8 @@ public protocol VectorArithmetic: AdditiveArithmetic {
 extension Float: VectorArithmetic {
   @_transparent
   public mutating func scale(by rhs: Double) { self *= Float(rhs) }
-  @_transparent public var magnitudeSquared: Double {
+  @_transparent
+  public var magnitudeSquared: Double {
     @_transparent get { Double(self * self) }
   }
 }
@@ -33,7 +34,8 @@ extension Float: VectorArithmetic {
 extension Double: VectorArithmetic {
   @_transparent
   public mutating func scale(by rhs: Double) { self *= rhs }
-  @_transparent public var magnitudeSquared: Double {
+  @_transparent
+  public var magnitudeSquared: Double {
     @_transparent get { self * self }
   }
 }
@@ -41,7 +43,8 @@ extension Double: VectorArithmetic {
 extension CGFloat: VectorArithmetic {
   @_transparent
   public mutating func scale(by rhs: Double) { self *= CGFloat(rhs) }
-  @_transparent public var magnitudeSquared: Double {
+  @_transparent
+  public var magnitudeSquared: Double {
     @_transparent get { Double(self * self) }
   }
 }

--- a/Sources/TokamakCore/Animation/_VectorMath.swift
+++ b/Sources/TokamakCore/Animation/_VectorMath.swift
@@ -20,7 +20,8 @@ import Foundation
 public protocol _VectorMath: Animatable {}
 
 public extension _VectorMath {
-  @inlinable var magnitude: Double {
+  @inlinable
+  var magnitude: Double {
     animatableData.magnitudeSquared.squareRoot()
   }
 

--- a/Sources/TokamakCore/App/AppStorage.swift
+++ b/Sources/TokamakCore/App/AppStorage.swift
@@ -17,9 +17,11 @@
 
 import OpenCombineShim
 
-@propertyWrapper public struct AppStorage<Value>: DynamicProperty {
+@propertyWrapper
+public struct AppStorage<Value>: DynamicProperty {
   let provider: _StorageProvider?
-  @Environment(\._defaultAppStorage) var defaultProvider: _StorageProvider?
+  @Environment(\._defaultAppStorage)
+  var defaultProvider: _StorageProvider?
   var unwrappedProvider: _StorageProvider {
     provider ?? defaultProvider!
   }

--- a/Sources/TokamakCore/App/AppStorage.swift
+++ b/Sources/TokamakCore/App/AppStorage.swift
@@ -20,8 +20,10 @@ import OpenCombineShim
 @propertyWrapper
 public struct AppStorage<Value>: DynamicProperty {
   let provider: _StorageProvider?
+
   @Environment(\._defaultAppStorage)
   var defaultProvider: _StorageProvider?
+
   var unwrappedProvider: _StorageProvider {
     provider ?? defaultProvider!
   }

--- a/Sources/TokamakCore/App/Scenes/SceneStorage.swift
+++ b/Sources/TokamakCore/App/Scenes/SceneStorage.swift
@@ -23,7 +23,8 @@ public enum _DefaultSceneStorageProvider {
   public static var `default`: _StorageProvider!
 }
 
-@propertyWrapper public struct SceneStorage<Value>: DynamicProperty {
+@propertyWrapper
+public struct SceneStorage<Value>: DynamicProperty {
   let key: String
   let defaultValue: Value
   let store: (_StorageProvider, String, Value) -> ()

--- a/Sources/TokamakCore/Environment/Environment.swift
+++ b/Sources/TokamakCore/Environment/Environment.swift
@@ -23,7 +23,8 @@ protocol EnvironmentReader {
   mutating func setContent(from values: EnvironmentValues)
 }
 
-@propertyWrapper public struct Environment<Value>: DynamicProperty {
+@propertyWrapper
+public struct Environment<Value>: DynamicProperty {
   enum Content {
     case keyPath(KeyPath<EnvironmentValues, Value>)
     case value(Value)

--- a/Sources/TokamakCore/Environment/EnvironmentObject.swift
+++ b/Sources/TokamakCore/Environment/EnvironmentObject.swift
@@ -17,10 +17,12 @@
 
 import OpenCombineShim
 
-@propertyWrapper public struct EnvironmentObject<ObjectType>: DynamicProperty
+@propertyWrapper
+public struct EnvironmentObject<ObjectType>: DynamicProperty
   where ObjectType: ObservableObject
 {
-  @dynamicMemberLookup public struct Wrapper {
+  @dynamicMemberLookup
+  public struct Wrapper {
     internal let root: ObjectType
     public subscript<Subject>(
       dynamicMember keyPath: ReferenceWritableKeyPath<ObjectType, Subject>

--- a/Sources/TokamakCore/Fiber/AlignmentID.swift
+++ b/Sources/TokamakCore/Fiber/AlignmentID.swift
@@ -49,7 +49,8 @@ public protocol AlignmentID {
 }
 
 /// An alignment position along the horizontal axis.
-@frozen public struct HorizontalAlignment: Equatable {
+@frozen
+public struct HorizontalAlignment: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.id == rhs.id
   }
@@ -87,7 +88,8 @@ extension HorizontalAlignment {
   }
 }
 
-@frozen public struct VerticalAlignment: Equatable {
+@frozen
+public struct VerticalAlignment: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.id == rhs.id
   }

--- a/Sources/TokamakCore/Fiber/Fiber.swift
+++ b/Sources/TokamakCore/Fiber/Fiber.swift
@@ -15,7 +15,8 @@
 //  Created by Carson Katri on 2/15/22.
 //
 
-@_spi(TokamakCore) public extension FiberReconciler {
+@_spi(TokamakCore)
+public extension FiberReconciler {
   /// A manager for a single `View`.
   ///
   /// There are always 2 `Fiber`s for every `View` in the tree,
@@ -42,7 +43,8 @@
     /// Stored as an IUO because we must use the `bindProperties` method
     /// to create the `View` with its dependencies setup,
     /// which requires all stored properties be set before using.
-    @_spi(TokamakCore) public var view: Any!
+    @_spi(TokamakCore)
+    public var view: Any!
     /// Outputs from evaluating `View._makeView`
     ///
     /// Stored as an IUO because creating `ViewOutputs` depends on
@@ -59,9 +61,11 @@
     /// The mounted element, if this is a Renderer primitive.
     var element: Renderer.ElementType?
     /// The first child node.
-    @_spi(TokamakCore) public var child: Fiber?
+    @_spi(TokamakCore)
+    public var child: Fiber?
     /// This node's right sibling.
-    @_spi(TokamakCore) public var sibling: Fiber?
+    @_spi(TokamakCore)
+    public var sibling: Fiber?
     /// An unowned reference to the parent node.
     ///
     /// Parent references are `unowned` (as opposed to `weak`)

--- a/Sources/TokamakCore/Fiber/FiberReconciler.swift
+++ b/Sources/TokamakCore/Fiber/FiberReconciler.swift
@@ -18,7 +18,8 @@
 /// A reconciler modeled after React's [Fiber reconciler](https://reactjs.org/docs/faq-internals.html#what-is-react-fiber)
 public final class FiberReconciler<Renderer: FiberRenderer> {
   /// The root node in the `Fiber` tree that represents the `View`s currently rendered on screen.
-  @_spi(TokamakCore) public var current: Fiber!
+  @_spi(TokamakCore)
+  public var current: Fiber!
   /// The alternate of `current`, or the work in progress tree root.
   ///
   /// We must keep a strong reference to both the current and alternate tree roots,

--- a/Sources/TokamakCore/Modifiers/AspectRatioLayout.swift
+++ b/Sources/TokamakCore/Modifiers/AspectRatioLayout.swift
@@ -14,7 +14,8 @@
 
 import Foundation
 
-@frozen public enum ContentMode: Hashable, CaseIterable {
+@frozen
+public enum ContentMode: Hashable, CaseIterable {
   case fit
   case fill
 }

--- a/Sources/TokamakCore/Modifiers/Effects/OffsetEffect.swift
+++ b/Sources/TokamakCore/Modifiers/Effects/OffsetEffect.swift
@@ -17,7 +17,8 @@
 
 import Foundation
 
-@frozen public struct _OffsetEffect: GeometryEffect, Equatable {
+@frozen
+public struct _OffsetEffect: GeometryEffect, Equatable {
   public var offset: CGSize
 
   @inlinable

--- a/Sources/TokamakCore/Modifiers/Effects/ScaleEffect.swift
+++ b/Sources/TokamakCore/Modifiers/Effects/ScaleEffect.swift
@@ -17,7 +17,8 @@
 
 import Foundation
 
-@frozen public struct _ScaleEffect: GeometryEffect, Equatable {
+@frozen
+public struct _ScaleEffect: GeometryEffect, Equatable {
   public var scale: CGSize
   public var anchor: UnitPoint
 

--- a/Sources/TokamakCore/Modifiers/ModifiedContent.swift
+++ b/Sources/TokamakCore/Modifiers/ModifiedContent.swift
@@ -20,7 +20,8 @@ protocol ModifiedContentProtocol {}
 
 /// A value with a modifier applied to it.
 public struct ModifiedContent<Content, Modifier>: ModifiedContentProtocol {
-  @Environment(\.self) public var environment
+  @Environment(\.self)
+  public var environment
   public typealias Body = Never
   public private(set) var content: Content
   public private(set) var modifier: Modifier

--- a/Sources/TokamakCore/Modifiers/ModifiedContent.swift
+++ b/Sources/TokamakCore/Modifiers/ModifiedContent.swift
@@ -22,6 +22,7 @@ protocol ModifiedContentProtocol {}
 public struct ModifiedContent<Content, Modifier>: ModifiedContentProtocol {
   @Environment(\.self)
   public var environment
+
   public typealias Body = Never
   public private(set) var content: Content
   public private(set) var modifier: Modifier

--- a/Sources/TokamakCore/Modifiers/StyleModifiers.swift
+++ b/Sources/TokamakCore/Modifiers/StyleModifiers.swift
@@ -77,7 +77,8 @@ public extension View {
   }
 }
 
-@frozen public struct _BackgroundShapeModifier<Style, Bounds>: ViewModifier, EnvironmentReader
+@frozen
+public struct _BackgroundShapeModifier<Style, Bounds>: ViewModifier, EnvironmentReader
   where Style: ShapeStyle, Bounds: Shape
 {
   public var environment: EnvironmentValues!

--- a/Sources/TokamakCore/Preferences/_PreferenceReadingView.swift
+++ b/Sources/TokamakCore/Preferences/_PreferenceReadingView.swift
@@ -20,7 +20,8 @@
 public struct _DelayedPreferenceView<Key, Content>: View, _PreferenceReadingViewProtocol
   where Key: PreferenceKey, Content: View
 {
-  @State private var resolvedValue: _PreferenceValue<Key> = _PreferenceValue(
+  @State
+  private var resolvedValue: _PreferenceValue<Key> = _PreferenceValue(
     valueList: [Key.defaultValue]
   )
   public let transform: (_PreferenceValue<Key>) -> Content

--- a/Sources/TokamakCore/PreviewProvider.swift
+++ b/Sources/TokamakCore/PreviewProvider.swift
@@ -18,7 +18,8 @@ import Foundation
 public protocol PreviewProvider {
   associatedtype Previews: View
 
-  @ViewBuilder static var previews: Previews { get }
+  @ViewBuilder
+  static var previews: Previews { get }
 }
 
 public struct PreviewDevice: RawRepresentable, ExpressibleByStringLiteral {

--- a/Sources/TokamakCore/Reflection/Layouts/StructTypeDescriptor.swift
+++ b/Sources/TokamakCore/Reflection/Layouts/StructTypeDescriptor.swift
@@ -20,7 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-typealias FieldTypeAccessor = @convention(c) (UnsafePointer<Int>) -> UnsafePointer<Int>
+typealias FieldTypeAccessor = @convention(c)
+  (UnsafePointer<Int>) -> UnsafePointer<Int>
 
 struct StructTypeDescriptor {
   let flags: Int32

--- a/Sources/TokamakCore/Shapes/ContainerRelativeShape.swift
+++ b/Sources/TokamakCore/Shapes/ContainerRelativeShape.swift
@@ -38,7 +38,8 @@ extension ContainerRelativeShape: InsettableShape {
   }
 
   @usableFromInline
-  @frozen internal struct _Inset: InsettableShape, DynamicProperty {
+  @frozen
+  internal struct _Inset: InsettableShape, DynamicProperty {
     @usableFromInline
     internal var amount: CGFloat
     @inlinable
@@ -76,7 +77,8 @@ private extension EnvironmentValues {
   }
 }
 
-@frozen public struct _ContainerShapeModifier<Shape>: ViewModifier where Shape: InsettableShape {
+@frozen
+public struct _ContainerShapeModifier<Shape>: ViewModifier where Shape: InsettableShape {
   public var shape: Shape
   @inlinable
   public init(shape: Shape) { self.shape = shape }

--- a/Sources/TokamakCore/Shapes/ModifiedShapes.swift
+++ b/Sources/TokamakCore/Shapes/ModifiedShapes.swift
@@ -20,6 +20,7 @@ import Foundation
 public struct _StrokedShape<S>: Shape, DynamicProperty where S: Shape {
   @Environment(\.self)
   public var environment
+
   public var shape: S
   public var style: StrokeStyle
 

--- a/Sources/TokamakCore/Shapes/ModifiedShapes.swift
+++ b/Sources/TokamakCore/Shapes/ModifiedShapes.swift
@@ -18,7 +18,8 @@
 import Foundation
 
 public struct _StrokedShape<S>: Shape, DynamicProperty where S: Shape {
-  @Environment(\.self) public var environment
+  @Environment(\.self)
+  public var environment
   public var shape: S
   public var style: StrokeStyle
 

--- a/Sources/TokamakCore/Shapes/Rectangle.swift
+++ b/Sources/TokamakCore/Shapes/Rectangle.swift
@@ -89,8 +89,10 @@ extension RoundedRectangle: InsettableShape {
 
   @usableFromInline
   struct _Inset: InsettableShape {
-    @usableFromInline var base: RoundedRectangle
-    @usableFromInline var amount: CGFloat
+    @usableFromInline
+    var base: RoundedRectangle
+    @usableFromInline
+    var amount: CGFloat
 
     @inlinable
     init(base: RoundedRectangle, amount: CGFloat) {

--- a/Sources/TokamakCore/Shapes/Rectangle.swift
+++ b/Sources/TokamakCore/Shapes/Rectangle.swift
@@ -91,6 +91,7 @@ extension RoundedRectangle: InsettableShape {
   struct _Inset: InsettableShape {
     @usableFromInline
     var base: RoundedRectangle
+
     @usableFromInline
     var amount: CGFloat
 

--- a/Sources/TokamakCore/Shapes/Shape.swift
+++ b/Sources/TokamakCore/Shapes/Shape.swift
@@ -57,8 +57,10 @@ public struct FillStyle: Equatable {
 public struct _ShapeView<Content, Style>: _PrimitiveView where Content: Shape, Style: ShapeStyle {
   @Environment(\.self)
   public var environment
+
   @Environment(\.foregroundColor)
   public var foregroundColor
+
   public var shape: Content
   public var style: Style
   public var fillStyle: FillStyle

--- a/Sources/TokamakCore/Shapes/Shape.swift
+++ b/Sources/TokamakCore/Shapes/Shape.swift
@@ -55,8 +55,10 @@ public struct FillStyle: Equatable {
 }
 
 public struct _ShapeView<Content, Style>: _PrimitiveView where Content: Shape, Style: ShapeStyle {
-  @Environment(\.self) public var environment
-  @Environment(\.foregroundColor) public var foregroundColor
+  @Environment(\.self)
+  public var environment
+  @Environment(\.foregroundColor)
+  public var foregroundColor
   public var shape: Content
   public var style: Style
   public var fillStyle: FillStyle

--- a/Sources/TokamakCore/Shapes/ShapeStyles/BackgroundStyle.swift
+++ b/Sources/TokamakCore/Shapes/ShapeStyles/BackgroundStyle.swift
@@ -56,7 +56,8 @@ public extension View {
   }
 }
 
-@frozen public struct _BackgroundStyleModifier<Style>: ViewModifier, EnvironmentModifier,
+@frozen
+public struct _BackgroundStyleModifier<Style>: ViewModifier, EnvironmentModifier,
   EnvironmentReader
   where Style: ShapeStyle
 {

--- a/Sources/TokamakCore/Shapes/ShapeStyles/ForegroundStyle.swift
+++ b/Sources/TokamakCore/Shapes/ShapeStyles/ForegroundStyle.swift
@@ -71,7 +71,8 @@ public extension View {
   }
 }
 
-@frozen public struct _ForegroundStyleModifier<
+@frozen
+public struct _ForegroundStyleModifier<
   Primary, Secondary, Tertiary
 >: ViewModifier, EnvironmentModifier
   where Primary: ShapeStyle, Secondary: ShapeStyle, Tertiary: ShapeStyle

--- a/Sources/TokamakCore/Shapes/ShapeStyles/Gradients/AngularGradient.swift
+++ b/Sources/TokamakCore/Shapes/ShapeStyles/Gradients/AngularGradient.swift
@@ -17,7 +17,8 @@
 
 import Foundation
 
-@frozen public struct AngularGradient: ShapeStyle, View {
+@frozen
+public struct AngularGradient: ShapeStyle, View {
   internal var gradient: Gradient
   internal var center: UnitPoint
   internal var startAngle: Angle

--- a/Sources/TokamakCore/Shapes/ShapeStyles/Gradients/EllipticalGradient.swift
+++ b/Sources/TokamakCore/Shapes/ShapeStyles/Gradients/EllipticalGradient.swift
@@ -17,7 +17,8 @@
 
 import Foundation
 
-@frozen public struct EllipticalGradient: ShapeStyle, View {
+@frozen
+public struct EllipticalGradient: ShapeStyle, View {
   internal var gradient: Gradient
   internal var center: UnitPoint
   internal var startRadiusFraction: CGFloat

--- a/Sources/TokamakCore/Shapes/ShapeStyles/Gradients/Gradient.swift
+++ b/Sources/TokamakCore/Shapes/ShapeStyles/Gradients/Gradient.swift
@@ -17,8 +17,10 @@
 
 import Foundation
 
-@frozen public struct Gradient: Equatable {
-  @frozen public struct Stop: Equatable {
+@frozen
+public struct Gradient: Equatable {
+  @frozen
+  public struct Stop: Equatable {
     public var color: Color
     public var location: CGFloat
 

--- a/Sources/TokamakCore/Shapes/ShapeStyles/Gradients/LinearGradient.swift
+++ b/Sources/TokamakCore/Shapes/ShapeStyles/Gradients/LinearGradient.swift
@@ -17,7 +17,8 @@
 
 import Foundation
 
-@frozen public struct LinearGradient: ShapeStyle, View {
+@frozen
+public struct LinearGradient: ShapeStyle, View {
   internal var gradient: Gradient
   internal var startPoint: UnitPoint
   internal var endPoint: UnitPoint

--- a/Sources/TokamakCore/Shapes/ShapeStyles/Gradients/RadialGradient.swift
+++ b/Sources/TokamakCore/Shapes/ShapeStyles/Gradients/RadialGradient.swift
@@ -17,7 +17,8 @@
 
 import Foundation
 
-@frozen public struct RadialGradient: ShapeStyle, View {
+@frozen
+public struct RadialGradient: ShapeStyle, View {
   internal var gradient: Gradient
   internal var center: UnitPoint
   internal var startRadius: CGFloat

--- a/Sources/TokamakCore/Shapes/ShapeStyles/HierarchicalShapeStyle.swift
+++ b/Sources/TokamakCore/Shapes/ShapeStyles/HierarchicalShapeStyle.swift
@@ -16,7 +16,8 @@
 //
 
 /// A `ShapeStyle` that provides the `primary`, `secondary`, `tertiary`, and `quaternary` styles.
-@frozen public struct HierarchicalShapeStyle: ShapeStyle {
+@frozen
+public struct HierarchicalShapeStyle: ShapeStyle {
   @usableFromInline
   internal var id: UInt32
 

--- a/Sources/TokamakCore/State/State.swift
+++ b/Sources/TokamakCore/State/State.swift
@@ -23,7 +23,8 @@ protocol WritableValueStorage: ValueStorage {
   var setter: ((Any, Transaction) -> ())? { get set }
 }
 
-@propertyWrapper public struct State<Value>: DynamicProperty {
+@propertyWrapper
+public struct State<Value>: DynamicProperty {
   private let initialValue: Value
 
   var anyInitialValue: Any { initialValue }

--- a/Sources/TokamakCore/Styles/ToggleStyle.swift
+++ b/Sources/TokamakCore/Styles/ToggleStyle.swift
@@ -25,7 +25,8 @@
 
 public struct ToggleStyleConfiguration {
   public let label: AnyView
-  @Binding public var isOn: Swift.Bool
+  @Binding
+  public var isOn: Swift.Bool
 }
 
 public protocol ToggleStyle {

--- a/Sources/TokamakCore/ViewTraits/TagValueTraitKey.swift
+++ b/Sources/TokamakCore/ViewTraits/TagValueTraitKey.swift
@@ -37,11 +37,13 @@ struct TagValueTraitKey<V>: _ViewTraitKey where V: Hashable {
     case tagged(V)
   }
 
-  @inlinable static var defaultValue: Value { .untagged }
+  @inlinable
+  static var defaultValue: Value { .untagged }
 }
 
 @usableFromInline
 struct IsAuxiliaryContentTraitKey: _ViewTraitKey {
-  @inlinable static var defaultValue: Bool { false }
+  @inlinable
+  static var defaultValue: Bool { false }
   @usableFromInline typealias Value = Bool
 }

--- a/Sources/TokamakCore/ViewTraits/Transition/Transition.swift
+++ b/Sources/TokamakCore/ViewTraits/Transition/Transition.swift
@@ -17,7 +17,8 @@
 
 import Foundation
 
-@frozen public struct AnyTransition {
+@frozen
+public struct AnyTransition {
   fileprivate let box: _AnyTransitionBox
 
   private init(_ box: _AnyTransitionBox) {
@@ -27,14 +28,16 @@ import Foundation
 
 @usableFromInline
 struct TransitionTraitKey: _ViewTraitKey {
-  @inlinable static var defaultValue: AnyTransition { .opacity }
+  @inlinable
+  static var defaultValue: AnyTransition { .opacity }
 
   @usableFromInline typealias Value = AnyTransition
 }
 
 @usableFromInline
 struct CanTransitionTraitKey: _ViewTraitKey {
-  @inlinable static var defaultValue: Bool { false }
+  @inlinable
+  static var defaultValue: Bool { false }
 
   @usableFromInline typealias Value = Bool
 }

--- a/Sources/TokamakCore/ViewTraits/_ViewTraitKey.swift
+++ b/Sources/TokamakCore/ViewTraits/_ViewTraitKey.swift
@@ -24,7 +24,8 @@ public protocol _TraitWritingModifierProtocol {
   func modifyViewTraitStore(_ viewTraitStore: inout _ViewTraitStore)
 }
 
-@frozen public struct _TraitWritingModifier<Trait>: ViewModifier, _TraitWritingModifierProtocol
+@frozen
+public struct _TraitWritingModifier<Trait>: ViewModifier, _TraitWritingModifierProtocol
   where Trait: _ViewTraitKey
 {
   public let value: Trait.Value

--- a/Sources/TokamakCore/Views/Canvas/Canvas.swift
+++ b/Sources/TokamakCore/Views/Canvas/Canvas.swift
@@ -26,6 +26,7 @@ public struct Canvas<Symbols> where Symbols: View {
 
   @Environment(\.self)
   public var _environment: EnvironmentValues
+
   public func _makeContext(
     onOperation: @escaping (GraphicsContext._Storage, GraphicsContext._Storage._Operation) -> (),
     imageResolver: @escaping (Image, EnvironmentValues) -> GraphicsContext.ResolvedImage,

--- a/Sources/TokamakCore/Views/Canvas/Canvas.swift
+++ b/Sources/TokamakCore/Views/Canvas/Canvas.swift
@@ -24,7 +24,8 @@ public struct Canvas<Symbols> where Symbols: View {
   public var colorMode: ColorRenderingMode
   public var rendersAsynchronously: Bool
 
-  @Environment(\.self) public var _environment: EnvironmentValues
+  @Environment(\.self)
+  public var _environment: EnvironmentValues
   public func _makeContext(
     onOperation: @escaping (GraphicsContext._Storage, GraphicsContext._Storage._Operation) -> (),
     imageResolver: @escaping (Image, EnvironmentValues) -> GraphicsContext.ResolvedImage,

--- a/Sources/TokamakCore/Views/Canvas/GraphicsContext/Filter.swift
+++ b/Sources/TokamakCore/Views/Canvas/GraphicsContext/Filter.swift
@@ -129,29 +129,49 @@ public extension GraphicsContext {
     }
   }
 
-  @frozen struct ShadowOptions: OptionSet {
+  @frozen
+  struct ShadowOptions: OptionSet {
     public let rawValue: UInt32
+
     @inlinable
     public init(rawValue: UInt32) { self.rawValue = rawValue }
-    @inlinable public static var shadowAbove: Self { Self(rawValue: 1 << 0) }
-    @inlinable public static var shadowOnly: Self { Self(rawValue: 1 << 1) }
-    @inlinable public static var invertsAlpha: Self { Self(rawValue: 1 << 2) }
-    @inlinable public static var disablesGroup: Self { Self(rawValue: 1 << 3) }
+
+    @inlinable
+    public static var shadowAbove: Self { Self(rawValue: 1 << 0) }
+
+    @inlinable
+    public static var shadowOnly: Self { Self(rawValue: 1 << 1) }
+
+    @inlinable
+    public static var invertsAlpha: Self { Self(rawValue: 1 << 2) }
+
+    @inlinable
+    public static var disablesGroup: Self { Self(rawValue: 1 << 3) }
   }
 
-  @frozen struct BlurOptions: OptionSet {
+  @frozen
+  struct BlurOptions: OptionSet {
     public let rawValue: UInt32
+
     @inlinable
     public init(rawValue: UInt32) { self.rawValue = rawValue }
-    @inlinable public static var opaque: Self { Self(rawValue: 1 << 0) }
-    @inlinable public static var dithersResult: Self { Self(rawValue: 1 << 1) }
+
+    @inlinable
+    public static var opaque: Self { Self(rawValue: 1 << 0) }
+
+    @inlinable
+    public static var dithersResult: Self { Self(rawValue: 1 << 1) }
   }
 
-  @frozen struct FilterOptions: OptionSet {
+  @frozen
+  struct FilterOptions: OptionSet {
     public let rawValue: UInt32
+
     @inlinable
     public init(rawValue: UInt32) { self.rawValue = rawValue }
-    @inlinable public static var linearColor: Self { Self(rawValue: 1 << 0) }
+
+    @inlinable
+    public static var linearColor: Self { Self(rawValue: 1 << 0) }
   }
 
   mutating func addFilter(

--- a/Sources/TokamakCore/Views/Canvas/GraphicsContext/GraphicsContext.swift
+++ b/Sources/TokamakCore/Views/Canvas/GraphicsContext/GraphicsContext.swift
@@ -113,11 +113,15 @@ public struct GraphicsContext {
     addFilter(.projectionTransform(.init(matrix)))
   }
 
-  @frozen public struct ClipOptions: OptionSet {
+  @frozen
+  public struct ClipOptions: OptionSet {
     public let rawValue: UInt32
+
     @inlinable
     public init(rawValue: UInt32) { self.rawValue = rawValue }
-    @inlinable public static var inverse: Self { Self(rawValue: 1 << 0) }
+
+    @inlinable
+    public static var inverse: Self { Self(rawValue: 1 << 0) }
   }
 
   public var clipBoundingRect: CGRect {

--- a/Sources/TokamakCore/Views/Canvas/GraphicsContext/Shading.swift
+++ b/Sources/TokamakCore/Views/Canvas/GraphicsContext/Shading.swift
@@ -175,13 +175,21 @@ public extension GraphicsContext {
     }
   }
 
-  @frozen struct GradientOptions: OptionSet {
+  @frozen
+  struct GradientOptions: OptionSet {
     public let rawValue: UInt32
+
     @inlinable
     public init(rawValue: UInt32) { self.rawValue = rawValue }
-    @inlinable public static var `repeat`: Self { Self(rawValue: 1 << 0) }
-    @inlinable public static var mirror: Self { Self(rawValue: 1 << 1) }
-    @inlinable public static var linearColor: Self { Self(rawValue: 1 << 2) }
+
+    @inlinable
+    public static var `repeat`: Self { Self(rawValue: 1 << 0) }
+
+    @inlinable
+    public static var mirror: Self { Self(rawValue: 1 << 1) }
+
+    @inlinable
+    public static var linearColor: Self { Self(rawValue: 1 << 2) }
   }
 
   func resolve(_ shading: Shading) -> Shading {

--- a/Sources/TokamakCore/Views/Canvas/TimelineView.swift
+++ b/Sources/TokamakCore/Views/Canvas/TimelineView.swift
@@ -81,7 +81,8 @@ public extension TimelineSchedule where Self == PeriodicTimelineSchedule {
 }
 
 public extension TimelineSchedule where Self == EveryMinuteTimelineSchedule {
-  @inlinable static var everyMinute: EveryMinuteTimelineSchedule { .init() }
+  @inlinable
+  static var everyMinute: EveryMinuteTimelineSchedule { .init() }
 }
 
 public extension TimelineSchedule {
@@ -155,7 +156,8 @@ public struct ExplicitTimelineSchedule<Entries>: TimelineSchedule where Entries:
 }
 
 public extension TimelineSchedule where Self == AnimationTimelineSchedule {
-  @inlinable static var animation: AnimationTimelineSchedule { .init() }
+  @inlinable
+  static var animation: AnimationTimelineSchedule { .init() }
   @inlinable
   static func animation(
     minimumInterval: Double? = nil,

--- a/Sources/TokamakCore/Views/Containers/DisclosureGroup.swift
+++ b/Sources/TokamakCore/Views/Containers/DisclosureGroup.swift
@@ -16,10 +16,12 @@
 //
 
 public struct DisclosureGroup<Label, Content>: _PrimitiveView where Label: View, Content: View {
-  @State var isExpanded: Bool = false
+  @State
+  var isExpanded: Bool = false
   let isExpandedBinding: Binding<Bool>?
 
-  @Environment(\._outlineGroupStyle) var style
+  @Environment(\._outlineGroupStyle)
+  var style
 
   let label: Label
   let content: () -> Content

--- a/Sources/TokamakCore/Views/Containers/List/List.swift
+++ b/Sources/TokamakCore/Views/Containers/List/List.swift
@@ -26,7 +26,8 @@ public struct List<SelectionValue, Content>: View
   let selection: _Selection
   let content: Content
 
-  @Environment(\.listStyle) var style
+  @Environment(\.listStyle)
+  var style
 
   public init(selection: Binding<Set<SelectionValue>>?, @ViewBuilder content: () -> Content) {
     self.selection = .many(selection)

--- a/Sources/TokamakCore/Views/Controls/Button.swift
+++ b/Sources/TokamakCore/Views/Controls/Button.swift
@@ -40,7 +40,8 @@ public struct Button<Label>: View where Label: View {
   let action: () -> ()
   let role: ButtonRole?
 
-  @Environment(\.buttonStyle) var buttonStyle
+  @Environment(\.buttonStyle)
+  var buttonStyle
 
   public init(action: @escaping () -> (), @ViewBuilder label: () -> Label) {
     self.init(role: nil, action: action, label: label)
@@ -84,7 +85,8 @@ public struct _PrimitiveButtonStyleBody<Label>: View where Label: View {
     anyStyle = .init(style)
   }
 
-  @Environment(\.controlSize) public var controlSize
+  @Environment(\.controlSize)
+  public var controlSize
 
   public var body: Never {
     neverBody("_PrimitiveButtonStyleBody")
@@ -99,7 +101,9 @@ public struct _Button<Label>: View where Label: View {
   public let label: Label
   public let role: ButtonRole?
   public let action: () -> ()
-  @State public var isPressed = false
+
+  @State
+  public var isPressed = false
 
   let anyStyle: AnyButtonStyle
   public var style: Any.Type { anyStyle.type }

--- a/Sources/TokamakCore/Views/Controls/ControlGroup.swift
+++ b/Sources/TokamakCore/Views/Controls/ControlGroup.swift
@@ -17,7 +17,9 @@
 
 public struct ControlGroup<Content>: View where Content: View {
   let content: Content
-  @Environment(\.controlGroupStyle) var style
+
+  @Environment(\.controlGroupStyle)
+  var style
 
   public init(@ViewBuilder content: () -> Content) {
     self.content = content()

--- a/Sources/TokamakCore/Views/Controls/Selectors/Picker.swift
+++ b/Sources/TokamakCore/Views/Controls/Selectors/Picker.swift
@@ -49,6 +49,7 @@ public struct _PickerContainer<
 public struct _PickerElement: _PrimitiveView {
   public let valueIndex: Int?
   public let content: AnyView
+
   @Environment(\.pickerStyle)
   public var style
 }

--- a/Sources/TokamakCore/Views/Controls/Selectors/Picker.swift
+++ b/Sources/TokamakCore/Views/Controls/Selectors/Picker.swift
@@ -23,11 +23,15 @@ public struct _PickerContainer<
 >: _PrimitiveView,
   _PickerContainerProtocol
 {
-  @Binding public var selection: SelectionValue
+  @Binding
+  public var selection: SelectionValue
+
   public let label: Label
   public let content: Content
   public let elements: [_AnyIDView]
-  @Environment(\.pickerStyle) public var style
+
+  @Environment(\.pickerStyle)
+  public var style
 
   public init(
     selection: Binding<SelectionValue>,
@@ -45,7 +49,8 @@ public struct _PickerContainer<
 public struct _PickerElement: _PrimitiveView {
   public let valueIndex: Int?
   public let content: AnyView
-  @Environment(\.pickerStyle) public var style
+  @Environment(\.pickerStyle)
+  public var style
 }
 
 public struct Picker<Label: View, SelectionValue: Hashable, Content: View>: View {

--- a/Sources/TokamakCore/Views/Controls/Selectors/Toggle.swift
+++ b/Sources/TokamakCore/Views/Controls/Selectors/Toggle.swift
@@ -16,9 +16,13 @@
 //
 
 public struct Toggle<Label>: View where Label: View {
-  @Binding var isOn: Bool
+  @Binding
+  var isOn: Bool
+
   var label: Label
-  @Environment(\.toggleStyle) var toggleStyle
+
+  @Environment(\.toggleStyle)
+  var toggleStyle
 
   public init(isOn: Binding<Bool>, label: () -> Label) {
     _isOn = isOn

--- a/Sources/TokamakCore/Views/Image.swift
+++ b/Sources/TokamakCore/Views/Image.swift
@@ -102,7 +102,9 @@ private class ResizableProvider: _AnyImageProviderBox {
 
 public struct Image: _PrimitiveView, Equatable {
   let provider: _AnyImageProviderBox
-  @Environment(\.self) var environment
+
+  @Environment(\.self)
+  var environment
 
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.provider == rhs.provider

--- a/Sources/TokamakCore/Views/Navigation/NavigationLink.swift
+++ b/Sources/TokamakCore/Views/Navigation/NavigationLink.swift
@@ -25,11 +25,16 @@ final class NavigationLinkDestination {
 public struct NavigationLink<Label, Destination>: _PrimitiveView where Label: View,
   Destination: View
 {
-  @State var destination: NavigationLinkDestination
+  @State
+  var destination: NavigationLinkDestination
+
   let label: Label
 
-  @EnvironmentObject var navigationContext: NavigationContext
-  @Environment(\._navigationLinkStyle) var style
+  @EnvironmentObject
+  var navigationContext: NavigationContext
+
+  @Environment(\._navigationLinkStyle)
+  var style
 
   public init(destination: Destination, @ViewBuilder label: () -> Label) {
     _destination = State(wrappedValue: NavigationLinkDestination(destination))

--- a/Sources/TokamakCore/Views/Navigation/NavigationView.swift
+++ b/Sources/TokamakCore/Views/Navigation/NavigationView.swift
@@ -16,13 +16,15 @@
 //
 
 public final class NavigationContext: ObservableObject {
-  @Published var destination = NavigationLinkDestination(EmptyView())
+  @Published
+  var destination = NavigationLinkDestination(EmptyView())
 }
 
 public struct NavigationView<Content>: _PrimitiveView where Content: View {
   let content: Content
 
-  @StateObject var context = NavigationContext()
+  @StateObject
+  var context = NavigationContext()
 
   public init(@ViewBuilder content: () -> Content) {
     self.content = content()

--- a/Sources/TokamakCore/Views/Progress/ProgressView.swift
+++ b/Sources/TokamakCore/Views/Progress/ProgressView.swift
@@ -42,7 +42,8 @@ public struct _CustomProgressView<Label, CurrentValueLabel>: View
   var label: Label?
   var currentValueLabel: CurrentValueLabel?
 
-  @Environment(\.progressViewStyle) var style
+  @Environment(\.progressViewStyle)
+  var style
 
   init(
     fractionCompleted: Double?,
@@ -74,7 +75,9 @@ public struct _FoundationProgressView: View {
 #else
 public struct _FoundationProgressView: View {
   let progress: Progress
-  @State private var state: ProgressState?
+
+  @State
+  private var state: ProgressState?
 
   struct ProgressState {
     var progress: Double

--- a/Sources/TokamakCore/Views/Spacers/Divider.swift
+++ b/Sources/TokamakCore/Views/Spacers/Divider.swift
@@ -17,7 +17,8 @@
 
 /// A horizontal line for separating content.
 public struct Divider: _PrimitiveView {
-  @Environment(\.self) public var environment
+  @Environment(\.self)
+  public var environment
 
   public init() {}
 }

--- a/Sources/TokamakCore/Views/Text/Text.swift
+++ b/Sources/TokamakCore/Views/Text/Text.swift
@@ -35,7 +35,8 @@ public struct Text: _PrimitiveView, Equatable {
   let storage: _Storage
   let modifiers: [_Modifier]
 
-  @Environment(\.self) var environment
+  @Environment(\.self)
+  var environment
 
   public static func == (lhs: Text, rhs: Text) -> Bool {
     lhs.storage == rhs.storage

--- a/Sources/TokamakCore/Views/Text/TextField.swift
+++ b/Sources/TokamakCore/Views/Text/TextField.swift
@@ -39,7 +39,9 @@ public struct TextField<Label>: _PrimitiveView where Label: View {
   let textBinding: Binding<String>
   let onEditingChanged: (Bool) -> ()
   let onCommit: () -> ()
-  @Environment(\.self) var environment
+
+  @Environment(\.self)
+  var environment
 }
 
 public extension TextField where Label == Text {

--- a/Sources/TokamakCore/Views/View.swift
+++ b/Sources/TokamakCore/Views/View.swift
@@ -18,7 +18,8 @@
 public protocol View {
   associatedtype Body: View
 
-  @ViewBuilder var body: Self.Body { get }
+  @ViewBuilder
+  var body: Self.Body { get }
 
   func _visitChildren<V: ViewVisitor>(_ visitor: V)
   static func _makeView(_ inputs: ViewInputs<Self>) -> ViewOutputs

--- a/Sources/TokamakCoreBenchmark/main.swift
+++ b/Sources/TokamakCoreBenchmark/main.swift
@@ -27,7 +27,8 @@ benchmark("typeConstructorName TokamakCore") {
 }
 
 struct UpdateWide: View {
-  @State var update = -1
+  @State
+  var update = -1
 
   var body: some View {
     VStack {
@@ -79,7 +80,8 @@ benchmark("update wide (FiberReconciler)") { state in
 }
 
 struct UpdateNarrow: View {
-  @State var update = -1
+  @State
+  var update = -1
 
   var body: some View {
     VStack {
@@ -131,7 +133,8 @@ benchmark("update narrow (FiberReconciler)") { state in
 }
 
 struct UpdateDeep: View {
-  @State var update = "A"
+  @State
+  var update = "A"
 
   struct RecursiveView: View {
     let count: Int
@@ -195,7 +198,8 @@ benchmark("update deep (FiberReconciler)") { state in
 }
 
 struct UpdateShallow: View {
-  @State var update = "A"
+  @State
+  var update = "A"
 
   struct RecursiveView: View {
     let count: Int

--- a/Sources/TokamakDOM/Views/Canvas/Canvas.swift
+++ b/Sources/TokamakDOM/Views/Canvas/Canvas.swift
@@ -17,7 +17,8 @@
 
 import Foundation
 import JavaScriptKit
-@_spi(TokamakCore) import TokamakCore
+@_spi(TokamakCore)
+import TokamakCore
 import TokamakStaticHTML
 
 extension Canvas: DOMPrimitive {
@@ -36,12 +37,20 @@ private let devicePixelRatio = JSObject.global.devicePixelRatio.number ?? 1
 
 struct _Canvas<Symbols: View>: View {
   let parent: Canvas<Symbols>
-  @StateObject private var coordinator = Coordinator()
-  @Environment(\.inAnimatingTimelineView) private var inAnimatingTimelineView
-  @Environment(\.isAnimatingTimelineViewPaused) private var isAnimatingTimelineViewPaused
+
+  @StateObject
+  private var coordinator = Coordinator()
+
+  @Environment(\.inAnimatingTimelineView)
+  private var inAnimatingTimelineView
+
+  @Environment(\.isAnimatingTimelineViewPaused)
+  private var isAnimatingTimelineViewPaused
 
   final class Coordinator: ObservableObject {
-    @Published var canvas: JSObject?
+    @Published
+    var canvas: JSObject?
+
     var currentDrawLoop: JSValue?
 
     /// A cache of resolved symbols by their tag.

--- a/Sources/TokamakDOM/Views/Canvas/TimelineView.swift
+++ b/Sources/TokamakDOM/Views/Canvas/TimelineView.swift
@@ -41,9 +41,15 @@ extension EnvironmentValues {
 
 private struct _TimelineView<Content: View, Schedule: TimelineSchedule>: View {
   let parent: _TimelineViewProxy<Schedule, Content>
-  @StateObject private var coordinator: Coordinator
-  @Environment(\.inAnimatingTimelineView) private var inAnimatingTimelineView
-  @Environment(\.isAnimatingTimelineViewPaused) private var isAnimatingTimelineViewPaused
+
+  @StateObject
+  private var coordinator: Coordinator
+
+  @Environment(\.inAnimatingTimelineView)
+  private var inAnimatingTimelineView
+
+  @Environment(\.isAnimatingTimelineViewPaused)
+  private var isAnimatingTimelineViewPaused
 
   init(parent: TimelineView<Schedule, Content>) {
     self.parent = _TimelineViewProxy(parent)
@@ -56,7 +62,8 @@ private struct _TimelineView<Content: View, Schedule: TimelineSchedule>: View {
   }
 
   final class Coordinator: ObservableObject {
-    @Published var date = Date()
+    @Published
+    var date = Date()
     var iterator: Schedule.Entries.Iterator
     var timeoutID: JSValue?
 

--- a/Sources/TokamakDOM/Views/Layout/GeometryReader.swift
+++ b/Sources/TokamakDOM/Views/Layout/GeometryReader.swift
@@ -39,12 +39,14 @@ struct _GeometryReader<Content: View>: View {
     var observerRef: JSObject?
 
     /// The last known size of the `observedNodeRef` DOM node.
-    @Published var size: CGSize?
+    @Published
+    var size: CGSize?
   }
 
   let content: (GeometryProxy) -> Content
 
-  @StateObject private var state = State()
+  @StateObject
+  private var state = State()
 
   var body: some View {
     HTML("div", ["class": "_tokamak-geometryreader"]) {

--- a/Sources/TokamakDemo/Buttons/Counter.swift
+++ b/Sources/TokamakDemo/Buttons/Counter.swift
@@ -18,17 +18,20 @@
 import TokamakShim
 
 final class Count: ObservableObject {
-  @Published var value: Int
+  @Published
+  var value: Int
 
   init(value: Int) { self.value = value }
 }
 
 struct Counter: View {
-  @ObservedObject var count: Count
+  @ObservedObject
+  var count: Count
 
   let limit: Int
 
-  @ViewBuilder public var body: some View {
+  @ViewBuilder
+  public var body: some View {
     if count.value < limit {
       VStack {
         Button("Increment") { count.value += 1 }

--- a/Sources/TokamakDemo/Containers/ForEachDemo.swift
+++ b/Sources/TokamakDemo/Containers/ForEachDemo.swift
@@ -15,7 +15,8 @@
 import TokamakShim
 
 public struct ForEachDemo: View {
-  @State public var maxItem = 0
+  @State
+  public var maxItem = 0
 
   public var body: some View {
     VStack {

--- a/Sources/TokamakDemo/DOM/DOMRefDemo.swift
+++ b/Sources/TokamakDemo/DOM/DOMRefDemo.swift
@@ -17,7 +17,8 @@ import JavaScriptKit
 import TokamakShim
 
 struct DOMRefDemo: View {
-  @State var button: JSObject?
+  @State
+  var button: JSObject?
 
   var body: some View {
     Button("Click me") {

--- a/Sources/TokamakDemo/DOM/URLHashDemo.swift
+++ b/Sources/TokamakDemo/DOM/URLHashDemo.swift
@@ -22,7 +22,8 @@ private let window = JSObject.global.window.object!
 private final class HashState: ObservableObject {
   var onHashChange: JSClosure!
 
-  @Published var currentHash = location["hash"].string!
+  @Published
+  var currentHash = location["hash"].string!
 
   init() {
     let onHashChange = JSClosure { [weak self] _ in
@@ -43,7 +44,8 @@ private final class HashState: ObservableObject {
 }
 
 struct URLHashDemo: View {
-  @StateObject private var hashState = HashState()
+  @StateObject
+  private var hashState = HashState()
 
   var body: some View {
     VStack {

--- a/Sources/TokamakDemo/Drawing/CanvasDemo.swift
+++ b/Sources/TokamakDemo/Drawing/CanvasDemo.swift
@@ -36,7 +36,8 @@ struct Confetti: View {
     Color.orange,
     Color.yellow,
   ]
-  @State private var startDate = Date()
+  @State
+  private var startDate = Date()
   private let pieces: [Piece] = (0..<50).map { _ in
     Piece(
       point: CGPoint(x: CGFloat.random(in: 0...1), y: CGFloat.random(in: 0...1)),

--- a/Sources/TokamakDemo/Drawing/ColorDemo.swift
+++ b/Sources/TokamakDemo/Drawing/ColorDemo.swift
@@ -53,11 +53,17 @@ public struct ColorDemo: View {
     ("Secondary", .secondary),
   ]
 
-  @State private var colorForm: ColorForm = .hsb
+  @State
+  private var colorForm: ColorForm = .hsb
 
-  @State private var v0: String = "0.9"
-  @State private var v1: String = "1"
-  @State private var v2: String = "0.5"
+  @State
+  private var v0: String = "0.9"
+
+  @State
+  private var v1: String = "1"
+
+  @State
+  private var v2: String = "0.5"
 
   public var body: some View {
     ScrollView {

--- a/Sources/TokamakDemo/Layout/StackDemo.swift
+++ b/Sources/TokamakDemo/Layout/StackDemo.swift
@@ -16,8 +16,11 @@ import Foundation
 import TokamakShim
 
 struct StackDemo: View {
-  @State private var horizontalSpacing: CGFloat = 8
-  @State private var verticalSpacing: CGFloat = 8
+  @State
+  private var horizontalSpacing: CGFloat = 8
+
+  @State
+  private var verticalSpacing: CGFloat = 8
 
   var body: some View {
     VStack(spacing: verticalSpacing) {

--- a/Sources/TokamakDemo/Misc/AnimationDemo.swift
+++ b/Sources/TokamakDemo/Misc/AnimationDemo.swift
@@ -19,9 +19,14 @@ import Foundation
 import TokamakShim
 
 struct AnimationDemo: View {
-  @State private var delay: Double = 0
-  @State private var speed: Double = 1
-  @State private var on = false
+  @State
+  private var delay: Double = 0
+
+  @State
+  private var speed: Double = 1
+
+  @State
+  private var on = false
 
   enum AnimationStyle: String, Identifiable, CaseIterable {
     case easeIn, easeOut, easeInOut, spring
@@ -82,7 +87,8 @@ struct AnimationDemo: View {
     }
   }
 
-  @State private var foreverAnimation = false
+  @State
+  private var foreverAnimation = false
 
   var repeatedAnimationDemo: some View {
     VStack {

--- a/Sources/TokamakDemo/Misc/AppStorageDemo.swift
+++ b/Sources/TokamakDemo/Misc/AppStorageDemo.swift
@@ -18,8 +18,11 @@
 import TokamakShim
 
 struct AppStorageButtons: View {
-  @AppStorage("count") var count: Int = 0
-  @SceneStorage("count") var sceneCount: Int = 0
+  @AppStorage("count")
+  var count: Int = 0
+
+  @SceneStorage("count")
+  var sceneCount: Int = 0
 
   var body: some View {
     HStack {
@@ -30,8 +33,10 @@ struct AppStorageButtons: View {
 }
 
 struct AppStorageDemo: View {
-  @AppStorage("count") var count: Int = 0
-  @SceneStorage("count") var sceneCount: Int = 0
+  @AppStorage("count")
+  var count: Int = 0
+  @SceneStorage("count")
+  var sceneCount: Int = 0
 
   public var body: some View {
     VStack {

--- a/Sources/TokamakDemo/Misc/EnvironmentDemo.swift
+++ b/Sources/TokamakDemo/Misc/EnvironmentDemo.swift
@@ -18,12 +18,15 @@
 import TokamakShim
 
 class TestEnvironment: ObservableObject {
-  @Published var envTest = "Hello, world!"
+  @Published
+  var envTest = "Hello, world!"
+
   init() {}
 }
 
 struct EnvironmentObjectDemo: View {
-  @EnvironmentObject var testEnv: TestEnvironment
+  @EnvironmentObject
+  var testEnv: TestEnvironment
 
   var body: some View {
     Button(testEnv.envTest) {
@@ -43,10 +46,14 @@ extension ColorScheme: CustomStringConvertible {
 }
 
 struct EnvironmentDemo: View {
-  @Environment(\.colorScheme) var colorScheme
+  @Environment(\.colorScheme)
+  var colorScheme
 
-  @Environment(\.font) var font
-  @EnvironmentObject var testEnv: TestEnvironment
+  @Environment(\.font)
+  var font
+
+  @EnvironmentObject
+  var testEnv: TestEnvironment
 
   var body: some View {
     VStack {

--- a/Sources/TokamakDemo/Misc/PreferenceKeyDemo.swift
+++ b/Sources/TokamakDemo/Misc/PreferenceKeyDemo.swift
@@ -25,8 +25,11 @@ struct TestPreferenceKey: PreferenceKey {
 }
 
 struct PreferenceKeyDemo: View {
-  @State private var testKeyValue: Color = .yellow
-  @Environment(\.colorScheme) var colorScheme
+  @State
+  private var testKeyValue: Color = .yellow
+
+  @Environment(\.colorScheme)
+  var colorScheme
 
   var body: some View {
     VStack {
@@ -119,7 +122,9 @@ struct PreferenceKeyDemo: View {
     let level: Int
     let color: Color
     let content: Content
-    @State private var testKeyValue: Color = .yellow
+
+    @State
+    private var testKeyValue: Color = .yellow
 
     init(_ level: Int, _ color: Color, @ViewBuilder _ content: () -> Content) {
       self.level = level

--- a/Sources/TokamakDemo/Misc/ProgressViewDemo.swift
+++ b/Sources/TokamakDemo/Misc/ProgressViewDemo.swift
@@ -18,7 +18,8 @@
 import TokamakShim
 
 struct ProgressViewDemo: View {
-  @State private var progress = 0.5
+  @State
+  private var progress = 0.5
 
   var body: some View {
     VStack {

--- a/Sources/TokamakDemo/Misc/TransitionDemo.swift
+++ b/Sources/TokamakDemo/Misc/TransitionDemo.swift
@@ -27,8 +27,11 @@ private struct ColorOverlayModifier: ViewModifier {
 }
 
 struct TransitionDemo: View {
-  @State private var isVisible = false
-  @State private var isInnerVisible = false
+  @State
+  private var isVisible = false
+
+  @State
+  private var isInnerVisible = false
 
   var body: some View {
     VStack {

--- a/Sources/TokamakDemo/Modifiers/TaskDemo.swift
+++ b/Sources/TokamakDemo/Modifiers/TaskDemo.swift
@@ -26,7 +26,8 @@ private struct Response: Decodable {
 }
 
 struct TaskDemo: View {
-  @State private var response: Result<Response, Error>?
+  @State
+  private var response: Result<Response, Error>?
 
   var body: some View {
     VStack {

--- a/Sources/TokamakDemo/Selectors/DatePickerDemo.swift
+++ b/Sources/TokamakDemo/Selectors/DatePickerDemo.swift
@@ -19,7 +19,8 @@ import struct Foundation.Date
 import TokamakShim
 
 struct DatePickerDemo: View {
-  @State private var date = Date()
+  @State
+  private var date = Date()
 
   var body: some View {
     VStack {

--- a/Sources/TokamakDemo/Selectors/PickerDemo.swift
+++ b/Sources/TokamakDemo/Selectors/PickerDemo.swift
@@ -17,7 +17,8 @@ import TokamakShim
 struct PickerDemo: View {
   var textStyles = Font.TextStyle.allCases
 
-  @State private var selection = 0
+  @State
+  private var selection = 0
 
   var body: some View {
     Picker(

--- a/Sources/TokamakDemo/Selectors/SliderDemo.swift
+++ b/Sources/TokamakDemo/Selectors/SliderDemo.swift
@@ -29,11 +29,20 @@ struct Title: View {
 }
 
 struct SliderDemo: View {
-  @State private var value: Double = 0
-  @State private var value2: Double = 0
-  @State private var value3: Double = 0
-  @State private var value4: Double = 0
-  @State private var editing = false
+  @State
+  private var value: Double = 0
+
+  @State
+  private var value2: Double = 0
+
+  @State
+  private var value3: Double = 0
+
+  @State
+  private var value4: Double = 0
+
+  @State
+  private var editing = false
 
   var body: some View {
     ScrollView(.vertical) {

--- a/Sources/TokamakDemo/Selectors/ToggleDemo.swift
+++ b/Sources/TokamakDemo/Selectors/ToggleDemo.swift
@@ -15,7 +15,8 @@
 import TokamakShim
 
 public struct ToggleDemo: View {
-  @State var checked = false
+  @State
+  var checked = false
 
   public var body: some View {
     VStack {

--- a/Sources/TokamakDemo/Text/TextEditorDemo.swift
+++ b/Sources/TokamakDemo/Text/TextEditorDemo.swift
@@ -15,7 +15,8 @@
 import TokamakShim
 
 struct TextEditorDemo: View {
-  @State var text = ""
+  @State
+  var text = ""
 
   var body: some View {
     Text("Word count: \(text.split(separator: " ").count)")

--- a/Sources/TokamakDemo/Text/TextFieldDemo.swift
+++ b/Sources/TokamakDemo/Text/TextFieldDemo.swift
@@ -15,11 +15,20 @@
 import TokamakShim
 
 struct TextFieldDemo: View {
-  @State var text = ""
-  @State var numCommits = 0
-  @State var isFocused = false
-  @State var password = ""
-  @State var committedPassword = ""
+  @State
+  var text = ""
+
+  @State
+  var numCommits = 0
+
+  @State
+  var isFocused = false
+
+  @State
+  var password = ""
+
+  @State
+  var committedPassword = ""
   // Uncomment this line and build to verify the
   // textFieldStyle environment variable is inaccessible
   // @Environment(\.textFieldStyle) var textFieldStyle: TextFieldStyle

--- a/Sources/TokamakDemo/main.swift
+++ b/Sources/TokamakDemo/main.swift
@@ -16,7 +16,8 @@ import TokamakShim
 
 @available(OSX 10.16, iOS 14.0, *)
 struct CustomScene: Scene {
-  @Environment(\.scenePhase) private var scenePhase
+  @Environment(\.scenePhase)
+  private var scenePhase
 
   var body: some Scene {
     print("In CustomScene.body scenePhase is \(scenePhase)")

--- a/Sources/TokamakGTK/GtkContainer+forEach.swift
+++ b/Sources/TokamakGTK/GtkContainer+forEach.swift
@@ -24,7 +24,8 @@ extension UnsafeMutablePointer where Pointee == GtkContainer {
     _ closure: @escaping (UnsafeMutablePointer<GtkWidget>?) -> ()
   ) {
     let closureBox = Unmanaged.passRetained(SingleParamClosureBox(closure)).toOpaque()
-    let handler: @convention(c) (UnsafeMutablePointer<GtkWidget>?, UnsafeRawPointer)
+    let handler: @convention(c)
+      (UnsafeMutablePointer<GtkWidget>?, UnsafeRawPointer)
       -> Bool = { (ref: UnsafeMutablePointer<GtkWidget>?, data: UnsafeRawPointer) -> Bool in
         let unpackedAction = Unmanaged<SingleParamClosureBox<UnsafeMutablePointer<GtkWidget>?, ()>>
           .fromOpaque(data)

--- a/Sources/TokamakGTKDemo/main.swift
+++ b/Sources/TokamakGTKDemo/main.swift
@@ -19,7 +19,8 @@ import Foundation
 import TokamakGTK
 
 struct Counter: View {
-  @State private var count: Int = 0
+  @State
+  private var count: Int = 0
   var body: some View {
     VStack {
       Text("\(count)")
@@ -34,7 +35,8 @@ struct Counter: View {
 }
 
 struct PickerDemo: View {
-  @State private var chosenValue: Int = 3
+  @State
+  private var chosenValue: Int = 3
   var body: some View {
     VStack {
       Text("Chose \(chosenValue)")

--- a/Sources/TokamakStaticHTML/StaticHTMLFiberRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLFiberRenderer.swift
@@ -87,25 +87,33 @@ public final class HTMLElement: FiberElement, CustomStringConvertible {
   }
 }
 
-@_spi(TokamakStaticHTML) public protocol HTMLConvertible {
+@_spi(TokamakStaticHTML)
+public protocol HTMLConvertible {
   var tag: String { get }
   var attributes: [HTMLAttribute: String] { get }
   var innerHTML: String? { get }
 }
 
 public extension HTMLConvertible {
-  @_spi(TokamakStaticHTML) var innerHTML: String? { nil }
+  @_spi(TokamakStaticHTML)
+  var innerHTML: String? { nil }
 }
 
-@_spi(TokamakStaticHTML) extension Text: HTMLConvertible {
-  @_spi(TokamakStaticHTML) public var innerHTML: String? {
+@_spi(TokamakStaticHTML)
+extension Text: HTMLConvertible {
+  @_spi(TokamakStaticHTML)
+  public var innerHTML: String? {
     _TextProxy(self).rawText
   }
 }
 
-@_spi(TokamakStaticHTML) extension VStack: HTMLConvertible {
-  @_spi(TokamakStaticHTML) public var tag: String { "div" }
-  @_spi(TokamakStaticHTML) public var attributes: [HTMLAttribute: String] {
+@_spi(TokamakStaticHTML)
+extension VStack: HTMLConvertible {
+  @_spi(TokamakStaticHTML)
+  public var tag: String { "div" }
+
+  @_spi(TokamakStaticHTML)
+  public var attributes: [HTMLAttribute: String] {
     let spacing = _VStackProxy(self).spacing
     return [
       "style": """
@@ -119,9 +127,13 @@ public extension HTMLConvertible {
   }
 }
 
-@_spi(TokamakStaticHTML) extension HStack: HTMLConvertible {
-  @_spi(TokamakStaticHTML) public var tag: String { "div" }
-  @_spi(TokamakStaticHTML) public var attributes: [HTMLAttribute: String] {
+@_spi(TokamakStaticHTML)
+extension HStack: HTMLConvertible {
+  @_spi(TokamakStaticHTML)
+  public var tag: String { "div" }
+
+  @_spi(TokamakStaticHTML)
+  public var attributes: [HTMLAttribute: String] {
     let spacing = _HStackProxy(self).spacing
     return [
       "style": """

--- a/Sources/TokamakStaticHTML/StaticHTMLFiberRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLFiberRenderer.swift
@@ -102,14 +102,6 @@ public extension HTMLConvertible {
 }
 
 @_spi(TokamakStaticHTML)
-extension Text: HTMLConvertible {
-  @_spi(TokamakStaticHTML)
-  public var innerHTML: String? {
-    _TextProxy(self).rawText
-  }
-}
-
-@_spi(TokamakStaticHTML)
 extension VStack: HTMLConvertible {
   @_spi(TokamakStaticHTML)
   public var tag: String { "div" }

--- a/Sources/TokamakStaticHTML/Views/Text/Text.swift
+++ b/Sources/TokamakStaticHTML/Views/Text/Text.swift
@@ -159,8 +159,10 @@ extension Text: AnyHTML {
   }
 }
 
-@_spi(TokamakStaticHTML) extension Text: HTMLConvertible {
-  @_spi(TokamakStaticHTML) public var innerHTML: String? {
+@_spi(TokamakStaticHTML)
+extension Text: HTMLConvertible {
+  @_spi(TokamakStaticHTML)
+  public var innerHTML: String? {
     innerHTML(shouldSortAttributes: false)
   }
 

--- a/Tests/TokamakReconcilerTests/VisitorTests.swift
+++ b/Tests/TokamakReconcilerTests/VisitorTests.swift
@@ -22,7 +22,8 @@ import TokamakTestRenderer
 
 private struct TestView: View {
   struct Counter: View {
-    @State private var count = 0
+    @State
+    private var count = 0
 
     var body: some View {
       VStack {

--- a/Tests/TokamakTests/EnvironmentTests.swift
+++ b/Tests/TokamakTests/EnvironmentTests.swift
@@ -16,7 +16,8 @@ import XCTest
 @testable import TokamakCore
 
 private struct TestView: View {
-  @Environment(\.colorScheme) var colorScheme
+  @Environment(\.colorScheme)
+  var colorScheme
 
   public var body: some View {
     EmptyView()

--- a/Tests/TokamakTests/ReconcilerTests.swift
+++ b/Tests/TokamakTests/ReconcilerTests.swift
@@ -21,7 +21,8 @@ import XCTest
 @testable import TokamakCore
 
 private struct Counter: View {
-  @State var count: Int
+  @State
+  var count: Int
 
   let limit: Int
 


### PR DESCRIPTION
The abundance of `@_spi(TokamakCore)` makes it harder to parse some of our code visually when skimming. I propose consistently moving attributes on declarations to separate lines. Here's an update to `.swiftformat` config with the new settings applied to the codebase.