### PR TITLE
Add file size to benchmark script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,9 @@ jobs:
           xcodebuild -version
 
           # Make sure Tokamak can be built on macOS so that Xcode autocomplete works.
-          # Disable macOS builds until Monterey is available on GHA.
-          # xcodebuild -scheme TokamakDemo -destination 'generic/platform=macOS' \
-          #   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
-          #   xcpretty --color
+          xcodebuild -scheme TokamakDemo -destination 'generic/platform=macOS' \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
+            xcpretty --color
 
           cd "NativeDemo"
           xcodebuild -scheme iOS -destination 'generic/platform=iOS' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
       - uses: swiftwasm/swiftwasm-action@v5.6
         with:
           shell-action: carton bundle --product TokamakDemo
+      - name: Check binary size
+        shell: bash
+        run: |
+          ls -la Bundle
+          ls -lh Bundle/*.wasm | awk '{printf  "::warning file=Sources/TokamakDemo/main.swift,line=1,col=1::TokamakDemo Wasm is %s.",$5}'
 
   swiftwasm_test_5_6:
     runs-on: ubuntu-20.04

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -3,6 +3,8 @@
 set -eux
 
 swift build -c release --product TokamakCoreBenchmark
+stat -f "TokamakCoreBenchmark: %z bytes" ./.build/release/TokamakCoreBenchmark
 ./.build/release/TokamakCoreBenchmark
 swift build -c release --product TokamakStaticHTMLBenchmark
+stat -f "TokamakStaticHTMLBenchmark: %z bytes" ./.build/release/TokamakStaticHTMLBenchmark
 ./.build/release/TokamakStaticHTMLBenchmark

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -3,8 +3,8 @@
 set -eux
 
 swift build -c release --product TokamakCoreBenchmark
-stat -f "TokamakCoreBenchmark: %z bytes" ./.build/release/TokamakCoreBenchmark
+stat -f "::warning file=Sources/TokamakCoreBenchmark/main.swift,line=1,col=1::TokamakCoreBenchmark is %z bytes." ./.build/release/TokamakCoreBenchmark
 ./.build/release/TokamakCoreBenchmark
 swift build -c release --product TokamakStaticHTMLBenchmark
-stat -f "TokamakStaticHTMLBenchmark: %z bytes" ./.build/release/TokamakStaticHTMLBenchmark
+stat -f "::warning file=Sources/TokamakStaticHTMLBenchmark/main.swift,line=1,col=1::TokamakStaticHTMLBenchmark is %z bytes." ./.build/release/TokamakStaticHTMLBenchmark
 ./.build/release/TokamakStaticHTMLBenchmark

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -3,8 +3,8 @@
 set -eux
 
 swift build -c release --product TokamakCoreBenchmark
-stat -f "::warning file=Sources/TokamakCoreBenchmark/main.swift,line=1,col=1::TokamakCoreBenchmark is %z bytes." ./.build/release/TokamakCoreBenchmark
+ls -lh ./.build/release/TokamakCoreBenchmark | awk '{printf  "::warning file=Sources/TokamakCoreBenchmark/main.swift,line=1,col=1::TokamakCoreBenchmark is %s.",$5}'
 ./.build/release/TokamakCoreBenchmark
 swift build -c release --product TokamakStaticHTMLBenchmark
-stat -f "::warning file=Sources/TokamakStaticHTMLBenchmark/main.swift,line=1,col=1::TokamakStaticHTMLBenchmark is %z bytes." ./.build/release/TokamakStaticHTMLBenchmark
+ls -lh ./.build/release/TokamakStaticHTMLBenchmark | awk '{printf  "::warning file=Sources/TokamakStaticHTMLBenchmark/main.swift,line=1,col=1::TokamakStaticHTMLBenchmark is %s.",$5}'
 ./.build/release/TokamakStaticHTMLBenchmark


### PR DESCRIPTION
As suggested in #490, this PR adds a file size display to CI. The benchmark script will now display the file size of both benchmarks.


Additionally, the TokamakDemo build in CI was still disabled. This has been fixed.