### PR TITLE
Support `Image` in Fiber renderers

### DIFF
--- a/Sources/TokamakCore/Fiber/FiberRenderer.swift
+++ b/Sources/TokamakCore/Fiber/FiberRenderer.swift
@@ -21,24 +21,39 @@ import Foundation
 public protocol FiberRenderer {
   /// The element class this renderer uses.
   associatedtype ElementType: FiberElement
+
   /// Check whether a `View` is a primitive for this renderer.
   static func isPrimitive<V>(_ view: V) -> Bool where V: View
+
   func visitPrimitiveChildren<Primitive, Visitor>(
     _ view: Primitive
   ) -> ViewVisitorF<Visitor>? where Primitive: View, Visitor: ViewVisitor
+
   /// Apply the mutations to the elements.
   func commit(_ mutations: [Mutation<Self>])
+
   /// The root element all top level views should be mounted on.
   var rootElement: ElementType { get }
+
   /// The smallest set of initial `EnvironmentValues` needed for this renderer to function.
   var defaultEnvironment: EnvironmentValues { get }
+
   /// The size of the window we are rendering in.
   var sceneSize: CGSize { get }
+
   /// Whether layout is enabled for this renderer.
   var useDynamicLayout: Bool { get }
+
   /// Calculate the size of `Text` in `environment` for layout.
   func measureText(
     _ text: Text,
+    proposal: ProposedViewSize,
+    in environment: EnvironmentValues
+  ) -> CGSize
+
+  /// Calculate the size of an `Image` in `environment` for layout.
+  func measureImage(
+    _ image: Image,
     proposal: ProposedViewSize,
     in environment: EnvironmentValues
   ) -> CGSize
@@ -84,5 +99,16 @@ extension EnvironmentValues {
   var measureText: (Text, ProposedViewSize, EnvironmentValues) -> CGSize {
     get { self[MeasureTextKey.self] }
     set { self[MeasureTextKey.self] = newValue }
+  }
+
+  private enum MeasureImageKey: EnvironmentKey {
+    static var defaultValue: (Image, ProposedViewSize, EnvironmentValues) -> CGSize {
+      { _, _, _ in .zero }
+    }
+  }
+
+  var measureImage: (Image, ProposedViewSize, EnvironmentValues) -> CGSize {
+    get { self[MeasureImageKey.self] }
+    set { self[MeasureImageKey.self] = newValue }
   }
 }

--- a/Sources/TokamakCore/Fiber/Layout/_AspectRatioLayout+Layout.swift
+++ b/Sources/TokamakCore/Fiber/Layout/_AspectRatioLayout+Layout.swift
@@ -1,0 +1,98 @@
+// Copyright 2022 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 6/27/22.
+//
+
+import Foundation
+
+private struct AspectRatioLayout: Layout {
+  let aspectRatio: CGFloat?
+  let contentMode: ContentMode
+
+  func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+    let aspectRatio: CGFloat
+    let maxAxis: Axis
+    if let ratio = self.aspectRatio {
+      aspectRatio = ratio
+      maxAxis = ratio > 1 ? .horizontal : .vertical
+    } else {
+      let idealSubviewSize = subviews.first?.sizeThatFits(.unspecified) ?? .zero
+      if idealSubviewSize.height == 0 {
+        aspectRatio = 0
+      } else {
+        aspectRatio = idealSubviewSize.width / idealSubviewSize.height
+      }
+      maxAxis = idealSubviewSize.width > idealSubviewSize.height ? .horizontal : .vertical
+    }
+    let proposal = proposal.replacingUnspecifiedDimensions()
+    let widthRatio = aspectRatio
+    let heightRatio = 1 / aspectRatio
+    switch contentMode {
+    case .fit:
+      if maxAxis == .horizontal {
+        return .init(
+          width: proposal.width,
+          height: heightRatio * proposal.width
+        )
+      } else {
+        return .init(
+          width: widthRatio * proposal.width,
+          height: proposal.height
+        )
+      }
+    case .fill:
+      if maxAxis == .horizontal {
+        return .init(
+          width: widthRatio * proposal.width,
+          height: proposal.width
+        )
+      } else {
+        return .init(
+          width: proposal.width,
+          height: heightRatio * proposal.height
+        )
+      }
+    }
+  }
+
+  func placeSubviews(
+    in bounds: CGRect,
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) {
+    for subview in subviews {
+      subview.place(
+        at: .init(x: bounds.midX, y: bounds.midY),
+        anchor: .center,
+        proposal: .init(bounds.size)
+      )
+    }
+  }
+}
+
+public extension _AspectRatioLayout {
+  func _visitChildren<V>(_ visitor: V, content: Content) where V: ViewVisitor {
+    visitor.visit(
+      AspectRatioLayout(
+        aspectRatio: aspectRatio,
+        contentMode: contentMode
+      )
+      .callAsFunction {
+        content
+      }
+    )
+  }
+}

--- a/Sources/TokamakCore/Fiber/Passes/ReconcilePass.swift
+++ b/Sources/TokamakCore/Fiber/Passes/ReconcilePass.swift
@@ -218,14 +218,14 @@ struct ReconcilePass: FiberReconcilerPass {
        let parent = node.fiber?.elementParent?.element
     {
       if node.fiber?.alternate == nil { // This didn't exist before (no alternate)
-        if let fiber = node.fiber?.elementParent {
+        if let fiber = node.fiber {
           invalidateCache(for: fiber, in: reconciler, caches: caches)
         }
         return .insert(element: element, parent: parent, index: index)
       } else if node.fiber?.typeInfo?.type != node.fiber?.alternate?.typeInfo?.type,
                 let previous = node.fiber?.alternate?.element
       {
-        if let fiber = node.fiber?.elementParent {
+        if let fiber = node.fiber {
           invalidateCache(for: fiber, in: reconciler, caches: caches)
         }
         // This is a completely different type of view.
@@ -233,7 +233,7 @@ struct ReconcilePass: FiberReconcilerPass {
       } else if let newContent = node.newContent,
                 newContent != element.content
       {
-        if let fiber = node.fiber?.elementParent {
+        if let fiber = node.fiber {
           invalidateCache(for: fiber, in: reconciler, caches: caches)
         }
         // This is the same type of view, but its backing data has changed.

--- a/Sources/TokamakCore/Views/Image.swift
+++ b/Sources/TokamakCore/Views/Image.swift
@@ -101,10 +101,15 @@ private class ResizableProvider: _AnyImageProviderBox {
 }
 
 public struct Image: _PrimitiveView, Equatable {
-  let provider: _AnyImageProviderBox
+  @_spi(TokamakCore)
+  public let provider: _AnyImageProviderBox
 
   @Environment(\.self)
   var environment
+
+  @_spi(TokamakCore)
+  @State
+  public var intrinsicSize: CGSize?
 
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.provider == rhs.provider
@@ -151,4 +156,25 @@ public struct _ImageProxy {
 
   public var provider: _AnyImageProviderBox { subject.provider }
   public var environment: EnvironmentValues { subject.environment }
+}
+
+extension Image: Layout {
+  public func sizeThatFits(
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) -> CGSize {
+    environment.measureImage(self, proposal, environment)
+  }
+
+  public func placeSubviews(
+    in bounds: CGRect,
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) {
+    for subview in subviews {
+      subview.place(at: bounds.origin, proposal: proposal)
+    }
+  }
 }

--- a/Sources/TokamakCore/Views/Image.swift
+++ b/Sources/TokamakCore/Views/Image.swift
@@ -109,7 +109,7 @@ public struct Image: _PrimitiveView, Equatable {
 
   @_spi(TokamakCore)
   @State
-  public var intrinsicSize: CGSize?
+  public var _intrinsicSize: CGSize?
 
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.provider == rhs.provider

--- a/Sources/TokamakDOM/DOMFiberRenderer.swift
+++ b/Sources/TokamakDOM/DOMFiberRenderer.swift
@@ -203,13 +203,13 @@ public struct DOMFiberRenderer: FiberRenderer {
           .path(forResource: name, ofType: nil) ?? name
       ) { naturalSize in
         environment.afterReconcile {
-          image.intrinsicSize = naturalSize
+          image._intrinsicSize = naturalSize
         }
       }
       return .zero
     case let .resizable(.named(name, bundle: bundle), capInsets, resizingMode):
       if proposal == .unspecified {
-        if let intrinsicSize = image.intrinsicSize {
+        if let intrinsicSize = image._intrinsicSize {
           return intrinsicSize
         }
         loadImageSize(
@@ -217,7 +217,7 @@ public struct DOMFiberRenderer: FiberRenderer {
             .path(forResource: name, ofType: nil) ?? name
         ) { naturalSize in
           environment.afterReconcile {
-            image.intrinsicSize = naturalSize
+            image._intrinsicSize = naturalSize
           }
         }
         return .zero

--- a/Sources/TokamakDOM/Storage/WebStorage.swift
+++ b/Sources/TokamakDOM/Storage/WebStorage.swift
@@ -73,6 +73,6 @@ extension WebStorage {
   }
 
   public func read(key: String) -> String? {
-    getItem(key: key, { $0 })
+    getItem(key: key) { $0 }
   }
 }

--- a/Sources/TokamakStaticHTML/StaticHTMLFiberRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLFiberRenderer.swift
@@ -226,6 +226,14 @@ public struct StaticHTMLFiberRenderer: FiberRenderer {
     .zero
   }
 
+  public func measureImage(
+    _ image: Image,
+    proposal: ProposedViewSize,
+    in environment: EnvironmentValues
+  ) -> CGSize {
+    .zero
+  }
+
   public func render<A: App>(_ app: A) -> String {
     _ = FiberReconciler(self, app)
     return """

--- a/Sources/TokamakStaticHTML/Views/Images/Image.swift
+++ b/Sources/TokamakStaticHTML/Views/Images/Image.swift
@@ -65,7 +65,7 @@ extension Image: HTMLConvertible {
       if useDynamicLayout {
         return [
           "src": src,
-          "data-loaded": intrinsicSize != nil ? "true" : "false",
+          "data-loaded": _intrinsicSize != nil ? "true" : "false",
         ]
       } else {
         return [
@@ -78,7 +78,7 @@ extension Image: HTMLConvertible {
       if useDynamicLayout {
         return [
           "src": src,
-          "data-loaded": intrinsicSize != nil ? "true" : "false",
+          "data-loaded": _intrinsicSize != nil ? "true" : "false",
         ]
       } else {
         return [

--- a/Sources/TokamakTestRenderer/TestFiberRenderer.swift
+++ b/Sources/TokamakTestRenderer/TestFiberRenderer.swift
@@ -137,7 +137,7 @@ public struct TestFiberRenderer: FiberRenderer {
   }
 
   public func measureImage(
-    _ image: _AnyImageProviderBox,
+    _ image: Image,
     proposal: ProposedViewSize,
     in environment: EnvironmentValues
   ) -> CGSize {

--- a/Sources/TokamakTestRenderer/TestFiberRenderer.swift
+++ b/Sources/TokamakTestRenderer/TestFiberRenderer.swift
@@ -136,6 +136,14 @@ public struct TestFiberRenderer: FiberRenderer {
     proposal.replacingUnspecifiedDimensions()
   }
 
+  public func measureImage(
+    _ image: _AnyImageProviderBox,
+    proposal: ProposedViewSize,
+    in environment: EnvironmentValues
+  ) -> CGSize {
+    proposal.replacingUnspecifiedDimensions()
+  }
+
   public typealias ElementType = TestFiberElement
 
   public let rootElement: ElementType

--- a/Tests/TokamakLayoutTests/AspectRatioTests.swift
+++ b/Tests/TokamakLayoutTests/AspectRatioTests.swift
@@ -1,0 +1,88 @@
+// Copyright 2022 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 6/27/22.
+//
+
+#if os(macOS)
+import SwiftUI
+import TokamakStaticHTML
+import XCTest
+
+final class AspectRatioTests: XCTestCase {
+  func testAspectRatio() async {
+    await compare(size: .init(width: 500, height: 500)) {
+      SwiftUI.Rectangle()
+        .fill(Color(white: 0))
+        .aspectRatio(1, contentMode: .fit)
+        .frame(width: 200, height: 100)
+    } to: {
+      TokamakStaticHTML.Rectangle()
+        .fill(Color(white: 0))
+        .aspectRatio(1, contentMode: .fit)
+        .frame(width: 200, height: 100)
+    }
+  }
+
+  func testWideRatio() async {
+    await compare(size: .init(width: 500, height: 500)) {
+      SwiftUI.Rectangle()
+        .fill(Color(white: 0))
+        .aspectRatio(1.5, contentMode: .fit)
+        .frame(width: 100, height: 100)
+    } to: {
+      TokamakStaticHTML.Rectangle()
+        .fill(Color(white: 0))
+        .aspectRatio(1.5, contentMode: .fit)
+        .frame(width: 100, height: 100)
+    }
+    await compare(size: .init(width: 500, height: 500)) {
+      SwiftUI.Rectangle()
+        .fill(Color(white: 0))
+        .aspectRatio(1.5, contentMode: .fill)
+        .frame(width: 100, height: 100)
+    } to: {
+      TokamakStaticHTML.Rectangle()
+        .fill(Color(white: 0))
+        .aspectRatio(1.5, contentMode: .fill)
+        .frame(width: 100, height: 100)
+    }
+  }
+
+  func testTallRatio() async {
+    await compare(size: .init(width: 500, height: 500)) {
+      SwiftUI.Rectangle()
+        .fill(Color(white: 0))
+        .aspectRatio(0.5, contentMode: .fit)
+        .frame(width: 100, height: 100)
+    } to: {
+      TokamakStaticHTML.Rectangle()
+        .fill(Color(white: 0))
+        .aspectRatio(0.5, contentMode: .fit)
+        .frame(width: 100, height: 100)
+    }
+    await compare(size: .init(width: 500, height: 500)) {
+      SwiftUI.Rectangle()
+        .fill(Color(white: 0))
+        .aspectRatio(0.5, contentMode: .fill)
+        .frame(width: 100, height: 100)
+    } to: {
+      TokamakStaticHTML.Rectangle()
+        .fill(Color(white: 0))
+        .aspectRatio(0.5, contentMode: .fill)
+        .frame(width: 100, height: 100)
+    }
+  }
+}
+#endif


### PR DESCRIPTION
This adds support for the `Image` view, as well as the `aspectRatio` modifier. With dynamic layout enabled, it computes the natural size of the image by loading it and setting an `intrinsicSize` state property on the `Image` to update the layout.

Aspect ratio support was also added to allow for images to be scaled while keeping their resolution.