### PR TITLE
Add support for preferences, `@StateObject`, `@EnvironmentObject`, and custom `DynamicProperty` types

### DIFF
--- a/Sources/TokamakCore/Fiber/Fiber+CustomDebugStringConvertible.swift
+++ b/Sources/TokamakCore/Fiber/Fiber+CustomDebugStringConvertible.swift
@@ -22,7 +22,7 @@ extension FiberReconciler.Fiber: CustomDebugStringConvertible {
     {
       return "Text(\"\(text.storage.rawText)\")"
     }
-    return "\(typeInfo?.name ?? "Unknown") \(ObjectIdentifier(self).debugDescription.split(separator: "(")[1].split(separator: ")")[0])"
+    return "\(typeInfo?.name ?? "Unknown")"
   }
 
   private func flush(level: Int = 0) -> String {

--- a/Sources/TokamakCore/Fiber/Fiber+CustomDebugStringConvertible.swift
+++ b/Sources/TokamakCore/Fiber/Fiber+CustomDebugStringConvertible.swift
@@ -22,7 +22,7 @@ extension FiberReconciler.Fiber: CustomDebugStringConvertible {
     {
       return "Text(\"\(text.storage.rawText)\")"
     }
-    return typeInfo?.name ?? "Unknown"
+    return "\(typeInfo?.name ?? "Unknown") \(ObjectIdentifier(self).debugDescription.split(separator: "(")[1].split(separator: ")")[0])"
   }
 
   private func flush(level: Int = 0) -> String {

--- a/Sources/TokamakCore/Fiber/Fiber+CustomDebugStringConvertible.swift
+++ b/Sources/TokamakCore/Fiber/Fiber+CustomDebugStringConvertible.swift
@@ -17,12 +17,13 @@
 
 extension FiberReconciler.Fiber: CustomDebugStringConvertible {
   public var debugDescription: String {
+    let memoryAddress = String(format: "%010p", unsafeBitCast(self, to: Int.self))
     if case let .view(view, _) = content,
        let text = view as? Text
     {
-      return "Text(\"\(text.storage.rawText)\")"
+      return "Text(\"\(text.storage.rawText)\") (\(memoryAddress))"
     }
-    return "\(typeInfo?.name ?? "Unknown")"
+    return "\(typeInfo?.name ?? "Unknown") (\(memoryAddress))"
   }
 
   private func flush(level: Int = 0) -> String {

--- a/Sources/TokamakCore/Fiber/Fiber.swift
+++ b/Sources/TokamakCore/Fiber/Fiber.swift
@@ -94,6 +94,9 @@ public extension FiberReconciler {
     /// Boxes that store `State` data.
     var state: [PropertyInfo: MutableStorage] = [:]
 
+    /// Storage for `PreferenceKey` values as they are passed up the tree.
+    var preferences: _PreferenceStore = .init()
+
     /// The computed dimensions and origin.
     var geometry: ViewGeometry?
 
@@ -175,6 +178,7 @@ public extension FiberReconciler {
         let alternate = Fiber(
           bound: alternateView,
           state: self.state,
+          preferences: self.preferences,
           layout: self.layout,
           alternate: self,
           outputs: self.outputs,
@@ -205,6 +209,7 @@ public extension FiberReconciler {
     init<V: View>(
       bound view: V,
       state: [PropertyInfo: MutableStorage],
+      preferences: _PreferenceStore,
       layout: AnyLayout!,
       alternate: Fiber,
       outputs: ViewOutputs,
@@ -224,6 +229,7 @@ public extension FiberReconciler {
       self.typeInfo = typeInfo
       self.outputs = outputs
       self.state = state
+      self.preferences = preferences
       if element != nil {
         self.layout = layout
       }
@@ -326,6 +332,7 @@ public extension FiberReconciler {
         let alternate = Fiber(
           bound: alternateApp,
           state: self.state,
+          preferences: self.preferences,
           layout: self.layout,
           alternate: self,
           outputs: self.outputs,
@@ -341,6 +348,7 @@ public extension FiberReconciler {
     init<A: App>(
       bound app: A,
       state: [PropertyInfo: MutableStorage],
+      preferences: _PreferenceStore,
       layout: AnyLayout?,
       alternate: Fiber,
       outputs: SceneOutputs,
@@ -358,6 +366,7 @@ public extension FiberReconciler {
       self.typeInfo = typeInfo
       self.outputs = outputs
       self.state = state
+      self.preferences = preferences
       self.layout = layout
       content = content(for: app)
     }
@@ -401,6 +410,7 @@ public extension FiberReconciler {
         let alternate = Fiber(
           bound: alternateScene,
           state: self.state,
+          preferences: self.preferences,
           layout: self.layout,
           alternate: self,
           outputs: self.outputs,
@@ -431,6 +441,7 @@ public extension FiberReconciler {
     init<S: Scene>(
       bound scene: S,
       state: [PropertyInfo: MutableStorage],
+      preferences: _PreferenceStore,
       layout: AnyLayout!,
       alternate: Fiber,
       outputs: SceneOutputs,
@@ -450,6 +461,7 @@ public extension FiberReconciler {
       self.typeInfo = typeInfo
       self.outputs = outputs
       self.state = state
+      self.preferences = preferences
       if element != nil {
         self.layout = layout
       }

--- a/Sources/TokamakCore/Fiber/Fiber.swift
+++ b/Sources/TokamakCore/Fiber/Fiber.swift
@@ -100,7 +100,10 @@ public extension FiberReconciler {
     /// Boxes that store `State` data.
     var state: [PropertyInfo: MutableStorage] = [:]
 
-    /// Subscribed `Cancellable`s
+    /// Subscribed `Cancellable`s keyed with the property contained the observable.
+    ///
+    /// Each time properties are bound, a new subscription could be created.
+    /// When the subscription is overridden, the old cancellable is released.
     var subscriptions: [PropertyInfo: AnyCancellable] = [:]
 
     /// Storage for `PreferenceKey` values as they are passed up the tree.

--- a/Sources/TokamakCore/Fiber/Fiber.swift
+++ b/Sources/TokamakCore/Fiber/Fiber.swift
@@ -85,7 +85,8 @@ public extension FiberReconciler {
     /// Parent references are `unowned` (as opposed to `weak`)
     /// because the parent will always exist if a child does.
     /// If the parent is released, the child is released with it.
-    unowned var parent: Fiber?
+    @_spi(TokamakCore)
+    public unowned var parent: Fiber?
 
     /// The nearest parent that can be mounted on.
     unowned var elementParent: Fiber?
@@ -109,7 +110,8 @@ public extension FiberReconciler {
     var geometry: ViewGeometry?
 
     /// The WIP node if this is current, or the current node if this is WIP.
-    weak var alternate: Fiber?
+    @_spi(TokamakCore)
+    public weak var alternate: Fiber?
 
     var createAndBindAlternate: (() -> Fiber?)?
 

--- a/Sources/TokamakCore/Fiber/FiberReconciler+TreeReducer.swift
+++ b/Sources/TokamakCore/Fiber/FiberReconciler+TreeReducer.swift
@@ -61,12 +61,13 @@ extension FiberReconciler {
       Self.reduce(
         into: &partialResult,
         nextValue: nextScene,
-        createFiber: { scene, element, parent, elementParent, _, _, reconciler in
+        createFiber: { scene, element, parent, elementParent, preferenceParent, _, _, reconciler in
           Fiber(
             &scene,
             element: element,
             parent: parent,
             elementParent: elementParent,
+            preferenceParent: preferenceParent,
             environment: nil,
             reconciler: reconciler
           )
@@ -82,12 +83,16 @@ extension FiberReconciler {
       Self.reduce(
         into: &partialResult,
         nextValue: nextView,
-        createFiber: { view, element, parent, elementParent, elementIndex, traits, reconciler in
+        createFiber: {
+          view, element,
+            parent, elementParent, preferenceParent, elementIndex,
+            traits, reconciler in
           Fiber(
             &view,
             element: element,
             parent: parent,
             elementParent: elementParent,
+            preferenceParent: preferenceParent,
             elementIndex: elementIndex,
             traits: traits,
             reconciler: reconciler
@@ -112,6 +117,7 @@ extension FiberReconciler {
       createFiber: (
         inout T,
         Renderer.ElementType?,
+        Fiber?,
         Fiber?,
         Fiber?,
         Int?,
@@ -154,6 +160,9 @@ extension FiberReconciler {
         let elementParent = partialResult.fiber?.element != nil
           ? partialResult.fiber
           : partialResult.fiber?.elementParent
+        let preferenceParent = partialResult.fiber?.preferences != nil
+          ? partialResult.fiber
+          : partialResult.fiber?.preferenceParent
         let key: ObjectIdentifier?
         if let elementParent = elementParent {
           key = ObjectIdentifier(elementParent)
@@ -166,6 +175,7 @@ extension FiberReconciler {
           partialResult.nextExistingAlternate?.element,
           partialResult.fiber,
           elementParent,
+          preferenceParent,
           key.map { partialResult.elementIndices[$0, default: 0] },
           partialResult.pendingTraits,
           partialResult.fiber?.reconciler

--- a/Sources/TokamakCore/Fiber/FiberReconciler.swift
+++ b/Sources/TokamakCore/Fiber/FiberReconciler.swift
@@ -182,7 +182,7 @@ public final class FiberReconciler<Renderer: FiberRenderer> {
         child: alternateRoot?.child,
         alternateChild: root.child,
         elementIndices: [:],
-        pendingTraits: .init()
+        nextTraits: .init()
       )
       reconciler.caches.clear()
       for pass in reconciler.passes {

--- a/Sources/TokamakCore/Fiber/FiberRenderer.swift
+++ b/Sources/TokamakCore/Fiber/FiberRenderer.swift
@@ -57,6 +57,11 @@ public protocol FiberRenderer {
     proposal: ProposedViewSize,
     in environment: EnvironmentValues
   ) -> CGSize
+
+  /// Run `action` on the next runloop.
+  ///
+  /// Called by the `FiberReconciler` to perform all reconciliation at once.
+  func schedule(_ action: @escaping () -> ())
 }
 
 public extension FiberRenderer {

--- a/Sources/TokamakCore/Fiber/FiberRenderer.swift
+++ b/Sources/TokamakCore/Fiber/FiberRenderer.swift
@@ -58,9 +58,31 @@ public protocol FiberRenderer {
     in environment: EnvironmentValues
   ) -> CGSize
 
-  /// Run `action` on the next runloop.
+  /// Run `action` on the next run loop.
   ///
-  /// Called by the `FiberReconciler` to perform all reconciliation at once.
+  /// Called by the `FiberReconciler` to perform reconciliation after all changed Fibers are collected.
+  ///
+  /// For example, take the following sample `View`:
+  ///
+  ///     struct DuelOfTheStates: View {
+  ///       @State private var hits1 = 0
+  ///       @State private var hits2 = 0
+  ///
+  ///       var body: some View {
+  ///         Button("Hit") {
+  ///           hits1 += 1
+  ///           hits2 += 2
+  ///         }
+  ///       }
+  ///     }
+  ///
+  /// When the button is pressed, both `hits1` and `hits2` are updated.
+  /// If reconciliation was done on every state change, we would needlessly run it twice,
+  /// once for `hits1` and again for `hits2`.
+  ///
+  /// Instead, we create a list of changed fibers
+  /// (in this case just `DuelOfTheStates` as both properties were on it),
+  /// and reconcile after all changes have been collected.
   func schedule(_ action: @escaping () -> ())
 }
 

--- a/Sources/TokamakCore/Fiber/Layout/LayoutSubviews.swift
+++ b/Sources/TokamakCore/Fiber/Layout/LayoutSubviews.swift
@@ -141,8 +141,9 @@ public struct LayoutSubview: Equatable {
           )
           cache.sizeThatFits[request] = size
           if let alternate = fiber.alternate {
-            caches.updateLayoutCache(for: alternate) { cache in
-              cache.sizeThatFits[request] = size
+            caches.updateLayoutCache(for: alternate) { alternateCache in
+              alternateCache.cache = cache.cache
+              alternateCache.sizeThatFits[request] = size
             }
           }
           return size
@@ -246,6 +247,6 @@ public struct LayoutSubview: Equatable {
   }
 
   public static func == (lhs: LayoutSubview, rhs: LayoutSubview) -> Bool {
-    lhs.id == rhs.id
+    lhs.storage === rhs.storage
   }
 }

--- a/Sources/TokamakCore/Fiber/Layout/StackLayout.swift
+++ b/Sources/TokamakCore/Fiber/Layout/StackLayout.swift
@@ -98,6 +98,7 @@ public extension StackLayout {
   }
 
   func updateCache(_ cache: inout Cache, subviews: Subviews) {
+    print("Update cache for \(subviews)")
     cache.maxSubview = nil
     // Ensure we have enough space in `idealSizes` for each subview.
     cache.idealSizes = Array(repeating: .zero, count: subviews.count)

--- a/Sources/TokamakCore/Fiber/Layout/StackLayout.swift
+++ b/Sources/TokamakCore/Fiber/Layout/StackLayout.swift
@@ -98,7 +98,6 @@ public extension StackLayout {
   }
 
   func updateCache(_ cache: inout Cache, subviews: Subviews) {
-    print("Update cache for \(subviews)")
     cache.maxSubview = nil
     // Ensure we have enough space in `idealSizes` for each subview.
     cache.idealSizes = Array(repeating: .zero, count: subviews.count)
@@ -118,7 +117,6 @@ public extension StackLayout {
 
     /// The aggregate minimum size of each `View` with a given priority.
     var prioritySize = [Double: CGFloat]()
-
     let measuredSubviews = subviews.enumerated().map { index, view -> MeasuredSubview in
       priorityCount[view.priority, default: 0] += 1
 

--- a/Sources/TokamakCore/Fiber/Passes/FiberReconcilerPass.swift
+++ b/Sources/TokamakCore/Fiber/Passes/FiberReconcilerPass.swift
@@ -61,9 +61,9 @@ extension FiberReconciler {
     }
 
     func clear() {
-      elementIndices = [:]
-      layoutSubviews = [:]
-      mutations = []
+      elementIndices.removeAll()
+      layoutSubviews.removeAll()
+      mutations.removeAll()
     }
 
     func layoutCache(for fiber: Fiber) -> LayoutCache? {
@@ -123,14 +123,14 @@ protocol FiberReconcilerPass {
   /// - Parameter root: The node to start the pass from.
   ///                   The top of the `View` hierarchy when `useDynamicLayout` is enabled.
   ///                   Otherwise, the same as `reconcileRoot`.
-  /// - Parameter reconcileRoot: The topmost node that needs reconciliation.
+  /// - Parameter reconcileRoot: A list of topmost nodes that need reconciliation.
   ///                            When `useDynamicLayout` is enabled, this can be used to limit
   ///                            the number of operations performed during reconciliation.
   /// - Parameter caches: The shared cache data for this and other passes.
   func run<R: FiberRenderer>(
     in reconciler: FiberReconciler<R>,
     root: FiberReconciler<R>.TreeReducer.Result,
-    reconcileRoot: FiberReconciler<R>.Fiber,
+    changedFibers: Set<ObjectIdentifier>,
     caches: FiberReconciler<R>.Caches
   )
 }

--- a/Sources/TokamakCore/Fiber/Passes/LayoutPass.swift
+++ b/Sources/TokamakCore/Fiber/Passes/LayoutPass.swift
@@ -22,7 +22,7 @@ struct LayoutPass: FiberReconcilerPass {
   func run<R>(
     in reconciler: FiberReconciler<R>,
     root: FiberReconciler<R>.TreeReducer.Result,
-    reconcileRoot: FiberReconciler<R>.Fiber,
+    changedFibers: Set<ObjectIdentifier>,
     caches: FiberReconciler<R>.Caches
   ) where R: FiberRenderer {
     guard let root = root.fiber else { return }

--- a/Sources/TokamakCore/Fiber/Passes/ReconcilePass.swift
+++ b/Sources/TokamakCore/Fiber/Passes/ReconcilePass.swift
@@ -131,6 +131,7 @@ struct ReconcilePass: FiberReconcilerPass {
         if let element = fiber.element,
            let elementParent = fiber.elementParent
         {
+          print("Add \(fiber) to \(elementParent)")
           let parentKey = ObjectIdentifier(elementParent)
           let subview = LayoutSubview(
             id: ObjectIdentifier(fiber),
@@ -190,15 +191,6 @@ struct ReconcilePass: FiberReconcilerPass {
         if let preferences = node.fiber?.preferences {
           node.fiber?.outputs.transformPreferences?(preferences)
           if let parentPreferences = node.fiber?.preferenceParent?.preferences {
-//              print(
-//                """
-//                === MERGE ===
-//                \(node.fiber!)
-//                    \(preferences)
-//                \(node.fiber!.preferenceParent!)
-//                    \(parentPreferences)
-//                """
-//              )
             parentPreferences.merge(preferences)
           }
           if let action = node.fiber?.outputs.preferenceAction {

--- a/Sources/TokamakCore/Fiber/Passes/ReconcilePass.swift
+++ b/Sources/TokamakCore/Fiber/Passes/ReconcilePass.swift
@@ -119,6 +119,8 @@ struct ReconcilePass: FiberReconcilerPass {
       node.elementIndices = caches.elementIndices
       node.pendingTraits = pendingTraits
 
+      // Update `DynamicProperty`s before accessing the `View`'s body.
+      node.fiber?.updateDynamicProperties()
       // Compute the children of the node.
       let reducer = FiberReconciler<R>.TreeReducer.SceneVisitor(initialResult: node)
       node.visitChildren(reducer)

--- a/Sources/TokamakCore/Fiber/Passes/ReconcilePass.swift
+++ b/Sources/TokamakCore/Fiber/Passes/ReconcilePass.swift
@@ -131,11 +131,10 @@ struct ReconcilePass: FiberReconcilerPass {
         if let element = fiber.element,
            let elementParent = fiber.elementParent
         {
-          print("Add \(fiber) to \(elementParent)")
           let parentKey = ObjectIdentifier(elementParent)
           let subview = LayoutSubview(
             id: ObjectIdentifier(fiber),
-            traits: node.fiber?.outputs.traits,
+            traits: fiber.outputs.traits,
             fiber: fiber,
             element: element,
             caches: caches

--- a/Sources/TokamakCore/Fiber/Passes/ReconcilePass.swift
+++ b/Sources/TokamakCore/Fiber/Passes/ReconcilePass.swift
@@ -179,12 +179,11 @@ struct ReconcilePass: FiberReconcilerPass {
         }
 
         if let preferences = node.fiber?.preferences {
-          node.fiber?.outputs.transformPreferences?(preferences)
-          if let parentPreferences = node.fiber?.preferenceParent?.preferences {
-            parentPreferences.merge(preferences)
-          }
           if let action = node.fiber?.outputs.preferenceAction {
             action(preferences)
+          }
+          if let parentPreferences = node.fiber?.preferenceParent?.preferences {
+            parentPreferences.merge(preferences)
           }
         }
 

--- a/Sources/TokamakCore/Fiber/ViewArguments.swift
+++ b/Sources/TokamakCore/Fiber/ViewArguments.swift
@@ -33,7 +33,9 @@ public struct ViewOutputs {
   /// This is stored as a reference to avoid copying the environment when unnecessary.
   let environment: EnvironmentBox
 
-  let preferences: _PreferenceStore
+  let transformPreferences: ((_PreferenceStore) -> ())?
+
+  let preferenceAction: ((_PreferenceStore) -> ())?
 
   let traits: _ViewTraitStore?
 }
@@ -51,13 +53,15 @@ public extension ViewOutputs {
   init<V>(
     inputs: ViewInputs<V>,
     environment: EnvironmentValues? = nil,
-    preferences: _PreferenceStore? = nil,
+    transformPreferences: ((_PreferenceStore) -> ())? = nil,
+    preferenceAction: ((_PreferenceStore) -> ())? = nil,
     traits: _ViewTraitStore? = nil
   ) {
     // Only replace the `EnvironmentBox` when we change the environment.
     // Otherwise the same box can be reused.
     self.environment = environment.map(EnvironmentBox.init) ?? inputs.environment
-    self.preferences = preferences ?? .init()
+    self.transformPreferences = transformPreferences
+    self.preferenceAction = preferenceAction
     self.traits = traits ?? inputs.traits
   }
 }

--- a/Sources/TokamakCore/Fiber/ViewArguments.swift
+++ b/Sources/TokamakCore/Fiber/ViewArguments.swift
@@ -21,6 +21,9 @@ import Foundation
 public struct ViewInputs<V> {
   public let content: V
 
+  /// Mutate the underlying content with the given inputs.
+  ///
+  /// Used to inject values such as environment values, traits, and preferences into the `View` type.
   public let updateContent: ((inout V) -> ()) -> ()
 
   @_spi(TokamakCore)
@@ -39,8 +42,9 @@ public struct ViewOutputs {
 
   let preferenceStore: _PreferenceStore?
 
-  let transformPreferences: ((_PreferenceStore) -> ())?
-
+  /// An action to perform after all preferences values have been reduced.
+  ///
+  /// Called when walking back up the tree in the `ReconcilePass`.
   let preferenceAction: ((_PreferenceStore) -> ())?
 
   let traits: _ViewTraitStore?
@@ -60,7 +64,6 @@ public extension ViewOutputs {
     inputs: ViewInputs<V>,
     environment: EnvironmentValues? = nil,
     preferenceStore: _PreferenceStore? = nil,
-    transformPreferences: ((_PreferenceStore) -> ())? = nil,
     preferenceAction: ((_PreferenceStore) -> ())? = nil,
     traits: _ViewTraitStore? = nil
   ) {
@@ -68,7 +71,6 @@ public extension ViewOutputs {
     // Otherwise the same box can be reused.
     self.environment = environment.map(EnvironmentBox.init) ?? inputs.environment
     self.preferenceStore = preferenceStore
-    self.transformPreferences = transformPreferences
     self.preferenceAction = preferenceAction
     self.traits = traits ?? inputs.traits
   }

--- a/Sources/TokamakCore/Fiber/walk.swift
+++ b/Sources/TokamakCore/Fiber/walk.swift
@@ -15,20 +15,23 @@
 //  Created by Carson Katri on 2/11/22.
 //
 
-enum WalkWorkResult<Success> {
+@_spi(TokamakCore)
+public enum WalkWorkResult<Success> {
   case `continue`
   case `break`(with: Success)
   case pause
 }
 
-enum WalkResult<Renderer: FiberRenderer, Success> {
+@_spi(TokamakCore)
+public enum WalkResult<Renderer: FiberRenderer, Success> {
   case success(Success)
   case finished
   case paused(at: FiberReconciler<Renderer>.Fiber)
 }
 
+@_spi(TokamakCore)
 @discardableResult
-func walk<Renderer: FiberRenderer>(
+public func walk<Renderer: FiberRenderer>(
   _ root: FiberReconciler<Renderer>.Fiber,
   _ work: @escaping (FiberReconciler<Renderer>.Fiber) throws -> Bool
 ) rethrows -> WalkResult<Renderer, ()> {
@@ -38,7 +41,8 @@ func walk<Renderer: FiberRenderer>(
 }
 
 /// Parent-first depth-first traversal of a `Fiber` tree.
-func walk<Renderer: FiberRenderer, Success>(
+@_spi(TokamakCore)
+public func walk<Renderer: FiberRenderer, Success>(
   _ root: FiberReconciler<Renderer>.Fiber,
   _ work: @escaping (FiberReconciler<Renderer>.Fiber) throws -> WalkWorkResult<Success>
 ) rethrows -> WalkResult<Renderer, Success> {

--- a/Sources/TokamakCore/Fiber/walk.swift
+++ b/Sources/TokamakCore/Fiber/walk.swift
@@ -29,6 +29,7 @@ public enum WalkResult<Renderer: FiberRenderer, Success> {
   case paused(at: FiberReconciler<Renderer>.Fiber)
 }
 
+/// Walk a fiber tree from `root` until the `work` predicate returns `false`.
 @_spi(TokamakCore)
 @discardableResult
 public func walk<Renderer: FiberRenderer>(
@@ -41,6 +42,15 @@ public func walk<Renderer: FiberRenderer>(
 }
 
 /// Parent-first depth-first traversal of a `Fiber` tree.
+/// `work` is called with each `Fiber` in the tree as they are entered.
+///
+/// Traversal uses the following process:
+/// 1. Perform work on the current `Fiber`.
+/// 2. If the `Fiber` has a child, repeat from (1) with the child.
+/// 3. If the `Fiber` does not have a sibling, walk up until we find a `Fiber` that does have one.
+/// 4. Walk across to the sibling.
+///
+/// When the `root` is reached, the loop exits.
 @_spi(TokamakCore)
 public func walk<Renderer: FiberRenderer, Success>(
   _ root: FiberReconciler<Renderer>.Fiber,

--- a/Sources/TokamakCore/Preferences/PreferenceKey.swift
+++ b/Sources/TokamakCore/Preferences/PreferenceKey.swift
@@ -79,9 +79,9 @@ public extension _PreferenceValue {
 
 public final class _PreferenceStore: CustomDebugStringConvertible {
   /// The values of the `_PreferenceStore` on the last update.
-  private var previousValues: [String: _PreferenceValueStorage]
+  private var previousValues: [ObjectIdentifier: _PreferenceValueStorage]
   /// The backing values of the `_PreferenceStore`.
-  private var values: [String: _PreferenceValueStorage]
+  private var values: [ObjectIdentifier: _PreferenceValueStorage]
 
   weak var parent: _PreferenceStore?
 
@@ -89,7 +89,7 @@ public final class _PreferenceStore: CustomDebugStringConvertible {
     "Preferences (\(ObjectIdentifier(self))): \(values)"
   }
 
-  init(values: [String: _PreferenceValueStorage] = [:]) {
+  init(values: [ObjectIdentifier: _PreferenceValueStorage] = [:]) {
     previousValues = [:]
     self.values = values
   }
@@ -98,12 +98,13 @@ public final class _PreferenceStore: CustomDebugStringConvertible {
   public func value<Key>(forKey key: Key.Type = Key.self) -> _PreferenceValue<Key>
     where Key: PreferenceKey
   {
+    let keyID = ObjectIdentifier(key)
     let storage: _PreferenceValueStorage
-    if let existing = values[String(reflecting: key)] {
+    if let existing = values[keyID] {
       storage = existing
     } else {
       storage = .init(key)
-      values[String(reflecting: key)] = storage
+      values[keyID] = storage
     }
     return _PreferenceValue(storage: storage)
   }
@@ -114,16 +115,17 @@ public final class _PreferenceStore: CustomDebugStringConvertible {
   func previousValue<Key>(forKey key: Key.Type = Key.self) -> _PreferenceValue<Key>
     where Key: PreferenceKey
   {
-    _PreferenceValue(storage: previousValues[String(reflecting: key)] ?? .init(key))
+    _PreferenceValue(storage: previousValues[ObjectIdentifier(key)] ?? .init(key))
   }
 
   public func insert<Key>(_ value: Key.Value, forKey key: Key.Type = Key.self)
     where Key: PreferenceKey
   {
-    if !values.keys.contains(String(reflecting: key)) {
-      values[String(reflecting: key)] = .init(key)
+    let keyID = ObjectIdentifier(key)
+    if !values.keys.contains(keyID) {
+      values[keyID] = .init(key)
     }
-    values[String(reflecting: key)]?.valueList.append(value)
+    values[keyID]?.valueList.append(value)
     parent?.insert(value, forKey: key)
   }
 

--- a/Sources/TokamakCore/Preferences/PreferenceKey.swift
+++ b/Sources/TokamakCore/Preferences/PreferenceKey.swift
@@ -78,6 +78,7 @@ public extension _PreferenceValue {
 }
 
 public final class _PreferenceStore: CustomDebugStringConvertible {
+  /// The values of the `_PreferenceStore` on the last update.
   private var previousValues: [String: _PreferenceValueStorage]
   /// The backing values of the `_PreferenceStore`.
   private var values: [String: _PreferenceValueStorage]
@@ -93,6 +94,7 @@ public final class _PreferenceStore: CustomDebugStringConvertible {
     self.values = values
   }
 
+  /// Retrieve a late-binding token for `key`, or save the default value if it does not yet exist.
   public func value<Key>(forKey key: Key.Type = Key.self) -> _PreferenceValue<Key>
     where Key: PreferenceKey
   {
@@ -106,6 +108,9 @@ public final class _PreferenceStore: CustomDebugStringConvertible {
     return _PreferenceValue(storage: storage)
   }
 
+  /// Retrieve the value `Key` had on the last update.
+  ///
+  /// Used to check if the value changed during the last update.
   func previousValue<Key>(forKey key: Key.Type = Key.self) -> _PreferenceValue<Key>
     where Key: PreferenceKey
   {
@@ -132,6 +137,10 @@ public final class _PreferenceStore: CustomDebugStringConvertible {
     }
   }
 
+  /// Copies `values` to `previousValues`, and clears `values`.
+  ///
+  /// Each reconcile pass the preferences are collected from scratch, so we need to
+  /// clear out the old values.
   func reset() {
     previousValues = values.mapValues {
       _PreferenceValueStorage(valueList: $0.valueList)

--- a/Sources/TokamakCore/Preferences/_PreferenceActionModifier.swift
+++ b/Sources/TokamakCore/Preferences/_PreferenceActionModifier.swift
@@ -25,7 +25,7 @@ public struct _PreferenceActionModifier<Key>: _PreferenceWritingModifierProtocol
 
   public func body(_ content: Content, with preferenceStore: inout _PreferenceStore) -> AnyView {
     let value = preferenceStore.value(forKey: Key.self)
-    let previousValue = value.reduce(value.valueList.dropLast())
+    let previousValue = value.reduce((value.storage.valueList as? [Key.Value] ?? []).dropLast())
     if previousValue != value.value {
       action(value.value)
     }
@@ -35,11 +35,12 @@ public struct _PreferenceActionModifier<Key>: _PreferenceWritingModifierProtocol
   public static func _makeView(_ inputs: ViewInputs<Self>) -> ViewOutputs {
     .init(
       inputs: inputs,
+      preferenceStore: inputs.preferenceStore ?? .init(),
       preferenceAction: {
-        let value = $0.value(forKey: Key.self)
-        let previousValue = value.reduce(value.valueList.dropLast())
-        if previousValue != value.value {
-          inputs.content.action(value.value)
+        let value = $0.value(forKey: Key.self).value
+        let previousValue = $0.previousValue(forKey: Key.self).value
+        if value != previousValue {
+          inputs.content.action(value)
         }
       }
     )

--- a/Sources/TokamakCore/Preferences/_PreferenceActionModifier.swift
+++ b/Sources/TokamakCore/Preferences/_PreferenceActionModifier.swift
@@ -31,6 +31,19 @@ public struct _PreferenceActionModifier<Key>: _PreferenceWritingModifierProtocol
     }
     return content.view
   }
+
+  public static func _makeView(_ inputs: ViewInputs<Self>) -> ViewOutputs {
+    .init(
+      inputs: inputs,
+      preferenceAction: {
+        let value = $0.value(forKey: Key.self)
+        let previousValue = value.reduce(value.valueList.dropLast())
+        if previousValue != value.value {
+          inputs.content.action(value.value)
+        }
+      }
+    )
+  }
 }
 
 public extension View {

--- a/Sources/TokamakCore/Preferences/_PreferenceTransformModifier.swift
+++ b/Sources/TokamakCore/Preferences/_PreferenceTransformModifier.swift
@@ -39,7 +39,7 @@ public struct _PreferenceTransformModifier<Key>: _PreferenceWritingModifierProto
     .init(
       inputs: inputs,
       preferenceStore: inputs.preferenceStore ?? .init(),
-      transformPreferences: {
+      preferenceAction: {
         var value = $0.value(forKey: Key.self).value
         inputs.content.transform(&value)
         $0.insert(value, forKey: Key.self)

--- a/Sources/TokamakCore/Preferences/_PreferenceTransformModifier.swift
+++ b/Sources/TokamakCore/Preferences/_PreferenceTransformModifier.swift
@@ -34,6 +34,17 @@ public struct _PreferenceTransformModifier<Key>: _PreferenceWritingModifierProto
     preferenceStore.insert(newValue, forKey: Key.self)
     return content.view
   }
+
+  public static func _makeView(_ inputs: ViewInputs<Self>) -> ViewOutputs {
+    .init(
+      inputs: inputs,
+      transformPreferences: {
+        var value = $0.value(forKey: Key.self).value
+        inputs.content.transform(&value)
+        $0.insert(value, forKey: Key.self)
+      }
+    )
+  }
 }
 
 public extension View {

--- a/Sources/TokamakCore/Preferences/_PreferenceTransformModifier.swift
+++ b/Sources/TokamakCore/Preferences/_PreferenceTransformModifier.swift
@@ -38,6 +38,7 @@ public struct _PreferenceTransformModifier<Key>: _PreferenceWritingModifierProto
   public static func _makeView(_ inputs: ViewInputs<Self>) -> ViewOutputs {
     .init(
       inputs: inputs,
+      preferenceStore: inputs.preferenceStore ?? .init(),
       transformPreferences: {
         var value = $0.value(forKey: Key.self).value
         inputs.content.transform(&value)

--- a/Sources/TokamakCore/Preferences/_PreferenceWritingModifier.swift
+++ b/Sources/TokamakCore/Preferences/_PreferenceWritingModifier.swift
@@ -31,6 +31,7 @@ public struct _PreferenceWritingModifier<Key>: _PreferenceWritingModifierProtoco
   public static func _makeView(_ inputs: ViewInputs<Self>) -> ViewOutputs {
     .init(
       inputs: inputs,
+      preferenceStore: inputs.preferenceStore ?? .init(),
       transformPreferences: { $0.insert(inputs.content.value, forKey: Key.self) }
     )
   }

--- a/Sources/TokamakCore/Preferences/_PreferenceWritingModifier.swift
+++ b/Sources/TokamakCore/Preferences/_PreferenceWritingModifier.swift
@@ -32,7 +32,7 @@ public struct _PreferenceWritingModifier<Key>: _PreferenceWritingModifierProtoco
     .init(
       inputs: inputs,
       preferenceStore: inputs.preferenceStore ?? .init(),
-      transformPreferences: { $0.insert(inputs.content.value, forKey: Key.self) }
+      preferenceAction: { $0.insert(inputs.content.value, forKey: Key.self) }
     )
   }
 }

--- a/Sources/TokamakCore/Preferences/_PreferenceWritingModifier.swift
+++ b/Sources/TokamakCore/Preferences/_PreferenceWritingModifier.swift
@@ -27,6 +27,13 @@ public struct _PreferenceWritingModifier<Key>: _PreferenceWritingModifierProtoco
     preferenceStore.insert(value, forKey: Key.self)
     return content.view
   }
+
+  public static func _makeView(_ inputs: ViewInputs<Self>) -> ViewOutputs {
+    .init(
+      inputs: inputs,
+      transformPreferences: { $0.insert(inputs.content.value, forKey: Key.self) }
+    )
+  }
 }
 
 extension _PreferenceWritingModifier: Equatable where Key.Value: Equatable {

--- a/Sources/TokamakDOM/Core.swift
+++ b/Sources/TokamakDOM/Core.swift
@@ -182,8 +182,15 @@ public typealias View = TokamakCore.View
 public typealias AnyView = TokamakCore.AnyView
 public typealias EmptyView = TokamakCore.EmptyView
 
+// MARK: Layout
+
 public typealias Layout = TokamakCore.Layout
 public typealias AnyLayout = TokamakCore.AnyLayout
+public typealias LayoutProperties = TokamakCore.LayoutProperties
+public typealias LayoutSubviews = TokamakCore.LayoutSubviews
+public typealias LayoutSubview = TokamakCore.LayoutSubview
+public typealias ProposedViewSize = TokamakCore.ProposedViewSize
+public typealias ViewSpacing = TokamakCore.ViewSpacing
 
 // MARK: Toolbars
 

--- a/Sources/TokamakDOM/Core.swift
+++ b/Sources/TokamakDOM/Core.swift
@@ -189,6 +189,7 @@ public typealias AnyLayout = TokamakCore.AnyLayout
 public typealias LayoutProperties = TokamakCore.LayoutProperties
 public typealias LayoutSubviews = TokamakCore.LayoutSubviews
 public typealias LayoutSubview = TokamakCore.LayoutSubview
+public typealias LayoutValueKey = TokamakCore.LayoutValueKey
 public typealias ProposedViewSize = TokamakCore.ProposedViewSize
 public typealias ViewSpacing = TokamakCore.ViewSpacing
 

--- a/Sources/TokamakDOM/Core.swift
+++ b/Sources/TokamakDOM/Core.swift
@@ -19,6 +19,8 @@ import TokamakCore
 
 // MARK: Environment & State
 
+public typealias DynamicProperty = TokamakCore.DynamicProperty
+
 public typealias Environment = TokamakCore.Environment
 public typealias EnvironmentKey = TokamakCore.EnvironmentKey
 public typealias EnvironmentObject = TokamakCore.EnvironmentObject

--- a/Sources/TokamakDOM/DOMFiberRenderer.swift
+++ b/Sources/TokamakDOM/DOMFiberRenderer.swift
@@ -89,6 +89,8 @@ public struct DOMFiberRenderer: FiberRenderer {
   public var defaultEnvironment: EnvironmentValues {
     var environment = EnvironmentValues()
     environment[_ColorSchemeKey.self] = .light
+    environment._defaultAppStorage = LocalStorage.standard
+    _DefaultSceneStorageProvider.default = SessionStorage.standard
     return environment
   }
 

--- a/Sources/TokamakDOM/DOMFiberRenderer.swift
+++ b/Sources/TokamakDOM/DOMFiberRenderer.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import JavaScriptKit
+import OpenCombineJS
 @_spi(TokamakCore)
 import TokamakCore
 @_spi(TokamakStaticHTML)
@@ -302,6 +303,11 @@ public struct DOMFiberRenderer: FiberRenderer {
         apply(geometry, to: element)
       }
     }
+  }
+
+  private let scheduler = JSScheduler()
+  public func schedule(_ action: @escaping () -> ()) {
+    scheduler.schedule(options: nil, action)
   }
 }
 

--- a/Sources/TokamakDOM/DOMFiberRenderer.swift
+++ b/Sources/TokamakDOM/DOMFiberRenderer.swift
@@ -117,6 +117,10 @@ public struct DOMFiberRenderer: FiberRenderer {
       _ = reference.style.setProperty("width", "100vw")
       _ = reference.style.setProperty("height", "100vh")
       _ = reference.style.setProperty("position", "relative")
+    } else {
+      let style = document.createElement!("style").object!
+      style.innerHTML = .string(TokamakStaticHTML.tokamakStyles)
+      _ = document.head.appendChild(style)
     }
   }
 

--- a/Sources/TokamakDOM/Storage/WebStorage.swift
+++ b/Sources/TokamakDOM/Storage/WebStorage.swift
@@ -73,6 +73,6 @@ extension WebStorage {
   }
 
   public func read(key: String) -> String? {
-    getItem(key: key, { $0 })
+    getItem(key: key) { $0 }
   }
 }

--- a/Sources/TokamakStaticHTML/StaticHTMLFiberRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLFiberRenderer.swift
@@ -253,4 +253,14 @@ public struct StaticHTMLFiberRenderer: FiberRenderer {
     </html>
     """
   }
+
+  public func schedule(_ action: @escaping () -> ()) {
+    #if canImport(Dispatch)
+    DispatchQueue.main.async {
+      action()
+    }
+    #else
+    fatalError("`schedule` requires Dispatch.")
+    #endif
+  }
 }

--- a/Sources/TokamakStaticHTML/StaticHTMLFiberRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLFiberRenderer.swift
@@ -255,12 +255,6 @@ public struct StaticHTMLFiberRenderer: FiberRenderer {
   }
 
   public func schedule(_ action: @escaping () -> ()) {
-    #if canImport(Dispatch)
-    DispatchQueue.main.async {
-      action()
-    }
-    #else
-    fatalError("`schedule` requires Dispatch.")
-    #endif
+    action()
   }
 }

--- a/Sources/TokamakTestRenderer/TestFiberRenderer.swift
+++ b/Sources/TokamakTestRenderer/TestFiberRenderer.swift
@@ -178,8 +178,6 @@ public struct TestFiberRenderer: FiberRenderer {
   }
 
   public func schedule(_ action: @escaping () -> ()) {
-    DispatchQueue.main.async {
-      action()
-    }
+    action()
   }
 }

--- a/Sources/TokamakTestRenderer/TestFiberRenderer.swift
+++ b/Sources/TokamakTestRenderer/TestFiberRenderer.swift
@@ -177,6 +177,7 @@ public struct TestFiberRenderer: FiberRenderer {
     }
   }
 
+  #if canImport(Dispatch)
   public final class WorkItemBox {
     public var workItem: DispatchWorkItem?
   }
@@ -191,4 +192,9 @@ public struct TestFiberRenderer: FiberRenderer {
     DispatchQueue.global(qos: .default).async(execute: workItem)
     self.workItem.workItem = workItem
   }
+  #else
+  public func schedule(_ action: @escaping () -> ()) {
+    action()
+  }
+  #endif
 }

--- a/Sources/TokamakTestRenderer/TestFiberRenderer.swift
+++ b/Sources/TokamakTestRenderer/TestFiberRenderer.swift
@@ -177,7 +177,13 @@ public struct TestFiberRenderer: FiberRenderer {
     }
   }
 
+  /// The actively scheduled `DispatchWorkItem`
+  public static var workItem: DispatchWorkItem?
   public func schedule(_ action: @escaping () -> ()) {
-    action()
+    let workItem = DispatchWorkItem {
+      action()
+    }
+    DispatchQueue.global(qos: .default).async(execute: workItem)
+    Self.workItem = workItem
   }
 }

--- a/Sources/TokamakTestRenderer/TestFiberRenderer.swift
+++ b/Sources/TokamakTestRenderer/TestFiberRenderer.swift
@@ -177,13 +177,18 @@ public struct TestFiberRenderer: FiberRenderer {
     }
   }
 
+  public final class WorkItemBox {
+    public var workItem: DispatchWorkItem?
+  }
+
   /// The actively scheduled `DispatchWorkItem`
-  public static var workItem: DispatchWorkItem?
+  public var workItem: WorkItemBox = .init()
+
   public func schedule(_ action: @escaping () -> ()) {
     let workItem = DispatchWorkItem {
       action()
     }
     DispatchQueue.global(qos: .default).async(execute: workItem)
-    Self.workItem = workItem
+    self.workItem.workItem = workItem
   }
 }

--- a/Sources/TokamakTestRenderer/TestFiberRenderer.swift
+++ b/Sources/TokamakTestRenderer/TestFiberRenderer.swift
@@ -177,24 +177,7 @@ public struct TestFiberRenderer: FiberRenderer {
     }
   }
 
-  #if canImport(Dispatch) && !os(WASI)
-  public final class WorkItemBox {
-    public var workItem: DispatchWorkItem?
-  }
-
-  /// The actively scheduled `DispatchWorkItem`
-  public var workItem: WorkItemBox = .init()
-
-  public func schedule(_ action: @escaping () -> ()) {
-    let workItem = DispatchWorkItem {
-      action()
-    }
-    DispatchQueue.global(qos: .default).async(execute: workItem)
-    self.workItem.workItem = workItem
-  }
-  #else
   public func schedule(_ action: @escaping () -> ()) {
     action()
   }
-  #endif
 }

--- a/Sources/TokamakTestRenderer/TestFiberRenderer.swift
+++ b/Sources/TokamakTestRenderer/TestFiberRenderer.swift
@@ -176,4 +176,10 @@ public struct TestFiberRenderer: FiberRenderer {
       }
     }
   }
+
+  public func schedule(_ action: @escaping () -> ()) {
+    DispatchQueue.main.async {
+      action()
+    }
+  }
 }

--- a/Sources/TokamakTestRenderer/TestFiberRenderer.swift
+++ b/Sources/TokamakTestRenderer/TestFiberRenderer.swift
@@ -177,7 +177,7 @@ public struct TestFiberRenderer: FiberRenderer {
     }
   }
 
-  #if canImport(Dispatch)
+  #if canImport(Dispatch) && !os(WASI)
   public final class WorkItemBox {
     public var workItem: DispatchWorkItem?
   }

--- a/Sources/TokamakTestRenderer/TestViewProxy.swift
+++ b/Sources/TokamakTestRenderer/TestViewProxy.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Tokamak contributors
+// Copyright 2022 Tokamak contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/TokamakTestRenderer/TestViewProxy.swift
+++ b/Sources/TokamakTestRenderer/TestViewProxy.swift
@@ -1,4 +1,4 @@
-// Copyright 2021 Tokamak contributors
+// Copyright 2020 Tokamak contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,19 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-//  Created by Carson Katri on 6/29/22.
+//  Created by Carson Katri on 6/30/22.
 //
 
+import Foundation
 @_spi(TokamakCore)
 import TokamakCore
 
-import TokamakTestRenderer
-
+/// A proxy for an identified view in the `TestFiberRenderer`.
+///
+/// The properties are evaluated on access,
+/// so you will never unintentionally access an `alternate` value.
 @dynamicMemberLookup
-struct TestViewProxy<V: View> {
+public struct TestViewProxy<V: View> {
+  /// The id to lookup.
   let id: AnyHashable
+
+  /// The active reconciler instance to search in.
   let reconciler: FiberReconciler<TestFiberRenderer>
-  var fiber: FiberReconciler<TestFiberRenderer>.Fiber? {
+
+  /// Searches for a `Fiber` representing `id`.
+  ///
+  /// - Note: This returns the child of the `identified(by:)` modifier,
+  ///         not the `IdentifiedView` itself.
+  @_spi(TokamakCore)
+  public var fiber: FiberReconciler<TestFiberRenderer>.Fiber? {
     let id = AnyHashable(id)
     let result = TokamakCore.walk(
       reconciler.current
@@ -40,20 +52,24 @@ struct TestViewProxy<V: View> {
     return fiber
   }
 
-  var view: V? {
+  /// The `fiber`'s content casted to `V`.
+  public var view: V? {
     guard case let .view(view, _) = fiber?.content else { return nil }
     return view as? V
   }
 
-  subscript<T>(dynamicMember member: KeyPath<V, T>) -> T? {
+  /// Access properties from the `view` without specifying `.view` manually.
+  public subscript<T>(dynamicMember member: KeyPath<V, T>) -> T? {
     self.view?[keyPath: member]
   }
 }
 
+/// An erased `IdentifiedView`.
 protocol IdentifiedViewProtocol {
   var id: AnyHashable { get }
 }
 
+/// A wrapper that identifies a `View` in a test.
 struct IdentifiedView<Content: View>: View, IdentifiedViewProtocol {
   let id: AnyHashable
   let content: Content
@@ -63,13 +79,20 @@ struct IdentifiedView<Content: View>: View, IdentifiedViewProtocol {
   }
 }
 
-extension View {
+public extension View {
+  /// Identifies a `View` in a test.
+  ///
+  /// You can access this view from the `FiberReconciler` with `findView(id:as:)`.
   func identified<ID: Hashable>(by id: ID) -> some View {
     IdentifiedView(id: id, content: self)
   }
 }
 
-extension FiberReconciler where Renderer == TestFiberRenderer {
+public extension FiberReconciler where Renderer == TestFiberRenderer {
+  /// Find the `View` identified by `ID`.
+  ///
+  /// - Note: This returns a proxy to the child of the `identified(by:)` modifier,
+  ///         not the `IdentifiedView` itself.
   func findView<ID: Hashable, V: View>(
     id: ID,
     as type: V.Type = V.self

--- a/Sources/TokamakTestRenderer/TestViewProxy.swift
+++ b/Sources/TokamakTestRenderer/TestViewProxy.swift
@@ -16,6 +16,7 @@
 //
 
 import Foundation
+
 @_spi(TokamakCore)
 import TokamakCore
 

--- a/Tests/TokamakReconcilerTests/PreferenceTests.swift
+++ b/Tests/TokamakReconcilerTests/PreferenceTests.swift
@@ -41,7 +41,9 @@ final class PreferenceTests: XCTestCase {
     }
     let reconciler = TestFiberRenderer(.root, size: .init(width: 500, height: 500))
       .render(TestView())
+    reconciler.turnRunLoop()
     reconciler.fiberChanged(reconciler.current)
+    reconciler.turnRunLoop()
   }
 
   func testOverlay() {
@@ -52,25 +54,16 @@ final class PreferenceTests: XCTestCase {
           .preference(key: TestKey.self, value: 3)
           .overlayPreferenceValue(TestKey.self) {
             Text("\($0)")
+              .identified(by: "overlay")
           }
       }
     }
 
     let reconciler = TestFiberRenderer(.root, size: .init(width: 500, height: 500))
       .render(TestView())
-    var overlayValue: FiberReconciler<TestFiberRenderer>.Fiber? {
-      reconciler.current // RootView
-        .child? // LayoutView
-        .child? // ModifiedContent
-        .child? // _ViewModifier_Content
-        .child? // TestView
-        .child? // _DelayedPreferenceView
-        .child? // ModifiedContent
-        .child? // _OverlayLayout
-        .child?.sibling? // _PreferenceReadingView
-        .child
-    }
 
-    reconciler.expect(overlayValue, equals: Text("5"))
+    reconciler.turnRunLoop()
+
+    XCTAssertEqual(reconciler.findView(id: "overlay").view, Text("5"))
   }
 }

--- a/Tests/TokamakReconcilerTests/PreferenceTests.swift
+++ b/Tests/TokamakReconcilerTests/PreferenceTests.swift
@@ -1,0 +1,76 @@
+// Copyright 2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 6/29/22.
+//
+
+import XCTest
+
+@_spi(TokamakCore) @testable import TokamakCore
+import TokamakTestRenderer
+
+private enum TestKey: PreferenceKey {
+  static let defaultValue: Int = 0
+  static func reduce(value: inout Int, nextValue: () -> Int) {
+    value += nextValue()
+  }
+}
+
+final class PreferenceTests: XCTestCase {
+  func testPreferenceAction() {
+    struct TestView: View {
+      public var body: some View {
+        Text("")
+          .preference(key: TestKey.self, value: 2)
+          .preference(key: TestKey.self, value: 3)
+          .onPreferenceChange(TestKey.self) {
+            XCTAssertEqual($0, 5)
+          }
+      }
+    }
+    let reconciler = TestFiberRenderer(.root, size: .init(width: 500, height: 500))
+      .render(TestView())
+    reconciler.fiberChanged(reconciler.current)
+  }
+
+  func testOverlay() {
+    struct TestView: View {
+      var body: some View {
+        Text("")
+          .preference(key: TestKey.self, value: 2)
+          .preference(key: TestKey.self, value: 3)
+          .overlayPreferenceValue(TestKey.self) {
+            Text("\($0)")
+          }
+      }
+    }
+
+    let reconciler = TestFiberRenderer(.root, size: .init(width: 500, height: 500))
+      .render(TestView())
+    var overlayValue: FiberReconciler<TestFiberRenderer>.Fiber? {
+      reconciler.current // RootView
+        .child? // LayoutView
+        .child? // ModifiedContent
+        .child? // _ViewModifier_Content
+        .child? // TestView
+        .child? // _DelayedPreferenceView
+        .child? // ModifiedContent
+        .child? // _OverlayLayout
+        .child?.sibling? // _PreferenceReadingView
+        .child
+    }
+
+    reconciler.expect(overlayValue, equals: Text("5"))
+  }
+}

--- a/Tests/TokamakReconcilerTests/PreferenceTests.swift
+++ b/Tests/TokamakReconcilerTests/PreferenceTests.swift
@@ -41,9 +41,7 @@ final class PreferenceTests: XCTestCase {
     }
     let reconciler = TestFiberRenderer(.root, size: .init(width: 500, height: 500))
       .render(TestView())
-    reconciler.turnRunLoop()
     reconciler.fiberChanged(reconciler.current)
-    reconciler.turnRunLoop()
   }
 
   func testOverlay() {
@@ -61,8 +59,6 @@ final class PreferenceTests: XCTestCase {
 
     let reconciler = TestFiberRenderer(.root, size: .init(width: 500, height: 500))
       .render(TestView())
-
-    reconciler.turnRunLoop()
 
     XCTAssertEqual(reconciler.findView(id: "overlay").view, Text("5"))
   }

--- a/Tests/TokamakReconcilerTests/TestViewProxy.swift
+++ b/Tests/TokamakReconcilerTests/TestViewProxy.swift
@@ -1,0 +1,87 @@
+// Copyright 2021 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 6/29/22.
+//
+
+@_spi(TokamakCore)
+import TokamakCore
+
+import TokamakTestRenderer
+
+import Dispatch
+
+@dynamicMemberLookup
+struct TestViewProxy<V: View> {
+  let id: AnyHashable
+  let reconciler: FiberReconciler<TestFiberRenderer>
+  var fiber: FiberReconciler<TestFiberRenderer>.Fiber? {
+    let id = AnyHashable(id)
+    let result = TokamakCore.walk(
+      reconciler.current
+    ) { fiber -> WalkWorkResult<FiberReconciler<TestFiberRenderer>.Fiber?> in
+      guard case let .view(view, _) = fiber.content,
+            !(view is AnyOptional),
+            (view as? IdentifiedViewProtocol)?.id == AnyHashable(id),
+            let child = fiber.child
+      else { return WalkWorkResult.continue }
+      return WalkWorkResult.break(with: child)
+    }
+    guard case let .success(fiber) = result else { return nil }
+    return fiber
+  }
+
+  var view: V? {
+    guard case let .view(view, _) = fiber?.content else { return nil }
+    return view as? V
+  }
+
+  subscript<T>(dynamicMember member: KeyPath<V, T>) -> T? {
+    self.view?[keyPath: member]
+  }
+}
+
+protocol IdentifiedViewProtocol {
+  var id: AnyHashable { get }
+}
+
+struct IdentifiedView<Content: View>: View, IdentifiedViewProtocol {
+  let id: AnyHashable
+  let content: Content
+
+  var body: some View {
+    content
+  }
+}
+
+extension View {
+  func identified<ID: Hashable>(by id: ID) -> some View {
+    IdentifiedView(id: id, content: self)
+  }
+}
+
+extension FiberReconciler where Renderer == TestFiberRenderer {
+  func findView<ID: Hashable, V: View>(
+    id: ID,
+    as type: V.Type = V.self
+  ) -> TestViewProxy<V> {
+    TestViewProxy<V>(id: id, reconciler: self)
+  }
+
+  /// Wait for the scheduled action to complete.
+  func turnRunLoop() {
+    TestFiberRenderer.workItem?.wait()
+    TestFiberRenderer.workItem = nil
+  }
+}

--- a/Tests/TokamakReconcilerTests/TestViewProxy.swift
+++ b/Tests/TokamakReconcilerTests/TestViewProxy.swift
@@ -81,7 +81,7 @@ extension FiberReconciler where Renderer == TestFiberRenderer {
 
   /// Wait for the scheduled action to complete.
   func turnRunLoop() {
-    TestFiberRenderer.workItem?.wait()
-    TestFiberRenderer.workItem = nil
+    renderer.workItem.workItem?.wait()
+    renderer.workItem.workItem = nil
   }
 }

--- a/Tests/TokamakReconcilerTests/TestViewProxy.swift
+++ b/Tests/TokamakReconcilerTests/TestViewProxy.swift
@@ -20,7 +20,9 @@ import TokamakCore
 
 import TokamakTestRenderer
 
+#if canImport(Dispatch)
 import Dispatch
+#endif
 
 @dynamicMemberLookup
 struct TestViewProxy<V: View> {
@@ -81,7 +83,10 @@ extension FiberReconciler where Renderer == TestFiberRenderer {
 
   /// Wait for the scheduled action to complete.
   func turnRunLoop() {
+    #if canImport(Dispatch)
     renderer.workItem.workItem?.wait()
     renderer.workItem.workItem = nil
+    #else
+    #endif
   }
 }

--- a/Tests/TokamakReconcilerTests/TestViewProxy.swift
+++ b/Tests/TokamakReconcilerTests/TestViewProxy.swift
@@ -20,10 +20,6 @@ import TokamakCore
 
 import TokamakTestRenderer
 
-#if canImport(Dispatch) && !os(WASI)
-import Dispatch
-#endif
-
 @dynamicMemberLookup
 struct TestViewProxy<V: View> {
   let id: AnyHashable
@@ -79,14 +75,5 @@ extension FiberReconciler where Renderer == TestFiberRenderer {
     as type: V.Type = V.self
   ) -> TestViewProxy<V> {
     TestViewProxy<V>(id: id, reconciler: self)
-  }
-
-  /// Wait for the scheduled action to complete.
-  func turnRunLoop() {
-    #if canImport(Dispatch) && !os(WASI)
-    renderer.workItem.workItem?.wait()
-    renderer.workItem.workItem = nil
-    #else
-    #endif
   }
 }

--- a/Tests/TokamakReconcilerTests/TestViewProxy.swift
+++ b/Tests/TokamakReconcilerTests/TestViewProxy.swift
@@ -83,7 +83,7 @@ extension FiberReconciler where Renderer == TestFiberRenderer {
 
   /// Wait for the scheduled action to complete.
   func turnRunLoop() {
-    #if canImport(Dispatch)
+    #if canImport(Dispatch) && !os(WASI)
     renderer.workItem.workItem?.wait()
     renderer.workItem.workItem = nil
     #else

--- a/Tests/TokamakReconcilerTests/TestViewProxy.swift
+++ b/Tests/TokamakReconcilerTests/TestViewProxy.swift
@@ -20,7 +20,7 @@ import TokamakCore
 
 import TokamakTestRenderer
 
-#if canImport(Dispatch)
+#if canImport(Dispatch) && !os(WASI)
 import Dispatch
 #endif
 

--- a/Tests/TokamakReconcilerTests/VisitorTests.swift
+++ b/Tests/TokamakReconcilerTests/VisitorTests.swift
@@ -221,6 +221,9 @@ final class VisitorTests: XCTestCase {
     )
     XCTAssertEqual(stateObjectButton.label, Text("0"))
     stateObjectButton.action?()
+    #if !canImport(Dispatch)
+    stateObjectButton.action?()
+    #endif
     reconciler.turnRunLoop()
     XCTAssertEqual(stateObjectButton.label, Text("5"))
 

--- a/Tests/TokamakReconcilerTests/VisitorTests.swift
+++ b/Tests/TokamakReconcilerTests/VisitorTests.swift
@@ -41,7 +41,6 @@ final class VisitorTests: XCTestCase {
               if count < 5 {
                 Button("Increment") {
                   count += 1
-                  print(count)
                 }
                 .identified(by: "increment")
               }
@@ -56,8 +55,6 @@ final class VisitorTests: XCTestCase {
     }
     let reconciler = TestFiberRenderer(.root, size: .zero).render(TestView())
 
-    reconciler.turnRunLoop()
-
     let incrementButton = reconciler.findView(id: "increment", as: Button<Text>.self)
     let countText = reconciler.findView(id: "count", as: Text.self)
     let decrementButton = reconciler.findView(id: "decrement", as: Button<Text>.self)
@@ -68,7 +65,6 @@ final class VisitorTests: XCTestCase {
     for i in 0..<5 {
       XCTAssertEqual(countText.view, Text("\(i)"))
       incrementButton.action?()
-      reconciler.turnRunLoop()
     }
     XCTAssertNil(incrementButton.view, "'Increment' should be hidden when count >= 5")
     XCTAssertNotNil(decrementButton.view, "'Decrement' should be visible when count > 0")
@@ -76,7 +72,6 @@ final class VisitorTests: XCTestCase {
     for i in 0..<5 {
       XCTAssertEqual(countText.view, Text("\(5 - i)"))
       decrementButton.action?()
-      reconciler.turnRunLoop()
     }
     XCTAssertNil(decrementButton.view, "'Decrement' should be hidden when count <= 0")
     XCTAssertNotNil(incrementButton.view, "'Increment' should be visible when count < 5")
@@ -100,13 +95,11 @@ final class VisitorTests: XCTestCase {
     }
 
     let reconciler = TestFiberRenderer(.root, size: .zero).render(TestView())
-    reconciler.turnRunLoop()
 
     let addItemButton = reconciler.findView(id: "addItem", as: Button<Text>.self)
     XCTAssertNotNil(addItemButton)
     for i in 0..<10 {
       addItemButton.action?()
-      reconciler.turnRunLoop()
       XCTAssertEqual(reconciler.findView(id: i).view, Text("Item \(i)"))
     }
   }
@@ -199,13 +192,10 @@ final class VisitorTests: XCTestCase {
 
     let reconciler = TestFiberRenderer(.root, size: .zero).render(TestView())
 
-    reconciler.turnRunLoop()
-
     // State
     let button = reconciler.findView(id: DynamicPropertyTest.state, as: Button<Text>.self)
     XCTAssertEqual(button.label, Text("0"))
     button.action?()
-    reconciler.turnRunLoop()
     XCTAssertEqual(button.label, Text("1"))
 
     // Environment
@@ -221,10 +211,7 @@ final class VisitorTests: XCTestCase {
     )
     XCTAssertEqual(stateObjectButton.label, Text("0"))
     stateObjectButton.action?()
-    #if !canImport(Dispatch) || os(WASI)
     stateObjectButton.action?()
-    #endif
-    reconciler.turnRunLoop()
     XCTAssertEqual(stateObjectButton.label, Text("5"))
 
     XCTAssertEqual(

--- a/Tests/TokamakReconcilerTests/VisitorTests.swift
+++ b/Tests/TokamakReconcilerTests/VisitorTests.swift
@@ -221,7 +221,7 @@ final class VisitorTests: XCTestCase {
     )
     XCTAssertEqual(stateObjectButton.label, Text("0"))
     stateObjectButton.action?()
-    #if !canImport(Dispatch)
+    #if !canImport(Dispatch) || os(WASI)
     stateObjectButton.action?()
     #endif
     reconciler.turnRunLoop()

--- a/Tests/TokamakReconcilerTests/VisitorTests.swift
+++ b/Tests/TokamakReconcilerTests/VisitorTests.swift
@@ -20,40 +20,6 @@ import XCTest
 @_spi(TokamakCore) @testable import TokamakCore
 import TokamakTestRenderer
 
-extension FiberReconciler {
-  /// Expect a `Fiber` to represent a particular `View` type.
-  func expect<V>(
-    _ fiber: Fiber?,
-    represents viewType: V.Type,
-    _ message: String? = nil
-  ) where V: View {
-    guard case let .view(view, _) = fiber?.content else {
-      return XCTAssert(false, "Fiber does not exit")
-    }
-    if let message = message {
-      XCTAssert(type(of: view) == viewType, message)
-    } else {
-      XCTAssert(type(of: view) == viewType)
-    }
-  }
-
-  /// Expect a `Fiber` to represent a `View` matching`testView`.
-  func expect<V>(
-    _ fiber: Fiber?,
-    equals testView: V,
-    _ message: String? = nil
-  ) where V: View & Equatable {
-    guard case let .view(fiberView, _) = fiber?.content else {
-      return XCTAssert(false, "Fiber does not exit")
-    }
-    if let message = message {
-      XCTAssertEqual(fiberView as? V, testView, message)
-    } else {
-      XCTAssertEqual(fiberView as? V, testView)
-    }
-  }
-}
-
 final class VisitorTests: XCTestCase {
   func testCounter() {
     struct TestView: View {


### PR DESCRIPTION
The following are now supported in the Fiber reconciler:
* Preferences
    * To support preferences keys, I made the `ReconcilePass` always start at the root of the view hierarchy (not just when dynamic layout is enabled), but it still only looks for changes once it reaches the first changed fiber.
* `@StateObject`/`@ObservedObject`
* `@EnvironmentObject`
* `@AppStorage`/`@SceneStorage`
* Custom `DynamicProperty` types

> Currently, `backgroundPreferenceValue` does not correctly access the preference values. `overlayPreferenceValue` works because the overlay is evaluated after the underlying content. To fix `backgroundPreferenceValue` we could evaluate the background after the foreground and set the `z-index` to put it underneath.


A new internal API for testing the `FiberReconciler` using `TestFiberRenderer` was also added when creating tests for the new dynamic properties:
```swift
struct TestView: View {
  @State private var count = 0

  var body: some View {
    Button(action: { count += 1 }) {
      Text("\(count)")
        .identified(by: "count") // Use `identified(by:)` to mark views for later retrieval.
    }
    .identified(by: "increment")
  }
}

// Setup a reconciler for `TestView`.
let reconciler = TestFiberRenderer(.root, size: .zero).render(TestView())

// Get a proxy to a View with the id "count".
let count = reconciler.findView(id: "count", as: Text.self)
let increment = reconciler.findView(id: "increment", as: Button<Text>.self)

// Access `.view` to resolve the current content of the fiber.
XCTAssertEqual(count.view, Text("0"))

// Use dynamic member lookup to access properties.
increment.action?()

// Make sure the state changed. `view` is computed when accessed, so it can be used across reconcile passes (despite `current`/`alternate` swaps).
XCTAssertEqual(count.view, Text("1"))
```