### PR TITLE
Support `<meta>`/`<title>` in Fiber renderers

### DIFF
--- a/Sources/TokamakCore/App/Scenes/WindowGroup.swift
+++ b/Sources/TokamakCore/App/Scenes/WindowGroup.swift
@@ -82,7 +82,6 @@ public struct WindowGroup<Content>: Scene, TitledScene where Content: View {
 //  }
 
   public func _visitChildren<V>(_ visitor: V) where V: SceneVisitor {
-    print("Visiting scene")
     visitor.visit(Group {
       _WindowGroupTitle(title: self.title)
       content

--- a/Sources/TokamakCore/App/Scenes/WindowGroup.swift
+++ b/Sources/TokamakCore/App/Scenes/WindowGroup.swift
@@ -15,6 +15,11 @@
 //  Created by Carson Katri on 7/16/20.
 //
 
+@_spi(TokamakCore)
+public struct _WindowGroupTitle: _PrimitiveView {
+  public let title: Text?
+}
+
 public struct WindowGroup<Content>: Scene, TitledScene where Content: View {
   public let id: String
   public let title: Text?
@@ -77,6 +82,10 @@ public struct WindowGroup<Content>: Scene, TitledScene where Content: View {
 //  }
 
   public func _visitChildren<V>(_ visitor: V) where V: SceneVisitor {
-    visitor.visit(content)
+    print("Visiting scene")
+    visitor.visit(Group {
+      _WindowGroupTitle(title: self.title)
+      content
+    })
   }
 }

--- a/Sources/TokamakCore/Fiber/Fiber.swift
+++ b/Sources/TokamakCore/Fiber/Fiber.swift
@@ -423,7 +423,8 @@ public extension FiberReconciler {
           environment: .init(rootEnvironment),
           traits: .init(),
           preferenceStore: preferences
-        )
+        ),
+        preferenceStore: preferences ?? .init()
       )
       if let preferenceStore = outputs.preferenceStore {
         preferences = preferenceStore

--- a/Sources/TokamakCore/Fiber/FiberReconciler.swift
+++ b/Sources/TokamakCore/Fiber/FiberReconciler.swift
@@ -69,6 +69,10 @@ public final class FiberReconciler<Renderer: FiberRenderer> {
           .environmentValues(environment)
       }
     }
+
+    static func _makeView(_ inputs: ViewInputs<Self>) -> ViewOutputs {
+      .init(inputs: inputs, preferenceStore: inputs.preferenceStore ?? .init())
+    }
   }
 
   /// The `Layout` container for the root of a `View` hierarchy.
@@ -274,6 +278,10 @@ public final class FiberReconciler<Renderer: FiberRenderer> {
 
     for action in afterReconcileActions {
       action()
+    }
+
+    if let preferences = current.preferences {
+      renderer.preferencesChanged(preferences)
     }
   }
 }

--- a/Sources/TokamakCore/Fiber/FiberRenderer.swift
+++ b/Sources/TokamakCore/Fiber/FiberRenderer.swift
@@ -88,6 +88,9 @@ public protocol FiberRenderer {
   /// (in this case just `DuelOfTheStates` as both properties were on it),
   /// and reconcile after all changes have been collected.
   func schedule(_ action: @escaping () -> ())
+
+  /// Called by the reconciler when the preferences of the topmost `Fiber` changed.
+  func preferencesChanged(_ preferenceStore: _PreferenceStore)
 }
 
 public extension FiberRenderer {
@@ -106,6 +109,8 @@ public extension FiberRenderer {
       return view._visitChildren
     }
   }
+
+  func preferencesChanged(_ preferenceStore: _PreferenceStore) {}
 
   @discardableResult
   @_disfavoredOverload

--- a/Sources/TokamakCore/Preferences/PreferenceKey.swift
+++ b/Sources/TokamakCore/Preferences/PreferenceKey.swift
@@ -118,6 +118,19 @@ public final class _PreferenceStore: CustomDebugStringConvertible {
     _PreferenceValue(storage: previousValues[ObjectIdentifier(key)] ?? .init(key))
   }
 
+  /// Returns the new value for `Key`, or `nil` if the value did not change.
+  public func newValue<Key>(forKey key: Key.Type = Key.self) -> Key.Value?
+    where Key: PreferenceKey, Key.Value: Equatable
+  {
+    let value = value(forKey: key).value
+    let previousValue = previousValue(forKey: key).value
+    if value != previousValue {
+      return value
+    } else {
+      return nil
+    }
+  }
+
   public func insert<Key>(_ value: Key.Value, forKey key: Key.Type = Key.self)
     where Key: PreferenceKey
   {

--- a/Sources/TokamakStaticHTML/Scenes/WindowGroup.swift
+++ b/Sources/TokamakStaticHTML/Scenes/WindowGroup.swift
@@ -15,10 +15,26 @@
 //  Created by Carson Katri on 7/19/20.
 //
 
-import TokamakCore
+@_spi(TokamakCore) import TokamakCore
 
 extension WindowGroup: SceneDeferredToRenderer {
   public var deferredBody: AnyView {
     AnyView(content)
+  }
+}
+
+extension _WindowGroupTitle: HTMLConvertible {
+  public var tag: String { "div" }
+  public func attributes(useDynamicLayout: Bool) -> [HTMLAttribute: String] {
+    guard !useDynamicLayout else { return [:] }
+    return ["style": "position: absolute; width: 0; height: 0; top: 0; left: 0;"]
+  }
+
+  public func primitiveVisitor<V>(useDynamicLayout: Bool) -> ((V) -> ())? where V: ViewVisitor {
+    {
+      if let title = self.title {
+        $0.visit(HTMLTitle(_TextProxy(title).rawText))
+      }
+    }
   }
 }

--- a/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
+++ b/Sources/TokamakStaticHTML/StaticHTMLRenderer.swift
@@ -58,7 +58,7 @@ struct HTMLBody: AnyHTML {
   ]
 }
 
-extension HTMLMeta.MetaTag {
+public extension HTMLMeta.MetaTag {
   func outerHTML() -> String {
     switch self {
     case let .charset(charset):


### PR DESCRIPTION
This adds compatibility with the `.htmlMeta()` and `.htmlTitle()` modifiers added in #483. 2 special cases were also added:

1. `WindowGroup` has a `title` parameter, which can now be used to specify the `<title>` tag in Fiber renderers by extending the `_WindowGroupTitle` view.

2. In SwiftUI, if a `_BackgroundStyleModifier` reaches the top of the scene, it will extend into the top safe area. This PR adds the `"theme-color"` meta tag when the background style reaches the top of the scene:

<table>
<tr>
<td>
  <img alt="Simulator Screen Shot - iPhone 13 Pro - 2022-07-06 at 10 49 28" src="https://user-images.githubusercontent.com/13581484/177578967-1d48ee62-a24a-454b-baf6-87bc521d961f.png" />
</td>
<td>
  <img alt="Screen Shot 2022-07-06 at 10 42 51 AM" src="https://user-images.githubusercontent.com/13581484/177578231-8a0705cf-9919-4f0c-9157-072e662f0e46.png">
</td>
</tr>
</table>

> While Safari will automatically detect the theme color without the additions from this PR, it will not pick up background color changes due to state. The changes from this PR allow that.