### PR TITLE
add missing length unit to width and height attributes

### DIFF
--- a/Sources/TokamakStaticHTML/Shapes/Path.swift
+++ b/Sources/TokamakStaticHTML/Shapes/Path.swift
@@ -149,8 +149,8 @@ extension Path: _HTMLPrimitive {
       height: 100%;
       """ :
       """
-      width: \(max(0, size.width));
-      height: \(max(0, size.height));
+      width: \(max(0, size.width))px;
+      height: \(max(0, size.height))px;
       """
   }
 


### PR DESCRIPTION
PR fixes missing "px" units to width and height attribute, that resulted in attribute being dropped as invalid by browsers.