### PR TITLE
Update default assignee in `bug_report.md`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: bug
-assignees: MaxDesiatov
+assignees: carson-katri
 
 ---
 
@@ -28,17 +28,17 @@ A clear and concise description of what you expected to happen.
 If this is a layout/rendering issue, please provide screenshots for both Tokamak and SwiftUI that highlight the difference.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. macOS]
+ - OS: [e.g. macOS 12.4]
  - Browser [e.g. chrome, safari]
  - Version of the browser [e.g. 22]
- - Version of Tokamak [e.g. 0.6.1]
+ - Version of Tokamak [e.g. 0.10.1]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
+ - Device: [e.g. iPhone 6]
+ - OS: [e.g. iOS15.1]
  - Browser [e.g. stock browser, safari]
  - Version of the browser [e.g. 22]
- - Version of Tokamak [e.g. 0.6.1]
+ - Version of Tokamak [e.g. 0.10.1]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
As I'm going to step away as a maintainer, I'd like to avoid being assigned for new issues by default.

Let me know if you'd like the assignee field to be empty by default.