### PR TITLE
Fix typos in doc comments across the codebase

### DIFF
--- a/Sources/TokamakCore/Animation/Transaction.swift
+++ b/Sources/TokamakCore/Animation/Transaction.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 public struct Transaction {
-  /// The overriden transaction for a state change in a `withTransaction` block.
+  /// The overridden transaction for a state change in a `withTransaction` block.
   /// Is always set back to `nil` when the block exits.
   static var _active: Self?
 

--- a/Sources/TokamakCore/Animation/_AnimationSolvers.swift
+++ b/Sources/TokamakCore/Animation/_AnimationSolvers.swift
@@ -21,7 +21,7 @@ import Foundation
 public protocol _AnimationSolver {
   /// Solve value at a specific point in time.
   func solve(at t: Double) -> Double
-  /// Calculates the duration of the animation to a specific presision.
+  /// Calculates the duration of the animation to a specific precision.
   func restingPoint(precision y: Double) -> Double
 }
 

--- a/Sources/TokamakCore/Stubs/CGStubs.swift
+++ b/Sources/TokamakCore/Stubs/CGStubs.swift
@@ -103,7 +103,7 @@ public struct CGAffineTransform: Equatable {
   /// Returns an affine transformation matrix constructed from a rotation value you provide.
   /// - Parameters:
   ///   - angle: The angle, in radians, by which this matrix rotates the coordinate system axes.
-  ///            A positive value specifies clockwise rotation and anegative value specifies
+  ///            A positive value specifies clockwise rotation and a negative value specifies
   ///            counterclockwise rotation.
   public init(rotationAngle angle: CGFloat) {
     self.init(a: cos(angle), b: sin(angle), c: -sin(angle), d: cos(angle), tx: 0, ty: 0)

--- a/Sources/TokamakStaticHTML/Views/Containers/List.swift
+++ b/Sources/TokamakStaticHTML/Views/Containers/List.swift
@@ -162,7 +162,7 @@ extension InsetGroupedListStyle: ListStyleDeferredToRenderer {
   }
 }
 
-// TODO: Make sections collabsible (see Section.swift for more impl. details)
+// TODO: Make sections collapsible (see Section.swift for more impl. details)
 extension SidebarListStyle: ListStyleDeferredToRenderer {
   public func sectionHeader<Header>(_ header: Header) -> AnyView where Header: View {
     AnyView(


### PR DESCRIPTION
fix typos