### PR TITLE
Enable async/await in DOM Fiber renderer

### DIFF
--- a/Sources/TokamakDOM/DOMFiberRenderer.swift
+++ b/Sources/TokamakDOM/DOMFiberRenderer.swift
@@ -16,6 +16,7 @@
 //
 
 import Foundation
+import JavaScriptEventLoop
 import JavaScriptKit
 import OpenCombineJS
 import OpenCombineShim
@@ -97,6 +98,10 @@ public struct DOMFiberRenderer: FiberRenderer {
   }
 
   public init(_ rootSelector: String, useDynamicLayout: Bool = true) {
+    if #available(macOS 10.15, *) {
+      JavaScriptEventLoop.installGlobalExecutor()
+    }
+
     guard let reference = document.querySelector!(rootSelector).object else {
       fatalError("""
       The root element with selector '\(rootSelector)' could not be found. \


### PR DESCRIPTION
I noticed that Tasks weren't running when using the Fiber renderer. I'm not sure this is the appropriate place, but the normal DOM renderer calls `installGlobalExecutor` in it's `init`, so I just mirrored that.