### PR TITLE
[bug] Missing CoreGraphics import for Swift 5.7.1 / Xcode 14.1

### DIFF
--- a/Sources/TokamakCore/Shapes/StrokeStyle.swift
+++ b/Sources/TokamakCore/Shapes/StrokeStyle.swift
@@ -17,6 +17,10 @@
 
 import Foundation
 
+#if canImport(CoreGraphics)
+import CoreGraphics
+#endif
+
 public struct StrokeStyle: Equatable {
   public var lineWidth: CGFloat
   public var lineCap: CGLineCap


### PR DESCRIPTION
Fixes https://github.com/TokamakUI/Tokamak/issues/527